### PR TITLE
feat: preserve script joiners, flag emoji, and Arabic Cf marks in Layer A

### DIFF
--- a/skills/remove-ai-marks/references/mark-classes.md
+++ b/skills/remove-ai-marks/references/mark-classes.md
@@ -15,6 +15,8 @@ Invisible or near-invisible characters, exotic spaces, bidi controls, tag charac
 
 **Removal:** `clean_text.py` / Layer A — deterministic, verifiable.
 
+Load-bearing invisibles are preserved by default so real text is not corrupted: emoji glue (ZWJ/VS after an emoji base), script joiners (ZWNJ/ZWJ inside complex scripts like Persian or Devanagari), flag tag-char sequences, and orthographic Arabic/Syriac `Cf` marks. The same characters between plain ASCII stay carriers and are still stripped. Use `--strip-emoji-glue` for paranoid mode (strips all of them).
+
 Maps to Nature paper “edit-based watermarking.”
 
 ## 2. Generative / statistical text (token sampling)

--- a/skills/remove-ai-marks/scripts/clean_text.py
+++ b/skills/remove-ai-marks/scripts/clean_text.py
@@ -32,7 +32,7 @@ def main() -> int:
     p.add_argument(
         "--strip-emoji-glue",
         action="store_true",
-        help="Strip emoji presentation selectors/ZWJ even after an emoji base (paranoid)",
+        help="Paranoid: strip all load-bearing invisibles too (emoji glue, script joiners, flag tags, orthographic Cf)",
     )
     p.add_argument("--stats", action="store_true", help="Print stats JSON to stderr")
     p.add_argument(

--- a/skills/remove-ai-marks/scripts/inspect_text.py
+++ b/skills/remove-ai-marks/scripts/inspect_text.py
@@ -26,7 +26,7 @@ def main() -> int:
     p.add_argument(
         "--strip-emoji-glue",
         action="store_true",
-        help="Flag emoji presentation selectors/ZWJ even after an emoji base (paranoid)",
+        help="Paranoid: flag all load-bearing invisibles too (emoji glue, script joiners, flag tags, orthographic Cf)",
     )
     p.add_argument(
         "--force-text",

--- a/skills/remove-ai-marks/scripts/text_unicode.py
+++ b/skills/remove-ai-marks/scripts/text_unicode.py
@@ -241,6 +241,26 @@ def _is_emoji_base(cp: int) -> bool:
     return False
 
 
+# ZWNJ/ZWJ are orthographic inside complex scripts (Persian می‌روم, Devanagari
+# क्‍ष); flag emoji are an emoji base followed by tag chars (🏴󠁧󠁢󠁳󠁣󠁴󠁿); and a
+# handful of Cf codepoints are normal Arabic/Syriac orthography, not carriers.
+_SCRIPT_JOINERS: frozenset[int] = frozenset({0x200C, 0x200D})
+_TAG_RANGE = range(0xE0020, 0xE0080)
+_ORTHOGRAPHIC_CF: frozenset[int] = frozenset(
+    {0x0600, 0x0601, 0x0602, 0x0603, 0x0604, 0x0605, 0x06DD, 0x070F, 0x08E2, 0x110BD, 0x110CD}
+)
+
+
+def _is_joining_letter(cp: int) -> bool:
+    """Non-ASCII letter/mark — the neighbour that makes a joiner orthographic."""
+    return cp > 0x7F and unicodedata.category(chr(cp))[0] in ("L", "M")
+
+
+def _is_glue(cp: int) -> bool:
+    """Load-bearing invisible char: emoji glue, script joiner, or flag tag char."""
+    return _is_emoji_glue(cp) or cp in _SCRIPT_JOINERS or cp in _TAG_RANGE
+
+
 def _decide(
     ch: str,
     prev_kept: str | None,
@@ -258,6 +278,13 @@ def _decide(
     cp = ord(ch)
     if _is_emoji_glue(cp) and not strip_emoji_glue:
         if prev_kept is not None and _is_emoji_base(ord(prev_kept)):
+            return ("keep", ch, None)
+    if not strip_emoji_glue:
+        if cp in _SCRIPT_JOINERS and prev_kept is not None and _is_joining_letter(ord(prev_kept)):
+            return ("keep", ch, None)
+        if cp in _TAG_RANGE and prev_kept is not None and _is_emoji_base(ord(prev_kept)):
+            return ("keep", ch, None)
+        if cp in _ORTHOGRAPHIC_CF:
             return ("keep", ch, None)
     if _is_strip_cp(cp):
         return ("strip", "", _strip_kind(cp))
@@ -335,9 +362,9 @@ def inspect_text(
             strip_emoji_glue=strip_emoji_glue,
         )
         if kind is None:
-            # Kept; emoji glue does not advance the "previous kept" base so
-            # ZWJ chains (❤️‍🔥) continue to bind correctly.
-            if not _is_emoji_glue(ord(ch)):
+            # Kept; glue (emoji/script joiner/tag) does not advance the
+            # "previous kept" base so ZWJ chains and flag runs stay bound.
+            if not _is_glue(ord(ch)):
                 prev_kept = out_char
             continue
         key = (ord(ch), kind)
@@ -366,7 +393,7 @@ def inspect_text(
         "Layer A only: invisible/format Unicode and space homoglyphs (edit-based carriers).",
         "Statistical (token-sampling) watermarks are not detectable here; use Layer B rewrite.",
         "Inspect kinds: strip, bidi, tag_chars, variation_selector, zwj_family, space, confusable, other_cf.",
-        "Emoji presentation glue (ZWJ/VS15/VS16 after an emoji base) is preserved by default; use --strip-emoji-glue for paranoid mode.",
+        "Load-bearing invisibles are preserved by default: emoji glue (ZWJ/VS after an emoji base), script joiners (ZWNJ/ZWJ inside complex scripts), flag tag chars, and orthographic Arabic/Syriac Cf marks. Use --strip-emoji-glue for paranoid mode (strips them all).",
     ]
     if not hits:
         notes.append(
@@ -400,9 +427,9 @@ def clean_text(
         )
         if action == "keep":
             out_chars.append(out_char)
-            # Emoji glue does not advance the "previous kept" base, so a
-            # ZWJ chain (❤️‍🔥) stays bound to its original emoji base.
-            if not _is_emoji_glue(ord(ch)):
+            # Glue (emoji/script joiner/tag) does not advance the "previous
+            # kept" base, so ZWJ chains (❤️‍🔥) and flag runs stay bound.
+            if not _is_glue(ord(ch)):
                 prev_kept = out_char
         elif action == "replace":
             out_chars.append(out_char)

--- a/tests/test_clean_text.py
+++ b/tests/test_clean_text.py
@@ -117,3 +117,36 @@ def test_inspect_strip_emoji_glue_flag():
     raw = "\u2696\ufe0f"
     report = inspect_text(raw, strip_emoji_glue=True)
     assert report.suspicious_total >= 1
+
+
+def test_clean_preserves_script_joiners():
+    # Persian mi-ravam (ZWNJ) and a Devanagari conjunct (ZWJ) \u2014 orthographic.
+    for raw in ("\u0645\u06cc\u200c\u0631\u0648\u0645", "\u0915\u094d\u200d\u0937"):
+        cleaned, _ = clean_text(raw)
+        assert cleaned == raw
+
+
+def test_clean_preserves_flag_tag_sequence():
+    # Scotland flag: emoji base U+1F3F4 + tag chars ending in U+E007F.
+    raw = "\U0001F3F4\U000E0067\U000E0062\U000E0073\U000E0063\U000E0074\U000E007F"
+    cleaned, _ = clean_text(raw)
+    assert cleaned == raw
+
+
+def test_clean_preserves_orthographic_arabic_cf():
+    raw = "x\u0600y\u06ddz"  # ARABIC NUMBER SIGN, END OF AYAH
+    cleaned, _ = clean_text(raw)
+    assert cleaned == raw
+
+
+def test_clean_still_strips_joiners_between_latin():
+    # ZWJ/ZWNJ next to ASCII is a carrier, not orthography \u2014 still removed.
+    for raw in ("a\u200db", "a\u200cb", "ab\u200c"):
+        cleaned, _ = clean_text(raw)
+        assert "\u200c" not in cleaned and "\u200d" not in cleaned
+
+
+def test_strip_emoji_glue_flag_restores_blanket_strip():
+    cleaned, _ = clean_text("\u0645\u06cc\u200c\u0631", strip_emoji_glue=True)
+    assert "\u200c" not in cleaned
+    assert clean_text("x\u0600y", strip_emoji_glue=True)[0] == "xy"


### PR DESCRIPTION
Fixes #27

Layer A already preserves emoji ZWJ/VS glue after an emoji base, which is great. But a few other invisible characters that carry real meaning still got stripped, so cleaning text in some languages quietly changed the words.

Broken on `main`:

```python
>>> clean_text("x\u06DDy")   # ARABIC END OF AYAH
'xy'
>>> clean_text("می‌روم")     # Persian, ZWNJ
'میروم'                      # different word now
```

Same for Devanagari conjuncts (the ZWJ in `क्‍ष`) and flag emoji (`🏴󠁧󠁢󠁳󠁣󠁴󠁿` collapses to `🏴` once the tag chars go).

### what I did

Reused the machinery that's already there for emoji glue instead of adding a new system:

- ZWNJ/ZWJ (`U+200C`/`U+200D`) are kept when the previous kept char is a complex-script letter or mark (Arabic, Devanagari, etc). Between plain ASCII they're still carriers, so they still get stripped.
- Flag tag chars (`U+E0020`–`U+E007F`) are kept when they follow an emoji base, same idea as emoji glue.
- A small allowlist of orthographic Arabic/Syriac `Cf` marks (`U+0600`–`U+0605`, `U+06DD`, `U+070F`, `U+08E2`, `U+110BD`, `U+110CD`) is preserved instead of being dropped as `other_cf`.

`--strip-emoji-glue` (paranoid mode) still strips every one of these, so nothing changes for anyone who wants the old blanket behaviour.

### heads up

A ZWJ sitting between two non-ASCII letters that don't actually use it (say two random CJK chars) would now be preserved. That's a deliberate trade so real script text survives, and paranoid mode still removes it. Noted it in the code.

### changes

- `text_unicode.py`: extend `_decide()` with the three keep-rules, broaden the "don't advance prev_kept" guard from emoji glue to all glue.
- `clean_text.py` / `inspect_text.py`: updated `--strip-emoji-glue` help text.
- `references/mark-classes.md`: documented the preserve-by-default behaviour.
- `tests/test_clean_text.py`: preserve tests (Persian, Devanagari, flag, Arabic Cf), still-strips-between-ASCII tests, and a paranoid-mode test.

### checklist

- [x] matches `SKILL.md` / `references/mark-classes.md`
- [x] tests added under `tests/`
- [x] `python3 -m pytest -q` passes (141 tests)
- [x] docs updated (`mark-classes.md` + CLI help)
- [x] no unrelated refactors
