### PR TITLE
fix: guard os.fchmod for non-POSIX platforms (Windows)

### DIFF
--- a/skills/remove-ai-marks/scripts/common.py
+++ b/skills/remove-ai-marks/scripts/common.py
@@ -89,8 +89,10 @@ def safe_write_bytes(path: str | Path, data: bytes) -> None:
     fd, tmp_name = tempfile.mkstemp(prefix=f".{dest.name}.", suffix=".tmp", dir=str(parent))
     try:
         # mkstemp creates 0600; restore the umask-default mode so outputs
-        # keep normal permissions.
-        os.fchmod(fd, _default_file_mode())
+        # keep normal permissions. Windows has no fchmod and no POSIX mode
+        # bits to restore, so the call is skipped there.
+        if hasattr(os, "fchmod"):
+            os.fchmod(fd, _default_file_mode())
         with os.fdopen(fd, "wb") as f:
             f.write(data)
             f.flush()

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+import os
 import sys
 import zipfile
 from pathlib import Path
@@ -123,6 +124,15 @@ def test_safe_write_bytes_creates_parent_dirs(tmp_path: Path):
     dest = tmp_path / "a" / "b" / "out.bin"
     safe_write_bytes(dest, b"\x00\x01")
     assert dest.read_bytes() == b"\x00\x01"
+
+
+def test_safe_write_bytes_without_fchmod(tmp_path: Path, monkeypatch):
+    # os.fchmod is POSIX-only; on Windows the write must still go through.
+    monkeypatch.delattr(os, "fchmod", raising=False)
+    dest = tmp_path / "out.bin"
+    safe_write_bytes(dest, b"payload")
+    assert dest.read_bytes() == b"payload"
+    assert not list(tmp_path.glob("*.tmp"))
 
 
 def test_backup_path_creates_bak_copy(tmp_path: Path):


### PR DESCRIPTION
## Problem

`common.safe_write_bytes()` calls `os.fchmod()` to restore the umask-default mode after `mkstemp()` creates the temp file as `0600`. `os.fchmod` is POSIX-only, so on Windows every write path fails:

```
File "skills/remove-ai-marks/scripts/common.py", line 93, in safe_write_bytes
    os.fchmod(fd, _default_file_mode())
AttributeError: module 'os' has no attribute 'fchmod'. Did you mean: 'chmod'?
```

This makes the skill unusable on Windows as soon as an output file is requested — it hits `clean_text.py`, `clean_file.py`, `clean_image.py` and `rewrite_text.py`, all of which route through `write_text_output()` / `safe_write_bytes()`. Reproduced on Windows 11 with CPython 3.11 and 3.14:

```
python3 scripts/clean_text.py tests/fixtures/sample_watermarked.txt -o out.txt --stats
```

Inspect-only commands are unaffected, since they never write.

## Fix

Skip the call where the platform does not provide it:

```python
if hasattr(os, "fchmod"):
    os.fchmod(fd, _default_file_mode())
```

Windows has no POSIX mode bits to restore, so there is nothing to do there. The hardening from `fa81cbc` is untouched: the destination is protected by the `is_symlink()` refusal and the atomic `os.replace()`, not by the chmod. On POSIX the behaviour is byte-for-byte identical.

## Test

Adds `test_safe_write_bytes_without_fchmod`, which drops `os.fchmod` via `monkeypatch.delattr` so the case is exercised on POSIX CI too. Verified it is a real regression guard — reverting the one-line fix makes it fail with the original `AttributeError`.

After the patch, the full smoke sequence from the `Makefile` passes on Windows (Layer A, plus the MD / HTML / SVG container cleans).

## Notes

Two pre-existing tests fail on Windows for an unrelated reason — `test_safe_write_refuses_symlink_destination` and `test_backup_path_refuses_symlinked_bak` call `Path.symlink_to()`, which needs `SeCreateSymbolicLinkPrivilege` (admin or Developer Mode) and otherwise raises `WinError 1314`. Out of scope here; happy to open a separate issue or gate them behind a skip if you want Windows CI to be green.

Unrelated to this patch, `test_rewrite_blocks_redirect_and_never_sends_key` was flaky locally (1 failure in 4 runs). Not investigated, flagging only.

Checklist:

- [x] `python3 -m pytest -q` — 57 passed, 2 failed (the pre-existing symlink-privilege ones above)
- [x] Unit test added
- [x] No user-facing behaviour change, so no doc updates
- [x] No drive-by refactors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

