### PR TITLE
fix: c2patool "No claim found" reported as a C2PA manifest

### DIFF
--- a/skills/remove-ai-marks/scripts/image_meta.py
+++ b/skills/remove-ai-marks/scripts/image_meta.py
@@ -196,15 +196,20 @@ def run_optional_tools(path: Path) -> dict[str, Any]:
                 timeout=30,
             )
             out = (r.stdout or "") + (r.stderr or "")
+            low = out.lower()
+            # Negative markers must veto every positive branch, so the
+            # positive alternatives are parenthesised: c2patool reports a
+            # missing manifest as "Error: No claim found", which contains
+            # the substring "claim" and would otherwise read as a hit.
+            no_manifest = "no claim" in low or "no jumbf" in low
             tools["c2patool"] = {
                 "available": True,
                 "returncode": r.returncode,
                 "snippet": out[:2000],
-                "has_manifest": "claim" in out.lower()
-                or "c2pa" in out.lower()
-                or "manifest" in out.lower()
-                and "no claim" not in out.lower()
-                and "no jumbf" not in out.lower(),
+                "has_manifest": (
+                    "claim" in low or "c2pa" in low or "manifest" in low
+                )
+                and not no_manifest,
             }
         except Exception as e:
             tools["c2patool"] = {"available": True, "error": str(e)}

--- a/tests/test_c2patool_report.py
+++ b/tests/test_c2patool_report.py
@@ -1,0 +1,93 @@
+"""Tests for how c2patool output is interpreted by run_optional_tools."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "skills" / "remove-ai-marks" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import image_meta  # noqa: E402
+
+MANIFEST_OUTPUT = """{
+  "active_manifest": "urn:c2pa:0000",
+  "manifests": {
+    "urn:c2pa:0000": {
+      "claim_generator": "some_tool/1.0",
+      "assertions": [{"label": "c2pa.actions"}]
+    }
+  }
+}
+"""
+
+
+class _Completed:
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _fake_c2patool(monkeypatch, output: str, returncode: int, on_stderr: bool = False):
+    """Pretend c2patool exists and emits `output`; hide every other tool."""
+
+    def fake_which(cmd: str):
+        return "/fake/bin/c2patool" if cmd == "c2patool" else None
+
+    def fake_run(cmd, **kwargs):
+        if on_stderr:
+            return _Completed(returncode, stderr=output)
+        return _Completed(returncode, stdout=output)
+
+    monkeypatch.setattr(image_meta, "which", fake_which)
+    monkeypatch.setattr(image_meta.subprocess, "run", fake_run)
+
+
+def test_no_claim_found_is_not_a_manifest(monkeypatch, tmp_path):
+    """Absence of a manifest must not read as a hit.
+
+    c2patool reports a missing manifest as "Error: No claim found", which
+    contains the substring "claim"; a positive branch that is not vetoed by
+    the negative markers flags every clean asset as carrying C2PA.
+    """
+    _fake_c2patool(monkeypatch, "Error: No claim found\n", 1, on_stderr=True)
+    path = tmp_path / "clean.png"
+    path.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    tools = image_meta.run_optional_tools(path)
+
+    assert tools["c2patool"]["available"] is True
+    assert tools["c2patool"]["has_manifest"] is False
+
+
+def test_no_jumbf_data_is_not_a_manifest(monkeypatch, tmp_path):
+    _fake_c2patool(monkeypatch, "No JUMBF data found\n", 1, on_stderr=True)
+    path = tmp_path / "clean.jpg"
+    path.write_bytes(b"\xff\xd8\xff")
+
+    tools = image_meta.run_optional_tools(path)
+
+    assert tools["c2patool"]["has_manifest"] is False
+
+
+def test_real_manifest_is_detected(monkeypatch, tmp_path):
+    """The negative guard must not suppress genuine manifests."""
+    _fake_c2patool(monkeypatch, MANIFEST_OUTPUT, 0)
+    path = tmp_path / "signed.png"
+    path.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    tools = image_meta.run_optional_tools(path)
+
+    assert tools["c2patool"]["has_manifest"] is True
+
+
+def test_missing_c2patool_is_reported_unavailable(monkeypatch, tmp_path):
+    monkeypatch.setattr(image_meta, "which", lambda cmd: None)
+    path = tmp_path / "any.png"
+    path.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    tools = image_meta.run_optional_tools(path)
+
+    assert tools["c2patool"] == {"available": False}


### PR DESCRIPTION
## Problem

With `c2patool` on `PATH`, every clean asset is reported as carrying a C2PA manifest.

`run_optional_tools()` in `skills/remove-ai-marks/scripts/image_meta.py` decides `has_manifest` with:

```python
"has_manifest": "claim" in out.lower()
or "c2pa" in out.lower()
or "manifest" in out.lower()
and "no claim" not in out.lower()
and "no jumbf" not in out.lower(),
```

`and` binds tighter than `or`, so this parses as:

```python
("claim" in out) or ("c2pa" in out) or ("manifest" in out and <guards>)
```

The two negative guards only ever apply to the third alternative. `c2patool` reports a missing manifest as `Error: No claim found`, which contains the substring `claim`, so the first alternative matches and `has_manifest` is `True` for assets that carry no C2PA data at all.

Both `inspect_image()` and `inspect_container()` promote that flag to `has_c2pa`, so the false positive reaches the user-facing report for PNG, JPEG, PDF, SVG and DOCX alike. Without `c2patool` installed the branch never runs, which is why a default install looks correct.

## Reproduce

```bash
$ python3 scripts/inspect_image.py --json clean.png
{
  "has_c2pa": true,
  "findings": ["c2patool reports a C2PA-related manifest"],
  "tools": {"c2patool": {"returncode": 1,
                         "snippet": "Error: No claim found\n",
                         "has_manifest": true}}
}
```

## Fix

Parenthesise the positive alternatives so the negative markers veto all of them.

## Verification

Checked in both directions with `c2patool 0.27.11`, so the change is not simply suppressing the flag:

- clean PNG → `has_c2pa: false`
- PNG signed via `c2patool img.png -m manifest.json -o signed.png` (with a `c2pa.actions` assertion carrying `trainedAlgorithmicMedia`) → still detected: `caBX` chunk + manifest, `has_ai_metadata: true`
- that signed PNG after `clean_image.py` → `has_c2pa: false`, `c2patool` confirms `No claim found`

## Tests

Adds `tests/test_c2patool_report.py` — four cases covering `No claim found`, `No JUMBF data found`, a genuine manifest, and `c2patool` absent. `test_no_claim_found_is_not_a_manifest` fails on the current code and passes with the fix. Full suite: 26 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)