### PR TITLE
fix: preserve mixed-case CMS generator meta tags

### DIFF
--- a/skills/remove-ai-marks/scripts/container_meta.py
+++ b/skills/remove-ai-marks/scripts/container_meta.py
@@ -254,7 +254,7 @@ _GENERATOR_AI_RE = re.compile(
 
 
 def _meta_attrs(tag: str) -> dict[str, str]:
-    return dict(_META_ATTR_RE.findall(tag))
+    return {name.lower(): value for name, value in _META_ATTR_RE.findall(tag)}
 
 
 def _is_cms_generator_meta(tag: str) -> bool:

--- a/tests/test_container_meta.py
+++ b/tests/test_container_meta.py
@@ -116,6 +116,22 @@ def test_html_cms_generator_preserved_by_clean():
     assert "viewport" in cleaned
 
 
+def test_html_cms_generator_attribute_names_are_case_insensitive():
+    for html in (
+        '<META NAME="generator" CONTENT="WordPress 6.0">',
+        '<meta Name="generator" Content="WordPress 6.0">',
+    ):
+        has_c2pa, has_ai, findings, _ = inspect_html(html)
+        assert not has_c2pa
+        assert not has_ai
+        assert any("cms" in finding for finding in findings)
+        assert clean_html(html)[0] == html
+
+    ai_html = '<META NAME="generator" CONTENT="Claude">'
+    assert inspect_html(ai_html)[1]
+    assert clean_html(ai_html)[0] == ""
+
+
 def test_html_ai_generator_still_dropped():
     html = '<meta name="generator" content="Claude">'
     cleaned, actions = clean_html(html)


### PR DESCRIPTION
## Summary

- normalize parsed HTML meta attribute names before lookup
- preserve ordinary CMS generator tags when their attributes use uppercase or mixed case
- keep AI generator tags removable regardless of attribute-name casing

## Problem

HTML attribute names are ASCII case-insensitive, but the meta parser stored captured names with their original casing. As a result, NAME and CONTENT were not found by the CMS-generator check, so valid WordPress metadata was classified as AI metadata and removed.

## Fix

Lowercase attribute names when building the parsed attribute dictionary. Values and the original tag remain unchanged.

## Tests

- added uppercase and mixed-case CMS generator regression cases
- added an uppercase Claude generator case to ensure AI metadata is still removed
- uv run --with pytest==9.1.1 python -m pytest -q: 146 passed
- python3 -m compileall -q skills tests: passed
- git diff --check: passed