### PR TITLE
feat: support WebP provenance metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Agent skill + stdlib Python scripts to strip **multi-vendor AI provenance marks*
 | --- | --- | --- |
 | **A** | Invisible Unicode, exotic spaces, bidi, tag chars | Deterministic Python scripts |
 | **B** | Statistical (token-sampling) text watermarks | Agent rewrite + optional `rewrite_text.py` hook |
-| **Files** | C2PA / EXIF / XMP / doc props | PNG, JPEG, SVG, PDF, DOCX, ODT, HTML, Markdown |
+| **Files** | C2PA / EXIF / XMP / doc props | PNG, JPEG, WebP, SVG, PDF, DOCX, ODT, HTML, Markdown |
 
 Vendors / ecosystems (class-level): **Claude**, **Gemini / SynthID-Text**, **OpenAI** provenance surfaces, **open-LLM** Kirchenbauer-style marks.
 
@@ -280,7 +280,7 @@ Layer B makes sense when you specifically want the premium model's **thinking an
 
 | Format | Inspect | Clean |
 | --- | --- | --- |
-| PNG / JPEG | C2PA chunks / APP11, AI XMP hints | Drop metadata segments |
+| PNG / JPEG / WebP | C2PA chunks / APP11 / RIFF `C2PA`, AI XMP hints | Drop metadata segments |
 | SVG | `<metadata>`, XMP | Strip blocks |
 | PDF | Byte/XMP + optional tools | **exiftool** preferred; degraded without it |
 | DOCX | docProps / customXml | Scrub props, drop customXml |
@@ -333,6 +333,10 @@ make smoke                          # quick CLI smoke on fixtures
 ```
 
 ## Changelog
+
+### Unreleased
+
+- Add stdlib-only WebP inspection and metadata cleaning for RIFF `C2PA`, XMP, EXIF, and ICC profile chunks
 
 ### [v0.4.0](https://github.com/guillaumemeyer/watermarks-remover/releases/tag/v0.4.0) — pixel removal, finding confidence, Windows & false-positive fixes
 

--- a/skills/remove-ai-marks/SKILL.md
+++ b/skills/remove-ai-marks/SKILL.md
@@ -3,7 +3,7 @@ name: remove-ai-marks
 description: >
   Remove multi-vendor AI provenance marks: invisible Unicode (Layer A), statistical
   text watermarks via rewrite (Layer B, always offer), and C2PA/EXIF/XMP/container
-  metadata on PNG/JPEG/SVG/PDF/DOCX/ODT/HTML/MD. Covers Claude, Gemini/SynthID-class,
+  metadata on PNG/JPEG/WebP/SVG/PDF/DOCX/ODT/HTML/MD. Covers Claude, Gemini/SynthID-class,
   OpenAI provenance, and open-LLM sampling marks. Use when the user asks to strip
   watermarks, remove C2PA/Content Credentials, clean AI metadata, remove invisible
   Unicode, anti-detect clean AI output, or runs /remove-ai-marks (aliases:
@@ -52,7 +52,7 @@ Intended for **your own** content (privacy, hygiene, research). Do not market re
 | Pasted / clipboard text | temp file or stdin → text pipeline |
 | `.txt` / code | text Layer A (+ formatter for code) |
 | `.md` / `.html` | container clean (frontmatter/meta) + Layer A |
-| `.png` / `.jpg` / `.jpeg` | image metadata strip |
+| `.png` / `.jpg` / `.jpeg` / `.webp` | image metadata strip |
 | `.svg` / `.pdf` / `.docx` / `.odt` | container metadata strip |
 | Directory | aggregate report with `audit_dir.py` |
 | Website / sitemap | aggregate report with `audit_website.py` |

--- a/skills/remove-ai-marks/references/mark-classes.md
+++ b/skills/remove-ai-marks/references/mark-classes.md
@@ -47,7 +47,7 @@ Industry framing (C2PA + SynthID two-layer model; see Institute of AI PM guide i
 
 | Format | Support |
 | --- | --- |
-| PNG / JPEG | Full strip (stdlib + optional exiftool) |
+| PNG / JPEG / WebP | Full strip (stdlib + optional exiftool) |
 | SVG | Drop metadata/XMP blocks |
 | PDF | Prefer exiftool; degraded stdlib XMP strip |
 | DOCX / ODT | Scrub zip XML props / customXml |

--- a/skills/remove-ai-marks/references/removal-matrix.md
+++ b/skills/remove-ai-marks/references/removal-matrix.md
@@ -4,7 +4,7 @@
 | --- | --- | --- | --- | --- |
 | Invisible Unicode / exotic spaces / bidi / tags | Strip / normalize | `inspect_text.py`, `clean_text.py`, `clean_file.py` | Minimal | Yes (codepoint report) |
 | Statistical text watermark (SynthID-class / Kirchenbauer) | Multi-pass paraphrase / humanize / back-translate / structural | Agent Layer B + optional `rewrite_text.py` | Meaning/style drift | No without vendor key/detector |
-| C2PA on PNG/JPEG | Drop APP11 / text chunks / exiftool | `clean_image.py` | Loses provenance metadata | Yes |
+| C2PA on PNG/JPEG/WebP | Drop APP11 / PNG `caBX` / RIFF `C2PA` / exiftool | `clean_image.py` | Loses provenance metadata | Yes |
 | SVG metadata / XMP | Drop `<metadata>`, xmpmeta | `clean_file.py` | Loses SVG metadata | Yes (re-inspect) |
 | PDF XMP / info | exiftool `-all=` preferred | `clean_file.py` | Loses PDF metadata; degraded without exiftool | Partial |
 | DOCX props / customXml | Rewrite OOXML zip | `clean_file.py` | Loses doc properties | Yes |

--- a/skills/remove-ai-marks/scripts/clean_file.py
+++ b/skills/remove-ai-marks/scripts/clean_file.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Unified clean: text Layer A, PNG/JPEG metadata, and document containers."""
+"""Unified clean: text Layer A, PNG/JPEG/WebP metadata, and document containers."""
 
 from __future__ import annotations
 
@@ -23,7 +23,7 @@ from container_meta import clean_container, detect_container_format  # noqa: E40
 from image_meta import clean_image, detect_format as detect_image_format  # noqa: E402
 from text_unicode import clean_text  # noqa: E402
 
-IMAGE_EXTS = {".png", ".jpg", ".jpeg"}
+IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".webp"}
 CONTAINER_EXTS = {".svg", ".pdf", ".docx", ".odt", ".html", ".htm", ".md", ".markdown", ".mdx"}
 TEXT_EXTS = {
     ".txt",
@@ -50,7 +50,7 @@ def classify(path: Path) -> str:
     if ext in TEXT_EXTS:
         return "text"
     data = path.read_bytes()
-    if detect_image_format(data) in ("png", "jpeg"):
+    if detect_image_format(data) in ("png", "jpeg", "webp"):
         return "image"
     if detect_container_format(path, data) != "unknown":
         return "container"

--- a/skills/remove-ai-marks/scripts/clean_image.py
+++ b/skills/remove-ai-marks/scripts/clean_image.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Strip C2PA and AI-related metadata from PNG/JPEG."""
+"""Strip C2PA and AI-related metadata from PNG/JPEG/WebP."""
 
 from __future__ import annotations
 
@@ -16,7 +16,7 @@ from image_meta import clean_image  # noqa: E402
 
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("path", type=Path, help="Input PNG or JPEG")
+    p.add_argument("path", type=Path, help="Input PNG, JPEG, or WebP")
     p.add_argument("-o", "--output", type=Path, help="Output path (default: *.cleaned.*)")
     p.add_argument(
         "--in-place",

--- a/skills/remove-ai-marks/scripts/image_meta.py
+++ b/skills/remove-ai-marks/scripts/image_meta.py
@@ -1,4 +1,4 @@
-"""Detect and strip C2PA / AI-related metadata from PNG and JPEG (stdlib)."""
+"""Detect and strip C2PA / AI-related metadata from PNG, JPEG, and WebP (stdlib)."""
 
 from __future__ import annotations
 
@@ -39,6 +39,8 @@ ctrlregen_subprocess_preexec_fn = ctrlregen_preexec_fn if os.name == "posix" els
 
 PNG_SIG = b"\x89PNG\r\n\x1a\n"
 JPEG_SOI = b"\xff\xd8"
+WEBP_RIFF = b"RIFF"
+WEBP_SIG = b"WEBP"
 
 # Chunk types / content patterns associated with C2PA / AI provenance
 C2PA_MARKERS = (
@@ -77,7 +79,7 @@ AI_META_HINTS = (
 @dataclass
 class ImageInspectReport:
     path: str
-    format: str  # png | jpeg | unknown
+    format: str  # png | jpeg | webp | unknown
     has_c2pa: bool
     has_ai_metadata: bool
     findings: list[str] = field(default_factory=list)
@@ -106,6 +108,8 @@ def detect_format(data: bytes) -> str:
         return "png"
     if data.startswith(JPEG_SOI):
         return "jpeg"
+    if len(data) >= 12 and data[:4] == WEBP_RIFF and data[8:12] == WEBP_SIG:
+        return "webp"
     return "unknown"
 
 
@@ -213,6 +217,65 @@ def inspect_jpeg(data: bytes) -> tuple[bool, bool, list[str]]:
     if whole and not has_c2pa:
         has_c2pa = True
         findings.append(f"byte-scan C2PA markers: {', '.join(whole[:6])}")
+    return has_c2pa, has_ai or has_c2pa, findings
+
+
+def _webp_chunks(data: bytes) -> tuple[list[tuple[bytes, bytes, bytes]], list[str]]:
+    if detect_format(data) != "webp":
+        return [], ["not a WebP"]
+
+    notes: list[str] = []
+    declared_size = struct.unpack("<I", data[4:8])[0]
+    if declared_size + 8 != len(data):
+        notes.append(
+            f"RIFF size mismatch: header={declared_size + 8} actual={len(data)}"
+        )
+
+    chunks: list[tuple[bytes, bytes, bytes]] = []
+    pos = 12
+    while pos + 8 <= len(data):
+        fourcc = data[pos : pos + 4]
+        length = struct.unpack("<I", data[pos + 4 : pos + 8])[0]
+        payload_start = pos + 8
+        payload_end = payload_start + length
+        padded_end = payload_end + (length & 1)
+        if padded_end > len(data):
+            name = fourcc.decode("latin-1", errors="replace")
+            notes.append(f"truncated WebP chunk {name}")
+            break
+        chunks.append(
+            (fourcc, data[payload_start:payload_end], data[payload_end:padded_end])
+        )
+        pos = padded_end
+    if pos != len(data) and not any("truncated" in note for note in notes):
+        notes.append(f"trailing WebP bytes: {len(data) - pos}")
+    return chunks, notes
+
+
+def inspect_webp(data: bytes) -> tuple[bool, bool, list[str]]:
+    chunks, findings = _webp_chunks(data)
+    if not chunks and findings == ["not a WebP"]:
+        return False, False, findings
+
+    has_c2pa = False
+    has_ai = False
+    for fourcc, payload, _padding in chunks:
+        name = fourcc.decode("latin-1", errors="replace")
+        if fourcc.upper() == b"C2PA":
+            has_c2pa = True
+            has_ai = True
+            findings.append("WebP C2PA chunk")
+            continue
+        if fourcc in (b"XMP ", b"EXIF"):
+            hits = _contains_any(payload, AI_META_HINTS + C2PA_MARKERS)
+            if hits:
+                has_ai = True
+                if any(
+                    hit.lower() in ("c2pa", "contentcredentials", "jumb", "contentauth")
+                    for hit in hits
+                ):
+                    has_c2pa = True
+                findings.append(f"WebP {name}: {', '.join(hits[:8])}")
     return has_c2pa, has_ai or has_c2pa, findings
 
 
@@ -417,8 +480,10 @@ def inspect_image(
         has_c2pa, has_ai, findings = inspect_png(data)
     elif fmt == "jpeg":
         has_c2pa, has_ai, findings = inspect_jpeg(data)
+    elif fmt == "webp":
+        has_c2pa, has_ai, findings = inspect_webp(data)
     else:
-        has_c2pa, has_ai, findings = False, False, ["unsupported format (MVP: PNG/JPEG)"]
+        has_c2pa, has_ai, findings = False, False, ["unsupported format (PNG/JPEG/WebP)"]
 
     notes: list[str] = []
     if fmt == "unknown":
@@ -583,6 +648,45 @@ def strip_jpeg(data: bytes, *, strip_all_app: bool = True) -> tuple[bytes, list[
     return bytes(out), actions
 
 
+def strip_webp(data: bytes, *, strip_all_metadata: bool = True) -> tuple[bytes, list[str]]:
+    chunks, notes = _webp_chunks(data)
+    if not chunks and notes == ["not a WebP"]:
+        raise ValueError("not WebP")
+    if notes:
+        raise ValueError("malformed WebP: " + "; ".join(notes))
+
+    actions: list[str] = []
+    kept: list[tuple[bytes, bytes, bytes]] = []
+    removed_flags = 0
+    metadata_flags = {b"ICCP": 0x20, b"EXIF": 0x08, b"XMP ": 0x04}
+
+    for fourcc, payload, padding in chunks:
+        drop = fourcc.upper() == b"C2PA"
+        if fourcc in metadata_flags:
+            drop = strip_all_metadata or bool(
+                _contains_any(payload, AI_META_HINTS + C2PA_MARKERS)
+            )
+        if drop:
+            name = fourcc.decode("latin-1", errors="replace")
+            actions.append(f"drop WebP chunk {name}")
+            removed_flags |= metadata_flags.get(fourcc, 0)
+        else:
+            kept.append((fourcc, payload, padding))
+
+    body = bytearray(WEBP_SIG)
+    for fourcc, payload, padding in kept:
+        if fourcc == b"VP8X" and len(payload) >= 1 and removed_flags:
+            payload = bytes([payload[0] & ~removed_flags]) + payload[1:]
+        body.extend(fourcc)
+        body.extend(struct.pack("<I", len(payload)))
+        body.extend(payload)
+        body.extend(padding if len(payload) & 1 else b"")
+
+    if not actions:
+        actions.append("no WebP metadata chunks removed (already clean or none matched)")
+    return WEBP_RIFF + struct.pack("<I", len(body)) + bytes(body), actions
+
+
 def clean_image(
     path: Path,
     dest: Path,
@@ -604,6 +708,8 @@ def clean_image(
         cleaned, actions = strip_png(data, strip_all_text=strip_all_metadata)
     elif fmt == "jpeg":
         cleaned, actions = strip_jpeg(data, strip_all_app=strip_all_metadata)
+    elif fmt == "webp":
+        cleaned, actions = strip_webp(data, strip_all_metadata=strip_all_metadata)
     else:
         raise ValueError(f"unsupported format: {fmt}")
 

--- a/skills/remove-ai-marks/scripts/inspect_file.py
+++ b/skills/remove-ai-marks/scripts/inspect_file.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Unified inspect: text, images (PNG/JPEG), and containers (SVG/PDF/DOCX/ODT/HTML/MD)."""
+"""Unified inspect: text, images (PNG/JPEG/WebP), and document containers."""
 
 from __future__ import annotations
 
@@ -23,7 +23,7 @@ from image_meta import inspect_image  # noqa: E402
 from text_unicode import human_report, inspect_text  # noqa: E402
 
 TEXT_EXTS = {".txt", ".text", ".md", ".markdown", ".mdx", ".html", ".htm", ".css", ".js", ".py", ".rs", ".go", ".json", ".yaml", ".yml", ".toml", ".csv"}
-IMAGE_EXTS = {".png", ".jpg", ".jpeg"}
+IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".webp"}
 CONTAINER_EXTS = {".svg", ".pdf", ".docx", ".odt", ".html", ".htm", ".md", ".markdown", ".mdx"}
 
 
@@ -37,7 +37,11 @@ def classify(path: Path) -> str:
         return "text"
     # magic sniff
     data = path.read_bytes()[:16]
-    if detect_image_format(data if len(data) >= 8 else path.read_bytes()) in ("png", "jpeg"):
+    if detect_image_format(data if len(data) >= 12 else path.read_bytes()) in (
+        "png",
+        "jpeg",
+        "webp",
+    ):
         return "image"
     fmt = detect_container_format(path, path.read_bytes()[:4096] if path.stat().st_size else b"")
     if fmt != "unknown":

--- a/skills/remove-ai-marks/scripts/inspect_image.py
+++ b/skills/remove-ai-marks/scripts/inspect_image.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Inspect PNG/JPEG for C2PA and AI-related metadata."""
+"""Inspect PNG/JPEG/WebP for C2PA and AI-related metadata."""
 
 from __future__ import annotations
 
@@ -15,7 +15,7 @@ from image_meta import inspect_image  # noqa: E402
 
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("path", type=Path, help="Image path (PNG or JPEG)")
+    p.add_argument("path", type=Path, help="Image path (PNG, JPEG, or WebP)")
     p.add_argument("--json", action="store_true")
     p.add_argument(
         "--synthid-dir",

--- a/tests/test_clean_image.py
+++ b/tests/test_clean_image.py
@@ -1,4 +1,4 @@
-"""Tests for PNG/JPEG metadata strip."""
+"""Tests for PNG/JPEG/WebP metadata strip."""
 
 from __future__ import annotations
 
@@ -11,7 +11,15 @@ ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / "skills" / "remove-ai-marks" / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
-from image_meta import clean_image, inspect_image, strip_jpeg, strip_png  # noqa: E402
+from image_meta import (  # noqa: E402
+    clean_image,
+    detect_format,
+    inspect_image,
+    inspect_webp,
+    strip_jpeg,
+    strip_png,
+    strip_webp,
+)
 
 
 def _png_chunk(ctype: bytes, payload: bytes) -> bytes:
@@ -49,6 +57,18 @@ def _minimal_jpeg_with_app11() -> bytes:
     return b"\xff\xd8" + app0_seg + app11_seg + sos + entropy + b"\xff\xd9"
 
 
+def _webp_chunk(fourcc: bytes, payload: bytes) -> bytes:
+    padding = b"\x00" if len(payload) & 1 else b""
+    return fourcc + struct.pack("<I", len(payload)) + payload + padding
+
+
+def _minimal_webp(*chunks: tuple[bytes, bytes]) -> bytes:
+    body = b"WEBP" + b"".join(
+        _webp_chunk(fourcc, payload) for fourcc, payload in chunks
+    )
+    return b"RIFF" + struct.pack("<I", len(body)) + body
+
+
 def test_strip_png_removes_text_c2pa(tmp_path: Path):
     data = _minimal_png_with_text()
     cleaned, actions = strip_png(data)
@@ -74,3 +94,66 @@ def test_clean_image_roundtrip(tmp_path: Path):
     result = clean_image(src, dest)
     assert dest.is_file()
     assert result["bytes_out"] > 0
+
+
+def test_webp_c2pa_and_xmp_are_detected_and_removed(tmp_path: Path):
+    data = _minimal_webp(
+        (b"VP8X", b"\x04" + b"\x00" * 9),
+        (b"VP8 ", b"image-data"),
+        (b"XMP ", b"generator=OpenAI"),
+        (b"C2PA", b"jumb c2pa manifest"),
+    )
+    assert detect_format(data) == "webp"
+    has_c2pa, has_ai, findings = inspect_webp(data)
+    assert has_c2pa and has_ai
+    assert "WebP C2PA chunk" in findings
+
+    cleaned, actions = strip_webp(data)
+    assert any("C2PA" in action for action in actions)
+    assert any("XMP" in action for action in actions)
+    assert struct.unpack("<I", cleaned[4:8])[0] == len(cleaned) - 8
+    assert cleaned[20] & 0x04 == 0
+    assert inspect_webp(cleaned)[0:2] == (False, False)
+
+    src = tmp_path / "marked.webp"
+    dest = tmp_path / "marked.cleaned.webp"
+    src.write_bytes(data)
+    result = clean_image(src, dest)
+    assert result["format"] == "webp"
+    assert not result["still_has_c2pa"]
+    assert not result["still_has_ai_metadata"]
+
+
+def test_webp_image_payload_text_is_not_a_metadata_false_positive():
+    data = _minimal_webp((b"VP8 ", b"ordinary pixels mentioning c2pa"))
+    has_c2pa, has_ai, findings = inspect_webp(data)
+    assert not has_c2pa
+    assert not has_ai
+    assert findings == []
+
+
+def test_truncated_webp_is_reported_and_not_rewritten():
+    data = b"RIFF\x10\x00\x00\x00WEBPC2PA\x10\x00\x00\x00short"
+    has_c2pa, has_ai, findings = inspect_webp(data)
+    assert not has_c2pa
+    assert not has_ai
+    assert any("truncated" in finding for finding in findings)
+    try:
+        strip_webp(data)
+    except ValueError as error:
+        assert "malformed WebP" in str(error)
+    else:
+        raise AssertionError("truncated WebP should not be rewritten")
+
+
+def test_webp_size_mismatch_is_not_rewritten():
+    data = _minimal_webp((b"VP8 ", b"image-data"))
+    malformed = data[:4] + struct.pack("<I", len(data)) + data[8:]
+    assert any("size mismatch" in finding for finding in inspect_webp(malformed)[2])
+
+    try:
+        strip_webp(malformed)
+    except ValueError as error:
+        assert "size mismatch" in str(error)
+    else:
+        raise AssertionError("WebP with a size mismatch should not be rewritten")


### PR DESCRIPTION
## Summary

- add stdlib-only WebP RIFF inspection for C2PA, XMP, and EXIF provenance signals
- remove C2PA and metadata chunks without re-encoding image payloads, updating VP8X metadata flags
- route `.webp` files through the unified inspect/clean CLIs and document the format

## Safety

- refuse malformed, truncated, or RIFF-size-mismatched WebP files instead of rewriting them
- inspect metadata chunks only, so marker-like text inside compressed image payloads is not a false positive
- preserve image chunks and RIFF padding exactly

## Verification

- `python3 -m pytest -o addopts='' -q` -> 149 passed
- `make smoke` -> passed
- `git diff --check origin/main...HEAD` -> passed
- real-world check detected XMP `trainedAlgorithmicMedia` in two WebP files and cleaned copies retained identical decoded pixel hashes

Agent: Codex