### PR TITLE
fix: finish Windows support (preexec_fn, symlink tests, Windows CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,10 @@ jobs:
         if: matrix.os == 'windows-latest'
         shell: pwsh
         run: |
-          python skills/remove-ai-marks/scripts/clean_text.py tests/fixtures/sample_watermarked.txt -o "$env:TEMP/wm.cleaned.txt" --stats
-          python skills/remove-ai-marks/scripts/rewrite_text.py tests/fixtures/sample_watermarked.txt --backend print-prompt > $null
-          python skills/remove-ai-marks/scripts/clean_file.py tests/fixtures/sample_ai.md -o "$env:TEMP/sample_ai.cleaned.md"
-          python skills/remove-ai-marks/scripts/clean_file.py tests/fixtures/sample_ai.html -o "$env:TEMP/sample_ai.cleaned.html"
+          python skills/remove-ai-marks/scripts/clean_text.py tests/fixtures/sample_watermarked.txt -o "$env:TEMP/wm.cleaned.txt" --stats &&
+          python skills/remove-ai-marks/scripts/rewrite_text.py tests/fixtures/sample_watermarked.txt --backend print-prompt > $null &&
+          python skills/remove-ai-marks/scripts/clean_file.py tests/fixtures/sample_ai.md -o "$env:TEMP/sample_ai.cleaned.md" &&
+          python skills/remove-ai-marks/scripts/clean_file.py tests/fixtures/sample_ai.html -o "$env:TEMP/sample_ai.cleaned.html" &&
           python skills/remove-ai-marks/scripts/clean_file.py tests/fixtures/sample_meta.svg -o "$env:TEMP/sample_meta.cleaned.svg"
 
       - name: Audit dependencies (pip-audit)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,10 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -18,12 +21,23 @@ jobs:
           python-version: "3.12"
 
       - name: Install test deps
-        run: python3 -m pip install -r requirements-dev.txt
+        run: python -m pip install -r requirements-dev.txt
 
       - name: Test
-        run: python3 -m pytest -q
+        run: python -m pytest -q
+
+      - name: Smoke (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          python skills/remove-ai-marks/scripts/clean_text.py tests/fixtures/sample_watermarked.txt -o "$env:TEMP/wm.cleaned.txt" --stats
+          python skills/remove-ai-marks/scripts/rewrite_text.py tests/fixtures/sample_watermarked.txt --backend print-prompt > $null
+          python skills/remove-ai-marks/scripts/clean_file.py tests/fixtures/sample_ai.md -o "$env:TEMP/sample_ai.cleaned.md"
+          python skills/remove-ai-marks/scripts/clean_file.py tests/fixtures/sample_ai.html -o "$env:TEMP/sample_ai.cleaned.html"
+          python skills/remove-ai-marks/scripts/clean_file.py tests/fixtures/sample_meta.svg -o "$env:TEMP/sample_meta.cleaned.svg"
 
       - name: Audit dependencies (pip-audit)
+        if: matrix.os == 'ubuntu-latest'
         run: |
-          python3 -m pip_audit -r requirements-dev.txt \
+          python -m pip_audit -r requirements-dev.txt \
             -r skills/remove-ai-marks/scripts/requirements-synthid-scorer.txt

--- a/skills/remove-ai-marks/scripts/common.py
+++ b/skills/remove-ai-marks/scripts/common.py
@@ -26,6 +26,31 @@ def eprint(*args: object) -> None:
     print(*args, file=sys.stderr)
 
 
+def _reconfigure_stream(stream: Any, errors: str) -> None:
+    """Switch a std stream to UTF-8 when it supports reconfiguration.
+
+    On Windows, redirected stdin/stdout/stderr default to the ANSI codepage
+    (e.g. cp1252), which cannot encode/decode the invisible Unicode
+    characters this tool exists to remove. UTF-8 covers every codepoint, so
+    text writes stop raising and piped input matches the file-path handling.
+    """
+    reconfigure = getattr(stream, "reconfigure", None)
+    if reconfigure is not None:
+        try:
+            reconfigure(encoding="utf-8", errors=errors)
+        except (OSError, ValueError):
+            pass
+
+
+def _configure_stdio() -> None:
+    _reconfigure_stream(sys.stdin, "surrogateescape")
+    _reconfigure_stream(sys.stdout, "backslashreplace")
+    _reconfigure_stream(sys.stderr, "backslashreplace")
+
+
+_configure_stdio()
+
+
 def read_text_input(path: str | None) -> str:
     if path is None or path == "-":
         return _read_stdin_capped()

--- a/skills/remove-ai-marks/scripts/common.py
+++ b/skills/remove-ai-marks/scripts/common.py
@@ -141,6 +141,12 @@ def subprocess_rlimits() -> None:
         pass
 
 
+# subprocess.run(preexec_fn=...) is POSIX-only; on Windows the argument
+# itself raises ValueError before the callable runs. Windows resource
+# limiting would need a Job Object (pywin32), which is out of scope.
+subprocess_preexec_fn = subprocess_rlimits if os.name == "posix" else None
+
+
 def emit_json(data: Any) -> None:
     json.dump(data, sys.stdout, indent=2, ensure_ascii=False)
     sys.stdout.write("\n")
@@ -164,5 +170,7 @@ def safe_arg(path: str) -> str:
     (e.g. exiftool's -@argfile), turning a crafted filename into argv injection.
     """
     if path.startswith("-"):
+        # './' also resolves correctly on Windows (Win32 accepts '/' as a
+        # path separator), so no platform branch is needed here.
         return "./" + path
     return path

--- a/skills/remove-ai-marks/scripts/container_meta.py
+++ b/skills/remove-ai-marks/scripts/container_meta.py
@@ -13,7 +13,7 @@ import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
-from common import safe_arg, safe_write_bytes, safe_write_text, subprocess_rlimits, which
+from common import safe_arg, safe_write_bytes, safe_write_text, subprocess_preexec_fn, which
 from image_meta import AI_META_HINTS, C2PA_MARKERS, run_optional_tools
 
 # Frontmatter / meta keys that often carry AI provenance
@@ -634,7 +634,7 @@ def clean_pdf(path: Path, dest: Path) -> tuple[list[str], dict]:
                 text=True,
                 timeout=60,
                 check=False,
-                preexec_fn=subprocess_rlimits,
+                preexec_fn=subprocess_preexec_fn,
             )
             actions.append(f"exiftool -all= (rc={r.returncode})")
         except Exception as e:

--- a/skills/remove-ai-marks/scripts/image_meta.py
+++ b/skills/remove-ai-marks/scripts/image_meta.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from common import safe_arg, safe_write_bytes, subprocess_rlimits, which
+from common import safe_arg, safe_write_bytes, subprocess_preexec_fn, which
 
 SCRIPTS_DIR = Path(__file__).resolve().parent
 
@@ -201,7 +201,7 @@ def run_optional_tools(path: Path) -> dict[str, Any]:
                 capture_output=True,
                 text=True,
                 timeout=30,
-                preexec_fn=subprocess_rlimits,
+                preexec_fn=subprocess_preexec_fn,
             )
             out = (r.stdout or "") + (r.stderr or "")
             low = out.lower()
@@ -232,7 +232,7 @@ def run_optional_tools(path: Path) -> dict[str, Any]:
                 capture_output=True,
                 text=True,
                 timeout=30,
-                preexec_fn=subprocess_rlimits,
+                preexec_fn=subprocess_preexec_fn,
             )
             out = r.stdout or ""
             interesting = [
@@ -284,7 +284,7 @@ def run_synthid_score(
             capture_output=True,
             text=True,
             timeout=180,
-            preexec_fn=subprocess_rlimits,
+            preexec_fn=subprocess_preexec_fn,
         )
     except Exception as e:
         return {"available": False, "error": str(e)}
@@ -503,7 +503,7 @@ def clean_image(
                 text=True,
                 timeout=60,
                 check=False,
-                preexec_fn=subprocess_rlimits,
+                preexec_fn=subprocess_preexec_fn,
             )
             actions.append("exiftool -all= pass")
         except Exception as e:

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -99,11 +99,19 @@ def test_inspect_docx_with_ai_markers_does_not_crash():
 # ---------------------------------------------------------------------------
 
 
+def _make_symlink(dest: Path, target: Path) -> None:
+    """Create a symlink, skipping where the platform denies the privilege."""
+    try:
+        dest.symlink_to(target)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+
 def test_safe_write_refuses_symlink_destination(tmp_path: Path):
     victim = tmp_path / "victim.txt"
     victim.write_text("PRECIOUS DATA")
     dest = tmp_path / "out.txt"
-    dest.symlink_to(victim)
+    _make_symlink(dest, victim)
     with pytest.raises(OSError):
         safe_write_text(dest, "cleaned content")
     # The victim must be untouched and no temp litter may remain.
@@ -150,7 +158,7 @@ def test_backup_path_refuses_symlinked_bak(tmp_path: Path):
     bak = tmp_path / "doc.md.bak"
     victim = tmp_path / "victim.txt"
     victim.write_text("PRECIOUS")
-    bak.symlink_to(victim)
+    _make_symlink(bak, victim)
     with pytest.raises(SystemExit):
         backup_path(src)
     assert victim.read_text() == "PRECIOUS"

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -188,3 +188,12 @@ def test_read_stdin_under_cap_ok(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(common, "MAX_STDIN_BYTES", 1024)
     monkeypatch.setattr(sys, "stdin", io.StringIO("hello stdin"))
     assert read_text_input(None) == "hello stdin"
+
+
+def test_reconfigure_stream_writes_utf8():
+    buf = io.BytesIO()
+    stream = io.TextIOWrapper(buf, encoding="cp1252")
+    common._reconfigure_stream(stream, "backslashreplace")
+    stream.write("\u200b")
+    stream.flush()
+    assert buf.getvalue() == "\u200b".encode("utf-8")


### PR DESCRIPTION
## Problem

PR #15 fixed the `os.fchmod` crash on the write path. Three Windows issues remain:

1. `subprocess_rlimits` is passed as `preexec_fn` in five `subprocess.run()` calls. `preexec_fn` is POSIX-only; on Windows, CPython raises `ValueError: preexec_fn is not supported on Windows platforms` in `Popen.__init__` *before* the callable runs, so the try/except inside `subprocess_rlimits` never helps. This makes exiftool/c2patool inspection report the tool as available-but-errored, disables SynthID scoring, and makes PDF cleaning return `{"mode": "exiftool"}` even though exiftool never ran.
2. Redirected stdio on Windows uses the ANSI codepage (e.g. cp1252), so writing the invisible Unicode characters this tool removes raises `UnicodeEncodeError` (caught by the new Windows CI smoke step on `rewrite_text.py --backend print-prompt`).
3. Two symlink tests fail on a normal Windows machine without Developer Mode/admin (`SeCreateSymbolicLinkPrivilege` / `WinError 1314`).

There is also no Windows CI to catch these.

## Fix

- Add `subprocess_preexec_fn = subprocess_rlimits if os.name == "posix" else None` in `common.py` and use it at the five call sites. POSIX behavior is unchanged; Windows simply passes `None` (resource limiting on Windows would need a Job Object via pywin32, which is out of scope).
- Reconfigure stdin/stdout/stderr to UTF-8 at startup in `common.py` so Windows redirected streams stop raising `UnicodeEncodeError`; add a unit test that a cp1252 stream is reconfigured to UTF-8.
- Add a `_make_symlink` helper in `tests/test_security_hardening.py` that `pytest.skip`s when symlink creation is denied, so the tests still run where symlinks are allowed.
- Extend `.github/workflows/ci.yml` with a `windows-latest` matrix leg and a PowerShell smoke step that runs the real CLI entry points (`clean_text.py`, `rewrite_text.py`, `clean_file.py`), chained with `&&` so a failing script fails the step.
- Add a comment in `safe_arg` documenting that the `./` prefix also resolves on Windows.

## Test

- Linux: `python -m pytest -q` passes locally (62 passed).
- Windows: the new CI leg passes, including the CLI smoke step, which previously reproduced the `UnicodeEncodeError`.

Checklist:

- [x] `python -m pytest -q` passes locally
- [x] Windows CI leg added and green
- [x] No user-facing behavior change on POSIX

🤖 Generated with [Grok](https://grok.com)
