### PR TITLE
fix: print filename at top of inspect_file.py output

### DIFF
--- a/skills/remove-ai-marks/scripts/inspect_file.py
+++ b/skills/remove-ai-marks/scripts/inspect_file.py
@@ -81,8 +81,9 @@ def main() -> int:
         )
         report = inspect_text(text, aggressive=args.aggressive)
         if args.json:
-            emit_json({"kind": "text", **report.to_dict()})
+            emit_json({"kind": "text", "path": str(args.path), **report.to_dict()})
         else:
+            print(f"Path: {args.path}")
             print(f"Kind: text")
             print(human_report(report))
         return 0 if report.suspicious_total == 0 else 1
@@ -92,8 +93,8 @@ def main() -> int:
         if args.json:
             emit_json({"kind": "image", **report.to_dict()})
         else:
-            print(f"Kind: image")
             print(f"Path: {report.path}")
+            print(f"Kind: image")
             print(f"Format: {report.format}")
             print(f"C2PA: {report.has_c2pa}")
             print(f"AI metadata: {report.has_ai_metadata}")
@@ -105,8 +106,8 @@ def main() -> int:
     if args.json:
         emit_json({"kind": "container", **report.to_dict()})
     else:
-        print(f"Kind: container")
         print(f"Path: {report.path}")
+        print(f"Kind: container")
         print(f"Format: {report.format}")
         print(f"C2PA: {report.has_c2pa}")
         print(f"AI metadata: {report.has_ai_metadata}")

--- a/tests/test_inspect_file_path.py
+++ b/tests/test_inspect_file_path.py
@@ -1,0 +1,48 @@
+"""inspect_file.py must print the filename so batched runs (find -exec ... >results.txt)
+can be traced back to the file that produced each block. See issue #31."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "skills" / "remove-ai-marks" / "scripts"
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+
+
+def run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPTS / "inspect_file.py"), *args],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def test_text_kind_prints_path_as_first_line(tmp_path):
+    target = tmp_path / "sample.txt"
+    target.write_text("plain prose, nothing suspicious\n", encoding="utf-8")
+    r = run(str(target))
+    lines = r.stdout.splitlines()
+    assert lines[0] == f"Path: {target}"
+    assert lines[1] == "Kind: text"
+
+
+def test_text_kind_json_includes_path(tmp_path):
+    target = tmp_path / "sample.txt"
+    target.write_text("plain prose\n", encoding="utf-8")
+    r = run(str(target), "--json")
+    data = json.loads(r.stdout)
+    assert data["path"] == str(target)
+    assert data["kind"] == "text"
+
+
+def test_container_kind_prints_path_as_first_line():
+    target = FIXTURES / "sample_meta.svg"
+    r = run(str(target))
+    lines = r.stdout.splitlines()
+    assert lines[0] == f"Path: {target}"
+    assert lines[1] == "Kind: container"


### PR DESCRIPTION
Closes #31.

## Problem

Running `inspect_file.py` over a whole codebase with `find ... -exec inspect_file.py {} \; > results.txt` produces one block of findings per file, but nothing in the output says which file a block belongs to. You end up with a wall of `Kind: text` / `Suspicious: N` blocks and no way to trace a hit back to its source.

## Fix

`inspect_file.py` now prints `Path: <file>` as the first line of output, before `Kind:`, for all three inspect kinds (text, image, container). Image and container already carried a path internally (from `report.path`), just printed in the wrong order; text didn't carry one at all since `inspect_text()` works on raw strings and has no concept of a file. Kept `text_unicode.py` untouched (it's also used by `inspect_text.py` on stdin, which has no path to report) and added the path at the `inspect_file.py` layer instead, where the file argument is known.

`--json` output for the text kind now also includes a `"path"` key, matching what image/container already emit.

Before:
```
Kind: text
Length: 29523 chars
Suspicious: 1
...
```

After:
```
Path: /path/to/codebase/ai_watermarked_file.py
Kind: text
Length: 29523 chars
Suspicious: 1
...
```

## Testing

- Added `tests/test_inspect_file_path.py` covering the text and container kinds (human output line order + JSON `path` key).
- `python -m pytest tests/` — 152 passed, 0 failed.