### PR TITLE
fix: markdown frontmatter cleaner crashes and leaks nested AI keys

### DIFF
--- a/skills/remove-ai-marks/scripts/container_meta.py
+++ b/skills/remove-ai-marks/scripts/container_meta.py
@@ -186,31 +186,43 @@ def clean_markdown(text: str) -> tuple[str, list[str]]:
     block = m.group(1)
     body = text[m.end() :]
     kept: list[str] = []
+    dropping = False  # inside the nested block of a dropped top-level key
     for line in block.splitlines():
-        if not line.strip() or line.strip().startswith("#") or line[0] in (" ", "\t", "-"):
-            # drop nested lines only if previous key was dropped — simple approach:
-            # keep nested only if we kept a parent; track with flag
-            if kept and line[0] in (" ", "\t", "-"):
-                kept.append(line)
-            elif not line.strip() or line.strip().startswith("#"):
+        stripped = line.strip()
+
+        # Blank lines and comments belong to whichever block we are inside.
+        if not stripped or stripped.startswith("#"):
+            if not dropping:
                 kept.append(line)
             continue
+
+        # Continuation lines (nested mappings, list items) follow their parent.
+        if line[0] in (" ", "\t", "-"):
+            if not dropping:
+                kept.append(line)
+            continue
+
         km = re.match(r"^([A-Za-z0-9_.-]+)\s*:", line)
-        if km:
-            key = km.group(1)
-            if key.lower() in AI_FRONTMATTER_KEYS or AI_META_NAME_RE.search(key):
-                actions.append(f"drop frontmatter key: {key}")
-                continue
-            val = line.split(":", 1)[1] if ":" in line else ""
-            if AI_META_NAME_RE.search(val):
-                actions.append(f"drop frontmatter key (value hit): {key}")
-                continue
+        if not km:
+            dropping = False
             kept.append(line)
-        else:
-            kept.append(line)
+            continue
+
+        key = km.group(1)
+        val = line.split(":", 1)[1] if ":" in line else ""
+        if key.lower() in AI_FRONTMATTER_KEYS or AI_META_NAME_RE.search(key):
+            actions.append(f"drop frontmatter key: {key}")
+            dropping = True
+            continue
+        if AI_META_NAME_RE.search(val):
+            actions.append(f"drop frontmatter key (value hit): {key}")
+            dropping = True
+            continue
+
+        dropping = False
+        kept.append(line)
     if not actions:
         actions.append("no AI frontmatter keys removed")
-    # strip trailing empty nested orphans already handled
     new_block = "\n".join(kept).strip("\n")
     if new_block:
         out = f"---\n{new_block}\n---\n{body}"

--- a/tests/test_container_meta.py
+++ b/tests/test_container_meta.py
@@ -43,6 +43,49 @@ Body\u200b text.
     assert any("drop" in a for a in actions)
 
 
+def test_markdown_frontmatter_with_blank_line_does_not_crash():
+    """Regression: a blank line inside frontmatter used to raise IndexError."""
+    text = "---\ntitle: Demo\n\nauthor: you\n---\nBody\n"
+    cleaned, actions = clean_markdown(text)
+    assert "title: Demo" in cleaned
+    assert "author: you" in cleaned
+    assert actions
+
+
+def test_markdown_drops_nested_children_of_dropped_key():
+    """Regression: nested values under a dropped AI key survived the clean."""
+    text = (
+        "---\n"
+        "title: Demo\n"
+        "model:\n"
+        "  name: claude-opus\n"
+        "  version: 4\n"
+        "author: you\n"
+        "---\nBody\n"
+    )
+    cleaned, actions = clean_markdown(text)
+    assert "claude-opus" not in cleaned      # the leak
+    assert "version: 4" not in cleaned
+    assert "title: Demo" in cleaned          # siblings untouched
+    assert "author: you" in cleaned
+    assert any("drop frontmatter key: model" in a for a in actions)
+
+
+def test_markdown_clean_output_is_no_longer_flagged():
+    """Round-trip: re-inspecting a cleaned document reports nothing AI-ish."""
+    text = "---\ntitle: Demo\nmodel:\n  name: claude-opus\ngenerator: Claude\n---\nBody\n"
+    cleaned, _ = clean_markdown(text)
+    _c2, has_ai, findings, _d = inspect_markdown(cleaned)
+    assert not has_ai, findings
+
+
+def test_markdown_preserves_comments_and_non_ai_keys():
+    text = "---\n# editorial notes\ntitle: Demo\ntags:\n  - one\n  - two\n---\nBody\n"
+    cleaned, _ = clean_markdown(text)
+    assert "# editorial notes" in cleaned
+    assert "- one" in cleaned and "- two" in cleaned
+
+
 def test_html_meta_strip():
     html = """<html><head>
 <meta name="generator" content="ChatGPT">


### PR DESCRIPTION
Fixes #26

`clean_markdown()` has two bugs living in the same loop.

**It crashes.** Any markdown whose YAML frontmatter has a blank line in it throws `IndexError`, because the loop runs `line[0]` on an empty string:

```
>>> clean_markdown("---\ntitle: Demo\n\nauthor: you\n---\nBody\n")
IndexError: string index out of range
```

**It leaks the thing it says it removed.** When a top-level key gets dropped, its nested lines are still kept, since nothing tracks that the parent was dropped. So dropping `model:` leaves `name: claude-opus` behind and the frontmatter ends up as invalid YAML:

```
actions: ['drop frontmatter key: model']
output:
title: Demo
  name: claude-opus     <- reported as removed, still there
  version: 4
author: you
```

The comment already in the code ("keep nested only if we kept a parent; track with flag") describes a flag that was never actually added. This adds it.

Why it matters: the tool tells you it stripped the provenance and then doesn't. `references/ethics.md` says reports shouldn't imply a clean happened when it didn't, so this is that exact case.

### changes

- `container_meta.py`: rewrote the `clean_markdown()` loop with a `dropping` flag, and guard blank/comment lines before indexing them.
- `tests/test_container_meta.py`: 4 regression tests (blank-line crash, nested-key leak, inspect round-trip, comment + list preservation).

`inspect_markdown()` / `_parse_simple_yaml_keys()` are left alone. They already guard `line[0]` with an early `continue`, so they never hit this.

### behaviour change

A blank line between a dropped key and the next kept key now gets dropped along with that block. Cosmetic only.

### checklist

- [x] matches `SKILL.md` / `references/removal-matrix.md`
- [x] tests added under `tests/`
- [x] `python3 -m pytest -q` passes (136 tests)
- [x] no docs change needed (bug fix, no new flags)
- [x] no unrelated refactors
