### PR TITLE
fix: PDF metadata survives exiftool's incremental write

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Optional system tools (auto-used when present):
 | --- | --- |
 | [`c2patool`](https://github.com/contentauth/c2pa-rs/tree/main/cli) | Inspect C2PA manifests |
 | [`exiftool`](https://exiftool.org/) | Residual metadata strip (esp. **PDF**) |
+| [`qpdf`](https://qpdf.sourceforge.io/) | Structural PDF rebuild — **required** for a real PDF strip (see below) |
 
 Core scripts need **Python 3.10+** stdlib only. Layer B model calls are optional.
 
@@ -282,11 +283,29 @@ Layer B makes sense when you specifically want the premium model's **thinking an
 | --- | --- | --- |
 | PNG / JPEG | C2PA chunks / APP11, AI XMP hints | Drop metadata segments |
 | SVG | `<metadata>`, XMP | Strip blocks |
-| PDF | Byte/XMP + optional tools | **exiftool** preferred; degraded without it |
+| PDF | Byte/XMP + optional tools | **exiftool** then **qpdf**; degraded without either |
 | DOCX | docProps / customXml | Scrub props, drop customXml |
 | ODT | meta.xml | Drop generator / AI-ish meta |
 | HTML | meta, JSON-LD, data-ai* | Strip tags/attrs |
 | Markdown | YAML frontmatter AI keys | Drop keys + Layer A body |
+
+#### Why PDF needs qpdf, not just exiftool
+
+ExifTool writes PDFs **incrementally**. `exiftool -all=` appends a
+`%BeginExifToolUpdate` block that frees the Info object and drops `/Info` from
+the trailer — but the original metadata bytes stay in the file verbatim, and
+exiftool itself can undo the edit with `-PDF-update:all=`. The command exits
+`0`, viewers show no metadata, and the file gets *larger*, which is the tell.
+
+For a provenance-stripping tool that is a silent leak, so `clean_pdf` follows
+the exiftool pass with `qpdf --linearize`, which re-serializes the document
+from its object graph and drops the now-unreferenced objects. Without `qpdf`
+installed the clean still runs, but it says so:
+
+```
+warning: exiftool PDF edits are incremental — the original metadata bytes
+remain recoverable; install qpdf for a structural rewrite
+```
 
 Pixel-domain watermark **removal** is now available as an optional external CtrlRegen backend (see above); it is a regenerating remover, not a guarantee. **C2PA soft binding** (in-content watermark that can re-link a remote Content Credentials manifest after metadata is stripped) remains **out of scope**. Stripping hard-bound C2PA does **not** clear those channels.
 

--- a/skills/remove-ai-marks/SKILL.md
+++ b/skills/remove-ai-marks/SKILL.md
@@ -117,7 +117,7 @@ python3 "$SCRIPTS/clean_file.py" INPUT -o OUTPUT
 python3 "$SCRIPTS/inspect_file.py" OUTPUT   # verify
 ```
 
-Optional tools if installed: `c2patool`, `exiftool` (auto-used when present; PDF strongly prefers exiftool).
+Optional tools if installed: `c2patool`, `exiftool`, `qpdf` (auto-used when present). PDF needs **both** exiftool and qpdf: exiftool's PDF edits are incremental, so without the qpdf rebuild the original metadata bytes stay recoverable in the file. `clean_file.py` warns when qpdf is missing.
 
 **Images — optional pixel removal (external):** after the metadata clean, add
 `--remove-pixel ctrlregen` to `clean_image.py` (bootstrap the backend first).
@@ -236,7 +236,7 @@ Always state:
 
 - Layer A does **not** remove token-sampling watermarks.
 - Layer B cannot be gold-verified without vendor detectors / keys.
-- PDF strip is best-effort without `exiftool`.
+- PDF strip is best-effort without `exiftool`, and incomplete without `qpdf`: exiftool alone leaves the freed metadata objects in the byte stream.
 - Pixel-domain **image** watermarks can be removed optionally via the external CtrlRegen backend (`clean_image.py --remove-pixel ctrlregen`); audio/video watermarks remain out of scope for removal.
 - The CtrlRegen backend is external, all-rights-reserved (no LICENSE file), never bundled, heavy (~10 GB model downloads), and a regenerating remover — no local detector certifies StegaStamp/Tree-Ring/StableSignature removal.
 - The reverse-SynthID scorer is external, best-effort, and under a non-commercial Research License; it is not bundled and is not an official Google detector.

--- a/skills/remove-ai-marks/scripts/container_meta.py
+++ b/skills/remove-ai-marks/scripts/container_meta.py
@@ -694,6 +694,49 @@ def inspect_pdf(path: Path, data: bytes) -> tuple[bool, bool, list[str], dict]:
     return has_c2pa, has_ai or has_c2pa, findings, {"tools": tools}
 
 
+def _pdf_structural_rewrite(dest: Path, actions: list[str]) -> bool:
+    """Rebuild a PDF so unreferenced objects are dropped.
+
+    exiftool's PDF edits are incremental, so freed metadata objects survive in
+    the byte stream. qpdf re-serializes from the object graph, which is what
+    actually removes them. No-op (with a warning) when qpdf is absent.
+    """
+    qpdf = which("qpdf")
+    if not qpdf:
+        actions.append(
+            "warning: exiftool PDF edits are incremental — the original metadata "
+            "bytes remain recoverable; install qpdf for a structural rewrite"
+        )
+        return False
+
+    tmp = dest.with_name(dest.name + ".qpdf-tmp")
+    try:
+        r = subprocess.run(
+            [qpdf, "--linearize", "--", safe_arg(str(dest)), safe_arg(str(tmp))],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+            preexec_fn=subprocess_preexec_fn,
+        )
+    except Exception as e:
+        tmp.unlink(missing_ok=True)
+        actions.append(f"qpdf rewrite failed: {e}; metadata bytes may remain recoverable")
+        return False
+
+    # qpdf exit codes: 0 = clean, 3 = succeeded with warnings (output written).
+    if r.returncode in (0, 3) and tmp.is_file() and tmp.stat().st_size > 0:
+        tmp.replace(dest)
+        actions.append(f"qpdf --linearize structural rewrite (rc={r.returncode})")
+        return True
+
+    tmp.unlink(missing_ok=True)
+    actions.append(
+        f"qpdf rewrite skipped (rc={r.returncode}); metadata bytes may remain recoverable"
+    )
+    return False
+
+
 def clean_pdf(path: Path, dest: Path) -> tuple[list[str], dict]:
     """Best-effort PDF clean. Prefers exiftool; falls back to XMP strip warning."""
     actions: list[str] = []
@@ -720,11 +763,18 @@ def clean_pdf(path: Path, dest: Path) -> tuple[list[str], dict]:
             actions.append(f"exiftool -all= (rc={r.returncode})")
         except Exception as e:
             actions.append(f"exiftool failed: {e}")
+        # exiftool writes PDFs *incrementally*: it appends a
+        # %BeginExifToolUpdate block that frees the Info object and drops
+        # /Info from the trailer, but the original metadata bytes stay in the
+        # file verbatim and are trivially recoverable (exiftool itself can
+        # revert them with -PDF-update:all=). A structural rewrite is what
+        # actually drops the now-unreferenced objects.
+        rewritten = _pdf_structural_rewrite(dest, actions)
         c2patool = which("c2patool")
         # c2patool does not always strip; leave note
         if c2patool:
             actions.append("c2patool available for inspect; strip via exiftool/re-export")
-        return actions, {"mode": "exiftool"}
+        return actions, {"mode": "exiftool", "structural_rewrite": rewritten}
 
     # Degraded: strip obvious XMP packets between <?xpacket begin and end
     text = data

--- a/tests/test_pdf_structural_rewrite.py
+++ b/tests/test_pdf_structural_rewrite.py
@@ -1,0 +1,166 @@
+"""Tests for the qpdf structural rewrite that follows the exiftool PDF pass.
+
+exiftool writes PDFs *incrementally*: `-all=` appends a %BeginExifToolUpdate
+block that frees the Info object and drops /Info from the trailer, but the
+original metadata bytes stay in the file and exiftool itself can revert them
+with -PDF-update:all=. For a provenance-stripping tool that is a silent leak,
+so clean_pdf re-serializes the document with qpdf to drop the now-unreferenced
+objects.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "skills" / "remove-ai-marks" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import container_meta  # noqa: E402
+from container_meta import clean_pdf  # noqa: E402
+
+
+class _Completed:
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _ai_pdf() -> bytes:
+    """A small but structurally valid PDF carrying AI provenance in /Info."""
+    objs = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Resources << >> >>",
+        b"<< /Producer (Claude Opus) /Creator (Anthropic Claude) >>",
+    ]
+    out = bytearray(b"%PDF-1.4\n")
+    offsets = []
+    for i, body in enumerate(objs, start=1):
+        offsets.append(len(out))
+        out += b"%d 0 obj\n" % i + body + b"\nendobj\n"
+    xref = len(out)
+    out += b"xref\n0 %d\n" % (len(objs) + 1)
+    out += b"0000000000 65535 f \n"
+    for off in offsets:
+        out += b"%010d 00000 n \n" % off
+    out += b"trailer\n<< /Size %d /Root 1 0 R /Info 4 0 R >>\n" % (len(objs) + 1)
+    out += b"startxref\n%d\n%%%%EOF\n" % xref
+    return bytes(out)
+
+
+def _fake_tools(monkeypatch, *, qpdf: bool, qpdf_rc: int = 0, qpdf_writes: bool = True):
+    """Pretend exiftool exists (a no-op) and qpdf exists or not."""
+    seen: list[list[str]] = []
+
+    def fake_which(cmd: str):
+        if cmd == "exiftool":
+            return "/fake/bin/exiftool"
+        if cmd == "qpdf":
+            return "/fake/bin/qpdf" if qpdf else None
+        return None
+
+    def fake_run(cmd, **kwargs):
+        seen.append(list(cmd))
+        if cmd[0].endswith("qpdf"):
+            if qpdf_writes:
+                # qpdf writes its rebuilt document to the final argument.
+                Path(cmd[-1]).write_bytes(b"%PDF-1.4\n% rebuilt\n%%EOF\n")
+            return _Completed(qpdf_rc)
+        return _Completed(0)
+
+    monkeypatch.setattr(container_meta, "which", fake_which)
+    monkeypatch.setattr(container_meta.subprocess, "run", fake_run)
+    return seen
+
+
+def test_without_qpdf_the_incremental_leak_is_reported(monkeypatch, tmp_path: Path):
+    """No qpdf: the clean must not claim success it cannot deliver.
+
+    This is the regression guard. Before the structural rewrite existed,
+    clean_pdf returned only "exiftool -all= (rc=0)" and nothing told the caller
+    that the metadata bytes were still sitting in the file.
+    """
+    src = tmp_path / "in.pdf"
+    dest = tmp_path / "out.pdf"
+    src.write_bytes(_ai_pdf())
+    _fake_tools(monkeypatch, qpdf=False)
+
+    actions, meta = clean_pdf(src, dest)
+
+    assert meta["structural_rewrite"] is False
+    assert any("incremental" in a for a in actions), actions
+    assert any("qpdf" in a for a in actions), actions
+
+
+def test_with_qpdf_the_document_is_rebuilt(monkeypatch, tmp_path: Path):
+    src = tmp_path / "in.pdf"
+    dest = tmp_path / "out.pdf"
+    src.write_bytes(_ai_pdf())
+    seen = _fake_tools(monkeypatch, qpdf=True)
+
+    actions, meta = clean_pdf(src, dest)
+
+    assert meta["structural_rewrite"] is True
+    qpdf_cmd = [c for c in seen if c[0].endswith("qpdf")]
+    assert len(qpdf_cmd) == 1
+    assert "--linearize" in qpdf_cmd[0]
+    # The rebuilt file must replace the exiftool output, not sit beside it.
+    assert dest.read_bytes() == b"%PDF-1.4\n% rebuilt\n%%EOF\n"
+    assert not list(tmp_path.glob("*.qpdf-tmp"))
+
+
+def test_qpdf_warning_exit_code_still_counts(monkeypatch, tmp_path: Path):
+    """qpdf returns 3 for 'succeeded with warnings' and still writes output."""
+    src = tmp_path / "in.pdf"
+    dest = tmp_path / "out.pdf"
+    src.write_bytes(_ai_pdf())
+    _fake_tools(monkeypatch, qpdf=True, qpdf_rc=3)
+
+    actions, meta = clean_pdf(src, dest)
+
+    assert meta["structural_rewrite"] is True
+    assert any("rc=3" in a for a in actions), actions
+
+
+def test_qpdf_failure_keeps_exiftool_output_and_warns(monkeypatch, tmp_path: Path):
+    src = tmp_path / "in.pdf"
+    dest = tmp_path / "out.pdf"
+    src.write_bytes(_ai_pdf())
+    _fake_tools(monkeypatch, qpdf=True, qpdf_rc=2, qpdf_writes=False)
+
+    actions, meta = clean_pdf(src, dest)
+
+    assert meta["structural_rewrite"] is False
+    assert dest.is_file()
+    assert any("recoverable" in a for a in actions), actions
+    assert not list(tmp_path.glob("*.qpdf-tmp"))
+
+
+@pytest.mark.skipif(
+    shutil.which("exiftool") is None or shutil.which("qpdf") is None,
+    reason="needs real exiftool and qpdf",
+)
+def test_end_to_end_no_recoverable_metadata_bytes(tmp_path: Path):
+    """The whole point: nothing readable survives in the output bytes.
+
+    Run against the real tools this fails without the structural rewrite —
+    exiftool alone leaves '/Producer (Claude Opus)' verbatim in the file.
+    """
+    src = tmp_path / "in.pdf"
+    dest = tmp_path / "out.pdf"
+    src.write_bytes(_ai_pdf())
+
+    _actions, meta = clean_pdf(src, dest)
+
+    # Assert the leak itself before the bookkeeping flag, so reverting the
+    # rewrite fails here — on recoverable bytes — and not on a missing key.
+    body = dest.read_bytes()
+    assert b"Claude" not in body
+    assert b"Anthropic" not in body
+    assert meta["structural_rewrite"] is True


### PR DESCRIPTION
## The problem

`clean_pdf` reports success while leaving the metadata fully recoverable in the output file.

ExifTool writes PDFs **incrementally**. `-all=` does not rewrite the document: it appends a `%BeginExifToolUpdate` block containing a new xref that frees the Info object and a new trailer without `/Info`. The original object is still there, byte for byte, and exiftool itself undoes the edit with `-PDF-update:all=`.

Reproduction with a PDF whose `/Info` carries `/Producer (Claude Opus) /Creator (Anthropic Claude)`:

```
$ python3 skills/remove-ai-marks/scripts/clean_file.py in.pdf -o out.pdf
wrote out.pdf format=pdf
  - exiftool -all= (rc=0)
  - c2patool available for inspect; strip via exiftool/re-export
warning: residual C2PA/AI signals may remain
  ! pdf-structured:ai:Claude
  ! pdf-structured:ai:Anthropic

$ ls -l in.pdf out.pdf
493 in.pdf
654 out.pdf          # the output is LARGER — that is the tell

$ strings out.pdf | grep Producer
/Producer (Claude Opus) /Creator (Anthropic Claude)
```

`inspect_file.py` already catches it — the raw byte scan is why the residual-signal warning fires — but there was no code path that could act on it. Exit code and actions otherwise read as a clean strip, and the PDF row in the README says exiftool is the preferred cleaner.

## The fix

Follow the exiftool pass with `qpdf --linearize`. qpdf re-serializes the document from its object graph, so objects the incremental update freed are simply not written out.

```
  - exiftool -all= (rc=0)
  - qpdf --linearize structural rewrite (rc=3)
```

`AI metadata: False`, and no `Claude`/`Anthropic` bytes survive.

Guarded on `which("qpdf")`, so behaviour is unchanged where qpdf is absent apart from an explicit warning replacing the silent pass:

```
warning: exiftool PDF edits are incremental — the original metadata bytes
remain recoverable; install qpdf for a structural rewrite
```

qpdf's exit code 3 ("succeeded with warnings") is treated as success, since it still writes output. A failed rewrite leaves the exiftool output in place, removes the temp file, and says the bytes remain recoverable.

## Tests

New `tests/test_pdf_structural_rewrite.py`, 5 cases. Four are hermetic (`which` and `subprocess.run` monkeypatched, matching the style of `test_c2patool_report.py`): the no-qpdf warning, the rebuild replacing the exiftool output, `rc=3`, and a failed rewrite. The fifth is end-to-end and skips unless real exiftool and qpdf are present — CI installs neither, so it skips there.

The end-to-end case asserts on the output **bytes** before the bookkeeping flag, so reverting the rewrite fails on the leak itself:

```
>       assert b"Claude" not in body
E       AssertionError: assert b'Claude' not in b'%PDF-1.4\n1 0 obj\n<< /Type /Catalog ...
E         ...%EndExifToolUpdate 451\nstartxref\n472\n%%EOF\n'
```

All 150 tests pass with the fix; all 5 new ones fail without it.

## Checklist

- [x] Behaviour matches `SKILL.md` / `references/removal-matrix.md` when relevant
- [x] Unit tests updated or added under `tests/`
- [x] `python3 -m pytest -q` passes
- [x] Docs updated — README optional-tools table, PDF row in the format table, a short "Why PDF needs qpdf" section, and the `SKILL.md` tools line and limitations
- [x] No drive-by refactors unrelated to the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
