### PR TITLE
feat(gui): add the Setup and Guide screens (4/5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ Vendors / ecosystems (class-level): **Claude**, **Gemini / SynthID-Text**, **Ope
 Skill path: [`skills/remove-ai-marks/`](skills/remove-ai-marks/)  
 (migration: formerly `remove-claude-marks`; slash alias `/remove-claude-marks` still documented)
 
+## Desktop app (no terminal needed)
+
+```bash
+python3 gui/launch.py
+```
+
+Drag files in, read the verdict, click clean. Paste text to see hidden characters revealed in
+place. Python 3.10+ stdlib only — no packages to install. Runs on **Windows, macOS and Linux**,
+loopback-only, with every action mapped to the same scripts the CLI calls.
+
+Details: [`gui/README.md`](gui/README.md)
+
 ## Install (agent skill)
 
 ```bash

--- a/gui/README.md
+++ b/gui/README.md
@@ -1,0 +1,127 @@
+# watermarks-remover — desktop app
+
+A point-and-click front end for the `remove-ai-marks` scripts. No terminal, no
+Python packages to install, and nothing leaves your computer.
+
+Works on **Windows, macOS and Linux**.
+
+---
+
+## Start it
+
+```bash
+python3 gui/launch.py
+```
+
+The app opens in its own window if you have [pywebview](https://pywebview.flowrl.com/)
+installed, and in your default browser otherwise. Both are the same app — the
+page is served from your own machine on `127.0.0.1`.
+
+**Requirements:** Python 3.10 or newer, and nothing else. If Windows says Python
+is missing, install it from [python.org](https://www.python.org/downloads/) and
+tick *“Add python.exe to PATH”* during setup.
+
+Optional native window:
+
+```bash
+pip install pywebview
+```
+
+---
+
+## The Files screen
+
+Drag files in, or press **Browse…**. Every file is scanned as it arrives and
+gets a verdict: *marks* or *clean*. Open one to see the findings, the exact
+hidden characters it contains, and where they sit in the text.
+
+**Clean this file** strips the marks and hands back a copy to download —
+`draft.md` → `draft.cleaned.md`. The original is never touched.
+
+Handles PNG, JPEG, PDF, DOCX, ODT, SVG, HTML, Markdown and plain text. Batch
+work is fine: **Clean all**, then **Download all** for a zip.
+
+| Option | Effect |
+| --- | --- |
+| Treat file as | Overrides format detection, same as the CLI's `--as` |
+| Flag look-alike letters | Reports Cyrillic/Greek letters posing as Latin ones |
+| Also replace those letters | Rewrites them during a clean (`--aggressive-homoglyphs`) |
+| Normalise text (NFKC) | Folds ﬁ, ①, full-width forms into plain equivalents |
+| Keep camera metadata | Images: drop only AI/C2PA segments, keep EXIF |
+| Score SynthID | Appears only when `REVERSE_SYNTHID_DIR` is configured |
+
+#### Word and ODT documents
+
+A `.docx`/`.odt` is a zip, and its prose lives in `word/document.xml` /
+`content.xml`. Two consequences worth knowing:
+
+- **`inspect_text.py` must not be pointed at one.** It reads the file as text,
+  so it scans deflate-compressed bytes and reports whatever codepoints happen to
+  fall out. The counts are noise: a document with nothing hidden in it can report
+  a dozen "suspicious" characters, and the number changes with compression, not
+  content. Use `inspect_file.py`, or this app.
+- **`inspect_container` only reads metadata**, so hidden characters in the actual
+  text were invisible to both the CLI and, until now, this app. The Files screen
+  unzips the text parts and reports them under *Hidden characters inside the
+  document text*, with the reveal view showing the surrounding sentence.
+
+Cleaning still defaults to upstream behaviour — metadata only. *Word / ODT: also
+strip invisible characters from the document text* turns on a text pass that
+rewrites only the character data between tags, leaving all markup byte-exact, and
+re-zips with the original entry order and compression.
+
+No-break spaces get their own sub-option and stay put by default: in real
+documents they are almost always deliberate typography (`Table 1`, `p = 0.05`,
+`Fig. 3`) rather than a watermark, and converting them changes how the document
+breaks across lines.
+
+## What maps to what
+
+Every screen is a front end for the same scripts the CLI uses, called in-process:
+
+| Screen | Script |
+| --- | --- |
+| Files → scan | `inspect_file.py` · `inspect_image.py` · `inspect_text.py` |
+| Files → clean | `clean_file.py` · `clean_image.py` |
+
+Markdown and HTML get the text scan too, since `clean_container` scrubs their
+bodies — the report would otherwise hide characters the clean would remove.
+
+---
+
+## Windows notes
+
+The skill scripts pass `preexec_fn` to `subprocess`, which is POSIX-only — on
+Windows that made every `exiftool`/`c2patool` call raise, so the tools looked
+broken even when installed. `server/compat.py` drops that argument on Windows
+and hides the console window the child would otherwise flash. Nothing in
+`skills/` is modified.
+
+`setup_synthid.sh` is still a shell script; run it from Git Bash or WSL if you
+want SynthID scoring.
+
+---
+
+## Privacy and safety
+
+- The server binds to `127.0.0.1` only, on a random port.
+- Every API call needs a session token generated at launch, so other pages open
+  in your browser cannot drive it.
+- The only files the server will hand out are the three in `gui/web/`, listed in
+  a table built at startup; a request path is never joined onto a directory.
+- Files you add are copied to a temporary folder that is deleted when the app
+  exits. Your originals are never modified.
+- No telemetry and no network access at all.
+
+---
+
+## Options
+
+```bash
+python3 gui/launch.py --port 8731     # fixed port
+python3 gui/launch.py --browser       # force the browser over the native window
+python3 gui/launch.py --no-browser    # just print the URL
+```
+
+Environment variables the app respects: `WATERMARKS_SKILL_DIR`,
+`WATERMARKS_MAX_INPUT_BYTES` and `REVERSE_SYNTHID_DIR`.

--- a/gui/README.md
+++ b/gui/README.md
@@ -90,6 +90,26 @@ Here⟨ZWSP⟩is a paragraph that looks perfectly normal.⟨WJ⟩
 **Clean text** strips them and tells you the count. Then copy the result or save
 it as `.txt`.
 
+### 03 · Rewrite (Layer B)
+
+Invisible characters are one kind of mark. Statistical watermarks live in the
+word choice itself, so the only way out is rewriting the text — which replaces
+your wording with the rewriting model's. The screen says so, and no tool can
+certify the result passes a vendor's detector.
+
+Five approaches (paraphrase, humanize, back-translate, structural, code) and
+three ways to run them:
+
+- **Just give me the prompt** — the default. Produces a prompt you can paste into
+  any chat model. Nothing is sent anywhere.
+- **Ollama on this machine** — local model, press **Test** to list what you have.
+- **OpenAI-compatible endpoint** — for a local llama.cpp/vLLM server.
+
+Non-local endpoints are refused unless you tick *Allow a non-local endpoint*,
+which is labelled with what it means: your text leaves the machine. API keys
+live in memory for the length of one request — never on disk, never in a command
+line.
+
 ## What maps to what
 
 Every screen is a front end for the same scripts the CLI uses, called in-process:
@@ -99,6 +119,7 @@ Every screen is a front end for the same scripts the CLI uses, called in-process
 | Files → scan | `inspect_file.py` · `inspect_image.py` · `inspect_text.py` |
 | Files → clean | `clean_file.py` · `clean_image.py` |
 | Text | `inspect_text.py` · `clean_text.py` |
+| Rewrite | `rewrite_text.py` |
 
 Markdown and HTML get the text scan too, since `clean_container` scrubs their
 bodies — the report would otherwise hide characters the clean would remove.
@@ -127,7 +148,8 @@ want SynthID scoring.
   a table built at startup; a request path is never joined onto a directory.
 - Files you add are copied to a temporary folder that is deleted when the app
   exits. Your originals are never modified.
-- No telemetry and no network access at all.
+- No telemetry, no network access — except a rewrite backend you configure
+  yourself.
 
 ---
 
@@ -140,4 +162,5 @@ python3 gui/launch.py --no-browser    # just print the URL
 ```
 
 Environment variables the app respects: `WATERMARKS_SKILL_DIR`,
-`WATERMARKS_MAX_INPUT_BYTES` and `REVERSE_SYNTHID_DIR`.
+`WATERMARKS_MAX_INPUT_BYTES`, `REVERSE_SYNTHID_DIR`, and the
+`WATERMARKS_REWRITE_*` family.

--- a/gui/README.md
+++ b/gui/README.md
@@ -29,7 +29,9 @@ pip install pywebview
 
 ---
 
-## The Files screen
+## What each screen does
+
+### 01 · Files
 
 Drag files in, or press **Browse…**. Every file is scanned as it arrives and
 gets a verdict: *marks* or *clean*. Open one to see the findings, the exact
@@ -75,6 +77,19 @@ documents they are almost always deliberate typography (`Table 1`, `p = 0.05`,
 `Fig. 3`) rather than a watermark, and converting them changes how the document
 breaks across lines.
 
+### 02 · Text
+
+For everything you copied out of a chat window and never saved to a file. Paste
+it, and **Reveal** replaces every invisible character with a labelled chip, in
+place, so you can see exactly what came along:
+
+```
+Here⟨ZWSP⟩is a paragraph that looks perfectly normal.⟨WJ⟩
+```
+
+**Clean text** strips them and tells you the count. Then copy the result or save
+it as `.txt`.
+
 ## What maps to what
 
 Every screen is a front end for the same scripts the CLI uses, called in-process:
@@ -83,6 +98,7 @@ Every screen is a front end for the same scripts the CLI uses, called in-process
 | --- | --- |
 | Files → scan | `inspect_file.py` · `inspect_image.py` · `inspect_text.py` |
 | Files → clean | `clean_file.py` · `clean_image.py` |
+| Text | `inspect_text.py` · `clean_text.py` |
 
 Markdown and HTML get the text scan too, since `clean_container` scrubs their
 bodies — the report would otherwise hide characters the clean would remove.

--- a/gui/README.md
+++ b/gui/README.md
@@ -110,6 +110,20 @@ which is labelled with what it means: your text leaves the machine. API keys
 live in memory for the length of one request — never on disk, never in a command
 line.
 
+### 04 · Setup
+
+What this machine can do right now. `exiftool` and `c2patool` are optional but
+make cleaning meaningfully better (especially for PDFs); this screen tells you
+whether they are present and gives you the exact install command for your OS.
+Also covers SynthID scoring and the native file dialog.
+
+### 05 · Guide
+
+The project's own reference notes — ethics, mark classes, removal matrix, vendor
+notes — rendered offline from `skills/remove-ai-marks/references/`.
+
+---
+
 ## What maps to what
 
 Every screen is a front end for the same scripts the CLI uses, called in-process:
@@ -120,6 +134,7 @@ Every screen is a front end for the same scripts the CLI uses, called in-process
 | Files → clean | `clean_file.py` · `clean_image.py` |
 | Text | `inspect_text.py` · `clean_text.py` |
 | Rewrite | `rewrite_text.py` |
+| Setup → SynthID | `score_synthid.py` |
 
 Markdown and HTML get the text scan too, since `clean_container` scrubs their
 bodies — the report would otherwise hide characters the clean would remove.

--- a/gui/launch.py
+++ b/gui/launch.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Start the watermarks-remover GUI.
+
+    python3 gui/launch.py
+
+Opens a local, loopback-only app in a native window when pywebview is
+installed, otherwise in your default browser. Nothing is uploaded anywhere:
+the server only listens on 127.0.0.1 and every file stays on this machine.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import threading
+import webbrowser
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+if sys.version_info < (3, 10):
+    raise SystemExit(
+        f"Python 3.10 or newer is required (found {sys.version.split()[0]}).\n"
+        "Install it from https://www.python.org/downloads/ and try again."
+    )
+
+from server.app import TOKEN, make_server  # noqa: E402
+
+BANNER = r"""
+  watermarks-remover
+  ------------------------------------------------
+  Strip AI provenance marks from content you own.
+"""
+
+
+def _try_window(url: str, httpd) -> bool:
+    """Native window via pywebview, if the user happens to have it."""
+    try:
+        import webview  # type: ignore
+    except Exception:
+        return False
+
+    def _closed() -> None:
+        threading.Thread(target=httpd.shutdown, daemon=True).start()
+
+    try:
+        window = webview.create_window(
+            "watermarks-remover",
+            url,
+            width=1180,
+            height=820,
+            min_size=(880, 620),
+        )
+        try:
+            window.events.closed += _closed
+        except AttributeError:  # pywebview < 4
+            pass
+        webview.start()
+        return True
+    except Exception as e:
+        # No GUI backend (headless Linux, missing WebView2, old pywebview) —
+        # the browser path below still works.
+        print(f"  Native window unavailable ({e}); falling back to the browser.")
+        return False
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--port", type=int, default=0, help="Fixed port (default: pick a free one)")
+    p.add_argument("--no-browser", action="store_true", help="Do not open anything; print the URL")
+    p.add_argument("--browser", action="store_true", help="Force the browser instead of a window")
+    args = p.parse_args()
+
+    httpd = make_server(port=args.port)
+    port = httpd.server_address[1]
+    url = f"http://127.0.0.1:{port}/?t={TOKEN}"
+
+    print(BANNER)
+    print(f"  Running at {url}")
+    print("  Press Ctrl+C to stop.\n")
+
+    if args.no_browser:
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            print("\n  Stopped.")
+        finally:
+            httpd.server_close()
+        return 0
+
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        if args.browser or not _try_window(url, httpd):
+            webbrowser.open(url)
+            # The browser owns the UI now, so hold the process here.
+            while thread.is_alive():
+                thread.join(0.5)
+    except KeyboardInterrupt:
+        print("\n  Stopped.")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gui/server/__init__.py
+++ b/gui/server/__init__.py
@@ -1,0 +1,1 @@
+"""Local server for the watermarks-remover GUI."""

--- a/gui/server/app.py
+++ b/gui/server/app.py
@@ -362,11 +362,43 @@ def api_clean(h: Handler) -> None:
     h._json(result)
 
 
+def api_text_inspect(h: Handler) -> None:
+    data = h._payload()
+    text = str(data.get("text") or "")
+    h._json(bridge.inspect_text(text, aggressive=bool(data.get("aggressive"))))
+
+
+def api_text_clean(h: Handler) -> None:
+    data = h._payload()
+    text = str(data.get("text") or "")
+    result = bridge.clean_text(
+        text,
+        nfkc=bool(data.get("nfkc")),
+        aggressive_homoglyphs=bool(data.get("aggressive_homoglyphs")),
+    )
+    result["report"] = bridge.inspect_text(result["text"], aggressive=bool(data.get("aggressive")))
+    h._json(result)
+
+
+def api_text_save(h: Handler) -> None:
+    data = h._payload()
+    text = str(data.get("text") or "")
+    name = _safe_name(str(data.get("name") or "cleaned.txt"))
+    folder = WORKDIR / secrets.token_urlsafe(8)
+    folder.mkdir(parents=True, exist_ok=True)
+    target = folder / name
+    target.write_text(text, encoding="utf-8")
+    h._json({"download_id": register(target, name, origin="output"), "name": name})
+
+
 ROUTES = {
     "/api/diagnostics": api_diagnostics,
     "/api/upload": api_upload,
     "/api/inspect": api_inspect,
     "/api/clean": api_clean,
+    "/api/text/inspect": api_text_inspect,
+    "/api/text/clean": api_text_clean,
+    "/api/text/save": api_text_save,
 }
 
 

--- a/gui/server/app.py
+++ b/gui/server/app.py
@@ -303,6 +303,15 @@ def api_diagnostics(h: Handler) -> None:
     h._json(bridge.diagnostics())
 
 
+def api_refs(h: Handler) -> None:
+    data = h._payload()
+    doc_id = data.get("id")
+    if doc_id:
+        h._json({"id": doc_id, "body": bridge.reference_body(str(doc_id))})
+        return
+    h._json({"docs": bridge.reference_docs()})
+
+
 def api_upload(h: Handler) -> None:
     # The browser percent-encodes the name: HTTP headers cannot carry raw UTF-8.
     name = _safe_name(unquote(h.headers.get("X-WM-Filename") or "dropped-file"))
@@ -432,8 +441,14 @@ def api_rewrite_probe(h: Handler) -> None:
     )
 
 
+def api_shutdown(h: Handler) -> None:
+    h._json({"ok": True})
+    threading.Thread(target=h.server.shutdown, daemon=True).start()
+
+
 ROUTES = {
     "/api/diagnostics": api_diagnostics,
+    "/api/refs": api_refs,
     "/api/upload": api_upload,
     "/api/inspect": api_inspect,
     "/api/clean": api_clean,
@@ -443,6 +458,7 @@ ROUTES = {
     "/api/rewrite": api_rewrite,
     "/api/rewrite/prompt": api_rewrite_prompt,
     "/api/rewrite/probe": api_rewrite_probe,
+    "/api/shutdown": api_shutdown,
 }
 
 

--- a/gui/server/app.py
+++ b/gui/server/app.py
@@ -1,0 +1,376 @@
+"""Local HTTP server behind the GUI.
+
+Loopback-only, and every /api/ call must carry the session token handed to the
+page at launch. Without that, any web page open in the same browser could drive
+a server that reads and writes files on this machine.
+"""
+
+from __future__ import annotations
+
+import atexit
+import io
+import json
+import os
+import re
+import secrets
+import shutil
+import tempfile
+import threading
+import traceback
+import zipfile
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, unquote, urlparse
+
+from . import bridge
+
+WEB_DIR = Path(__file__).resolve().parent.parent / "web"
+MAX_BODY = bridge.MAX_INPUT_BYTES + (1 << 20)
+
+TOKEN = secrets.token_urlsafe(32)
+WORKDIR = Path(tempfile.mkdtemp(prefix="watermarks-gui-"))
+
+_files: dict[str, dict[str, Any]] = {}
+_files_lock = threading.Lock()
+
+_SAFE_NAME = re.compile(r"[^A-Za-z0-9._ \-()\[\]]+")
+
+# Control characters have no business in a header value; a stray CR/LF would
+# let a crafted name inject headers of its own.
+_HEADER_JUNK = re.compile(r"[\x00-\x1f\x7f]")
+
+CONTENT_TYPES = {
+    ".html": "text/html; charset=utf-8",
+    ".css": "text/css; charset=utf-8",
+    ".js": "text/javascript; charset=utf-8",
+    ".json": "application/json; charset=utf-8",
+    ".svg": "image/svg+xml",
+    ".png": "image/png",
+    ".ico": "image/x-icon",
+    ".woff2": "font/woff2",
+}
+
+
+def _asset_map() -> dict[str, Path]:
+    """Every shipped file under ``web/``, keyed by its request path.
+
+    Serving from a table built by walking the directory means a request never
+    contributes to a filesystem path: an unknown key is a 404 and nothing else.
+    """
+    root = WEB_DIR.resolve()
+    assets: dict[str, Path] = {}
+    for entry in sorted(root.rglob("*")):
+        if not entry.is_file():
+            continue
+        real = entry.resolve()
+        if real.is_relative_to(root):  # skip a symlink pointing out of web/
+            assets[entry.relative_to(root).as_posix()] = real
+    return assets
+
+
+ASSETS = _asset_map()
+
+
+@atexit.register
+def _cleanup() -> None:
+    shutil.rmtree(WORKDIR, ignore_errors=True)
+
+
+def _safe_name(name: str) -> str:
+    name = Path(name.replace("\\", "/")).name
+    name = _SAFE_NAME.sub("_", name).strip() or "file"
+    return name[:120]
+
+
+def register(path: Path, name: str | None = None, origin: str = "output") -> str:
+    fid = secrets.token_urlsafe(12)
+    with _files_lock:
+        _files[fid] = {
+            "path": str(Path(path).resolve()),
+            "name": name or Path(path).name,
+            "origin": origin,
+        }
+    return fid
+
+
+def lookup(fid: str) -> dict[str, Any] | None:
+    with _files_lock:
+        entry = _files.get(fid)
+    return dict(entry) if entry else None
+
+
+def resolve_ref(ref: dict[str, Any]) -> tuple[Path, str]:
+    """Resolve a client file reference to (path, display name).
+
+    Every file the client knows about was registered by an upload, so a
+    reference is an id we handed out — never a path the client made up.
+    """
+    if not isinstance(ref, dict):
+        raise ValueError("Missing file reference")
+    fid = ref.get("id")
+    if not fid:
+        raise ValueError("Missing file reference")
+    entry = lookup(str(fid))
+    if not entry:
+        raise ValueError("That file is no longer available — add it again.")
+    return Path(entry["path"]), entry["name"]
+
+
+class Handler(BaseHTTPRequestHandler):
+    server_version = "watermarks-remover-gui"
+    protocol_version = "HTTP/1.1"
+
+    # -- plumbing ---------------------------------------------------------
+    def log_message(self, fmt: str, *args: Any) -> None:  # quiet by default
+        if os.environ.get("WATERMARKS_GUI_VERBOSE"):
+            super().log_message(fmt, *args)
+
+    def _send(self, code: int, body: bytes, ctype: str, extra: dict | None = None) -> None:
+        headers = {
+            "Content-Type": ctype,
+            "Content-Length": str(len(body)),
+            "Cache-Control": "no-store",
+            "X-Content-Type-Options": "nosniff",
+            "Content-Security-Policy": (
+                "default-src 'self'; img-src 'self' data: blob:; style-src 'self'; "
+                "script-src 'self'; connect-src 'self'; base-uri 'none'; form-action 'none'"
+            ),
+            **(extra or {}),
+        }
+        self.send_response(code)
+        for k, v in headers.items():
+            self.send_header(k, _HEADER_JUNK.sub("", str(v)))
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(body)
+
+    def _json(self, data: Any, code: int = 200) -> None:
+        body = json.dumps(data, ensure_ascii=False, default=str).encode("utf-8")
+        self._send(code, body, "application/json; charset=utf-8")
+
+    def _fail(self, message: str, code: int = 400) -> None:
+        self._json({"error": message}, code)
+
+    def _reject(self, message: str) -> None:
+        """Refuse without reading the body, so drop the connection with it.
+
+        Leaving an unread body on a keep-alive connection makes the next
+        request line start mid-payload; closing is both correct and keeps an
+        unauthorized caller from parking megabytes in memory.
+        """
+        self.close_connection = True
+        self._json({"error": message}, 403)
+
+    def _guard(self) -> bool:
+        """Loopback host + session token. Blocks other local apps and web pages."""
+        host = (self.headers.get("Host") or "").rsplit(":", 1)[0].strip("[]")
+        if host not in ("127.0.0.1", "localhost", "::1"):
+            self._reject("Bad host")
+            return False
+        origin = self.headers.get("Origin")
+        if origin:
+            o = urlparse(origin)
+            if o.hostname not in ("127.0.0.1", "localhost", "::1"):
+                self._reject("Bad origin")
+                return False
+        token = self.headers.get("X-WM-Token") or ""
+        if not secrets.compare_digest(token, TOKEN):
+            self._reject("Bad session token — reopen the app window.")
+            return False
+        return True
+
+    def _read_body(self) -> None:
+        """Consume the request body exactly once, before any handler runs."""
+        length = int(self.headers.get("Content-Length") or 0)
+        if length < 0 or length > MAX_BODY:
+            self.close_connection = True
+            raise ValueError("Request too large")
+        self._raw = self.rfile.read(length) if length else b""
+
+    def _payload(self) -> dict[str, Any]:
+        raw = getattr(self, "_raw", b"")
+        if not raw:
+            return {}
+        try:
+            data = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as e:
+            raise ValueError(f"Bad JSON body: {e}") from e
+        return data if isinstance(data, dict) else {}
+
+    # -- routing ----------------------------------------------------------
+    def do_GET(self) -> None:  # noqa: N802
+        parsed = urlparse(self.path)
+        route = parsed.path
+        try:
+            if route in ("/", "/index.html"):
+                return self._static("index.html")
+            if route.startswith("/assets/"):
+                return self._static(route[len("/assets/"):])
+            if route == "/api/download":
+                if not self._guard():
+                    return
+                return self._download(parse_qs(parsed.query))
+            if route == "/api/download-all":
+                if not self._guard():
+                    return
+                return self._download_all(parse_qs(parsed.query))
+            self._fail("Not found", 404)
+        except Exception as e:
+            self._unexpected(e)
+
+    do_HEAD = do_GET
+
+    def do_POST(self) -> None:  # noqa: N802
+        route = urlparse(self.path).path
+        if not route.startswith("/api/"):
+            return self._fail("Not found", 404)
+        if not self._guard():
+            return
+        try:
+            self._read_body()
+            handler = ROUTES.get(route)
+            if handler is None:
+                return self._fail("Not found", 404)
+            handler(self)
+        except ValueError as e:
+            self._fail(str(e), 400)
+        except SystemExit as e:  # the skill scripts raise this for bad config
+            self._fail(str(e) or "Operation refused", 400)
+        except Exception as e:
+            self._unexpected(e)
+
+    def _unexpected(self, exc: Exception) -> None:
+        detail = "".join(traceback.format_exception_only(type(exc), exc)).strip()
+        try:
+            self._json({"error": detail}, 500)
+        except Exception:
+            pass
+
+    # -- static -----------------------------------------------------------
+    def _static(self, rel: str) -> None:
+        target = ASSETS.get(unquote(rel))
+        if target is None or not target.is_file():
+            return self._fail("Not found", 404)
+        ctype = CONTENT_TYPES.get(target.suffix.lower(), "application/octet-stream")
+        self._send(200, target.read_bytes(), ctype)
+
+    # -- downloads --------------------------------------------------------
+    def _download(self, query: dict[str, list[str]]) -> None:
+        fid = (query.get("id") or [""])[0]
+        entry = lookup(fid)
+        if not entry or not Path(entry["path"]).is_file():
+            return self._fail("File not found", 404)
+        data = Path(entry["path"]).read_bytes()
+        name = _safe_name(entry["name"])
+        self._send(
+            200,
+            data,
+            "application/octet-stream",
+            {"Content-Disposition": f'attachment; filename="{name}"'},
+        )
+
+    def _download_all(self, query: dict[str, list[str]]) -> None:
+        ids = [i for i in (query.get("ids") or [""])[0].split(",") if i]
+        entries = [e for e in (lookup(i) for i in ids) if e and Path(e["path"]).is_file()]
+        if not entries:
+            return self._fail("Nothing to download", 404)
+        buf = io.BytesIO()
+        used: set[str] = set()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+            for entry in entries:
+                name = _safe_name(entry["name"])
+                stem, dot, ext = name.partition(".")
+                n = 1
+                while name in used:
+                    n += 1
+                    name = f"{stem}-{n}{dot}{ext}"
+                used.add(name)
+                zf.write(entry["path"], arcname=name)
+        self._send(
+            200,
+            buf.getvalue(),
+            "application/zip",
+            {"Content-Disposition": 'attachment; filename="cleaned-files.zip"'},
+        )
+
+
+# ---------------------------------------------------------------------------
+# API handlers
+# ---------------------------------------------------------------------------
+
+def api_diagnostics(h: Handler) -> None:
+    h._json(bridge.diagnostics())
+
+
+def api_upload(h: Handler) -> None:
+    # The browser percent-encodes the name: HTTP headers cannot carry raw UTF-8.
+    name = _safe_name(unquote(h.headers.get("X-WM-Filename") or "dropped-file"))
+    raw = h._raw
+    if len(raw) > bridge.MAX_INPUT_BYTES:
+        raise ValueError(
+            f"File is larger than the {bridge.MAX_INPUT_BYTES // (1 << 20)} MiB safety limit."
+        )
+    folder = WORKDIR / secrets.token_urlsafe(8)
+    folder.mkdir(parents=True, exist_ok=True)
+    target = folder / name
+    target.write_bytes(raw)
+    h._json(
+        {
+            "id": register(target, name, origin="upload"),
+            "name": name,
+            "size": len(raw),
+            "local": False,
+        }
+    )
+
+
+def api_inspect(h: Handler) -> None:
+    data = h._payload()
+    path, name = resolve_ref(data.get("file") or {})
+    report = bridge.inspect_file(
+        path,
+        aggressive=bool(data.get("aggressive")),
+        force_type=str(data.get("as") or "auto"),
+        synthid=bool(data.get("synthid")),
+    )
+    report["name"] = name
+    h._json(report)
+
+
+def api_clean(h: Handler) -> None:
+    data = h._payload()
+    path, name = resolve_ref(data.get("file") or {})
+    opts = {
+        "force_type": str(data.get("as") or "auto"),
+        "nfkc": bool(data.get("nfkc")),
+        "aggressive_homoglyphs": bool(data.get("aggressive_homoglyphs")),
+        "keep_non_ai_metadata": bool(data.get("keep_non_ai_metadata")),
+        "synthid": bool(data.get("synthid")),
+        "scrub_document_text": bool(data.get("scrub_document_text")),
+        "convert_nbsp": bool(data.get("convert_nbsp")),
+    }
+
+    folder = WORKDIR / secrets.token_urlsafe(8)
+    folder.mkdir(parents=True, exist_ok=True)
+    out_path = folder / bridge.cleaned_path(Path(name)).name
+    result = bridge.clean_file(path, out_path, **opts)
+
+    result["download_id"] = register(out_path, Path(out_path).name, origin="output")
+    result["output_name"] = Path(out_path).name
+    result["name"] = name
+    h._json(result)
+
+
+ROUTES = {
+    "/api/diagnostics": api_diagnostics,
+    "/api/upload": api_upload,
+    "/api/inspect": api_inspect,
+    "/api/clean": api_clean,
+}
+
+
+def make_server(host: str = "127.0.0.1", port: int = 0) -> ThreadingHTTPServer:
+    ThreadingHTTPServer.daemon_threads = True
+    ThreadingHTTPServer.allow_reuse_address = False
+    return ThreadingHTTPServer((host, port), Handler)

--- a/gui/server/app.py
+++ b/gui/server/app.py
@@ -391,6 +391,47 @@ def api_text_save(h: Handler) -> None:
     h._json({"download_id": register(target, name, origin="output"), "name": name})
 
 
+def api_rewrite_prompt(h: Handler) -> None:
+    data = h._payload()
+    prompt = bridge.build_prompt(
+        str(data.get("text") or ""),
+        strength=str(data.get("strength") or "paraphrase"),
+        lang=str(data.get("lang") or "French"),
+        original_lang=str(data.get("original_lang") or "English"),
+    )
+    h._json({"prompt": prompt})
+
+
+def api_rewrite(h: Handler) -> None:
+    data = h._payload()
+    result = bridge.rewrite(
+        str(data.get("text") or ""),
+        backend=str(data.get("backend") or "print-prompt"),
+        model=str(data.get("model") or "") or None,
+        base_url=str(data.get("base_url") or "") or None,
+        api_key=str(data.get("api_key") or "") or None,
+        strength=str(data.get("strength") or "paraphrase"),
+        lang=str(data.get("lang") or "French"),
+        original_lang=str(data.get("original_lang") or "English"),
+        timeout=float(data.get("timeout") or 120.0),
+        temperature=float(data.get("temperature") or 0.9),
+        candidates=int(data.get("candidates") or 1),
+        layer_a_after=bool(data.get("layer_a_after", True)),
+        allow_remote=bool(data.get("allow_remote")),
+    )
+    h._json(result)
+
+
+def api_rewrite_probe(h: Handler) -> None:
+    data = h._payload()
+    h._json(
+        bridge.probe_endpoint(
+            str(data.get("base_url") or "http://127.0.0.1:11434"),
+            str(data.get("backend") or "ollama"),
+        )
+    )
+
+
 ROUTES = {
     "/api/diagnostics": api_diagnostics,
     "/api/upload": api_upload,
@@ -399,6 +440,9 @@ ROUTES = {
     "/api/text/inspect": api_text_inspect,
     "/api/text/clean": api_text_clean,
     "/api/text/save": api_text_save,
+    "/api/rewrite": api_rewrite,
+    "/api/rewrite/prompt": api_rewrite_prompt,
+    "/api/rewrite/probe": api_rewrite_probe,
 }
 
 

--- a/gui/server/bridge.py
+++ b/gui/server/bridge.py
@@ -1,0 +1,556 @@
+"""Adapter between the GUI and the remove-ai-marks skill scripts.
+
+Everything runs in-process: the skill modules are plain stdlib Python, so
+importing them avoids a subprocess (and its argument-quoting pitfalls) per
+action, and lets the GUI reuse the exact same code paths the CLI uses.
+"""
+
+from __future__ import annotations
+
+import html
+import io
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import unicodedata
+import zipfile
+from pathlib import Path
+from typing import Any
+
+from . import compat
+
+compat.apply()
+
+GUI_DIR = Path(__file__).resolve().parent.parent
+REPO_ROOT = GUI_DIR.parent
+
+
+def _find_scripts_dir() -> Path:
+    override = os.environ.get("WATERMARKS_SKILL_DIR")
+    candidates = []
+    if override:
+        candidates.append(Path(override))
+    candidates += [
+        REPO_ROOT / "skills" / "remove-ai-marks" / "scripts",
+        GUI_DIR / "skills" / "remove-ai-marks" / "scripts",
+    ]
+    for c in candidates:
+        if (c / "text_unicode.py").is_file():
+            return c.resolve()
+    raise RuntimeError(
+        "Cannot find skills/remove-ai-marks/scripts. Put the gui/ folder inside "
+        "the watermarks-remover checkout, or set WATERMARKS_SKILL_DIR."
+    )
+
+
+SCRIPTS_DIR = _find_scripts_dir()
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import common  # noqa: E402
+import container_meta  # noqa: E402
+import image_meta  # noqa: E402
+import text_unicode  # noqa: E402
+
+MAX_INPUT_BYTES = common.MAX_INPUT_BYTES
+
+IMAGE_EXTS = {".png", ".jpg", ".jpeg"}
+CONTAINER_EXTS = {".svg", ".pdf", ".docx", ".odt", ".html", ".htm", ".md", ".markdown", ".mdx"}
+TEXT_EXTS = {
+    ".txt", ".text", ".css", ".js", ".py", ".rs", ".go",
+    ".json", ".yaml", ".yml", ".toml", ".csv",
+}
+
+
+# Compact names for the reveal view. Unicode's official names are too long to
+# sit inline in a paragraph, and "U+200B" alone tells a non-expert nothing.
+MARK_ABBREV = {
+    0x200B: "ZWSP", 0x200C: "ZWNJ", 0x200D: "ZWJ", 0xFEFF: "BOM",
+    0x2060: "WJ", 0x00AD: "SHY", 0x180E: "MVS", 0x061C: "ALM",
+    0x200E: "LRM", 0x200F: "RLM", 0x202A: "LRE", 0x202B: "RLE",
+    0x202C: "PDF", 0x202D: "LRO", 0x202E: "RLO", 0x2066: "LRI",
+    0x2067: "RLI", 0x2068: "FSI", 0x2069: "PDI", 0x00A0: "NBSP",
+    0x202F: "NNBSP", 0x2007: "FIGSP", 0x2009: "THINSP", 0x200A: "HAIRSP",
+    0x2002: "ENSP", 0x2003: "EMSP", 0x3000: "IDSP", 0x205F: "MMSP",
+}
+
+KIND_HELP = {
+    "strip": "Invisible character with no visual role — a classic carrier for hidden marks.",
+    "bidi": "Bidirectional control character. Can reorder text invisibly.",
+    "tag_chars": "Unicode tag character. Can encode whole hidden messages.",
+    "variation_selector": "Variation selector. Invisible, and can carry payload bits.",
+    "zwj_family": "Zero-width joiner family. Invisible glue between characters.",
+    "space": "A look-alike space that is not a plain space.",
+    "confusable": "A letter that looks Latin but is from another alphabet.",
+    "other_cf": "Other invisible format character.",
+}
+
+
+# ---------------------------------------------------------------------------
+# Reveal: turn text into segments so the UI can show what is actually in there
+# ---------------------------------------------------------------------------
+
+REVEAL_MAX_CHARS = 400_000
+
+
+def _mark_kind(ch: str, *, aggressive: bool) -> str | None:
+    cp = ord(ch)
+    if text_unicode._is_strip_cp(cp):
+        return text_unicode._strip_kind(cp)
+    if cp in text_unicode.SPACE_HOMOGLYPHS:
+        return "space"
+    if aggressive and cp in text_unicode.LATIN_CONFUSABLES:
+        return "confusable"
+    if unicodedata.category(ch) == "Cf" and cp not in (0x00AD,):
+        return "other_cf"
+    return None
+
+
+def _abbrev(cp: int) -> str:
+    if cp in MARK_ABBREV:
+        return MARK_ABBREV[cp]
+    name = unicodedata.name(chr(cp), "")
+    if name:
+        initials = "".join(w[0] for w in name.split() if w)[:5]
+        if len(initials) >= 2:
+            return initials
+    return f"U+{cp:04X}"
+
+
+def reveal_segments(text: str, *, aggressive: bool = False) -> dict[str, Any]:
+    """Split text into plain runs and mark runs for the reveal view."""
+    truncated = len(text) > REVEAL_MAX_CHARS
+    body = text[:REVEAL_MAX_CHARS]
+
+    segments: list[dict[str, Any]] = []
+    buf: list[str] = []
+
+    def flush() -> None:
+        if buf:
+            segments.append({"t": "text", "v": "".join(buf)})
+            buf.clear()
+
+    for ch in body:
+        kind = _mark_kind(ch, aggressive=aggressive)
+        if kind is None:
+            buf.append(ch)
+            continue
+        flush()
+        cp = ord(ch)
+        segments.append(
+            {
+                "t": "mark",
+                "v": _abbrev(cp),
+                "kind": kind,
+                "cp": f"U+{cp:04X}",
+                "label": text_unicode._char_label(ch),
+                # A space homoglyph still occupies a slot in the sentence, so
+                # keep its replacement visible behind the chip.
+                "sub": text_unicode.SPACE_HOMOGLYPHS.get(cp, ""),
+            }
+        )
+    flush()
+    return {"segments": segments, "truncated": truncated}
+
+
+# ---------------------------------------------------------------------------
+# Text (Layer A)
+# ---------------------------------------------------------------------------
+
+def inspect_text(text: str, *, aggressive: bool = False) -> dict[str, Any]:
+    report = text_unicode.inspect_text(text, aggressive=aggressive)
+    data = report.to_dict()
+    for hit in data["hits"]:
+        hit["help"] = KIND_HELP.get(hit["kind"], "")
+    data["reveal"] = reveal_segments(text, aggressive=aggressive)
+    data["clean"] = report.suspicious_total == 0
+    return data
+
+
+def clean_text(
+    text: str,
+    *,
+    nfkc: bool = False,
+    aggressive_homoglyphs: bool = False,
+    normalize_spaces: bool = True,
+) -> dict[str, Any]:
+    cleaned, stats = text_unicode.clean_text(
+        text,
+        nfkc=nfkc,
+        aggressive_homoglyphs=aggressive_homoglyphs,
+        normalize_spaces=normalize_spaces,
+    )
+    return {"text": cleaned, "stats": stats}
+
+
+# ---------------------------------------------------------------------------
+# Files
+# ---------------------------------------------------------------------------
+
+def classify(path: Path) -> str:
+    ext = path.suffix.lower()
+    if ext in IMAGE_EXTS:
+        return "image"
+    if ext in CONTAINER_EXTS:
+        return "container"
+    if ext in TEXT_EXTS:
+        return "text"
+    data = path.read_bytes()
+    if image_meta.detect_format(data) in ("png", "jpeg"):
+        return "image"
+    if container_meta.detect_container_format(path, data) != "unknown":
+        return "container"
+    return "text"
+
+
+def _guard_size(path: Path) -> None:
+    size = path.stat().st_size
+    if size > MAX_INPUT_BYTES:
+        raise ValueError(
+            f"File is larger than the {MAX_INPUT_BYTES // (1 << 20)} MiB safety limit "
+            f"({size // (1 << 20)} MiB)."
+        )
+
+
+def _decode(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="surrogateescape")
+
+
+def _is_texty_container(fmt: str) -> bool:
+    return fmt in ("markdown", "html")
+
+
+# ---------------------------------------------------------------------------
+# Office containers: the prose lives inside the zip, so neither inspect_file
+# nor inspect_text sees it. inspect_text.py on a .docx scans deflate-compressed
+# bytes and reports whatever random codepoints fall out — pure noise.
+# ---------------------------------------------------------------------------
+
+OFFICE_TEXT_PARTS = {
+    "docx": re.compile(
+        r"^word/(document|footnotes|endnotes|comments)\.xml$"
+        r"|^word/(header|footer)\d*\.xml$"
+    ),
+    "odt": re.compile(r"^(content|styles)\.xml$"),
+}
+
+# Character data is everything between tags; markup itself is never touched.
+_XML_CHARDATA = re.compile(r">([^<]*)<", re.DOTALL)
+
+
+def is_office_container(fmt: str) -> bool:
+    return fmt in OFFICE_TEXT_PARTS
+
+
+def office_text(data: bytes, fmt: str) -> str:
+    """The readable text inside a DOCX/ODT, for inspection and reveal."""
+    pattern = OFFICE_TEXT_PARTS.get(fmt)
+    if pattern is None:
+        return ""
+    chunks: list[str] = []
+    budget = [0]
+    try:
+        with zipfile.ZipFile(io.BytesIO(data)) as zf:
+            for info in zf.infolist():
+                if not pattern.match(info.filename):
+                    continue
+                container_meta._check_zip_budget(info, budget)
+                try:
+                    xml = zf.read(info.filename).decode("utf-8")
+                except (UnicodeDecodeError, KeyError):
+                    continue
+                for m in _XML_CHARDATA.finditer(xml):
+                    chunk = m.group(1)
+                    if chunk:
+                        chunks.append(html.unescape(chunk))
+    except (zipfile.BadZipFile, ValueError):
+        return ""
+    return "".join(chunks)
+
+
+def scrub_office_text(
+    data: bytes,
+    fmt: str,
+    *,
+    nfkc: bool = False,
+    aggressive_homoglyphs: bool = False,
+    normalize_spaces: bool = False,
+) -> tuple[bytes, dict[str, Any]]:
+    """Rewrite only the character data of a DOCX/ODT, leaving markup byte-exact."""
+    pattern = OFFICE_TEXT_PARTS.get(fmt)
+    if pattern is None:
+        return data, {"removed_count": 0, "replaced_count": 0, "parts": []}
+
+    totals: dict[str, Any] = {"removed_count": 0, "replaced_count": 0, "parts": []}
+    out = io.BytesIO()
+    budget = [0]
+
+    try:
+        _rezip(data, pattern, out, budget, totals, nfkc, aggressive_homoglyphs, normalize_spaces)
+    except (zipfile.BadZipFile, ValueError) as e:
+        # A container we cannot safely rewrite is left exactly as it was.
+        totals["error"] = str(e)
+        return data, totals
+    return out.getvalue(), totals
+
+
+def _rezip(
+    data: bytes,
+    pattern: re.Pattern[str],
+    out: io.BytesIO,
+    budget: list[int],
+    totals: dict[str, Any],
+    nfkc: bool,
+    aggressive_homoglyphs: bool,
+    normalize_spaces: bool,
+) -> None:
+    with zipfile.ZipFile(io.BytesIO(data)) as zin, \
+            zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED) as zout:
+        for info in zin.infolist():
+            container_meta._check_zip_budget(info, budget)
+            raw = zin.read(info.filename)
+            if pattern.match(info.filename):
+                try:
+                    xml = raw.decode("utf-8")
+                except UnicodeDecodeError:
+                    xml = None
+                if xml is not None:
+                    removed = replaced = 0
+
+                    def _sub(m: re.Match[str]) -> str:
+                        nonlocal removed, replaced
+                        chunk = m.group(1)
+                        if not chunk:
+                            return m.group(0)
+                        cleaned, st = text_unicode.clean_text(
+                            chunk,
+                            nfkc=nfkc,
+                            aggressive_homoglyphs=aggressive_homoglyphs,
+                            normalize_spaces=normalize_spaces,
+                        )
+                        removed += st["removed_count"]
+                        replaced += st["replaced_count"]
+                        return f">{cleaned}<"
+
+                    new_xml = _XML_CHARDATA.sub(_sub, xml)
+                    if removed or replaced:
+                        totals["removed_count"] += removed
+                        totals["replaced_count"] += replaced
+                        totals["parts"].append(info.filename)
+                        raw = new_xml.encode("utf-8")
+
+            copy = zipfile.ZipInfo(info.filename, date_time=info.date_time)
+            copy.compress_type = info.compress_type
+            copy.external_attr = info.external_attr
+            copy.internal_attr = info.internal_attr
+            copy.create_system = info.create_system
+            zout.writestr(copy, raw)
+
+
+def inspect_file(
+    path: Path,
+    *,
+    aggressive: bool = False,
+    force_type: str = "auto",
+    synthid: bool = False,
+) -> dict[str, Any]:
+    path = Path(path)
+    if not path.is_file():
+        raise ValueError(f"Not a file: {path}")
+    _guard_size(path)
+
+    kind = force_type if force_type != "auto" else classify(path)
+    out: dict[str, Any] = {
+        "kind": kind,
+        "path": str(path),
+        "name": path.name,
+        "size": path.stat().st_size,
+    }
+
+    if kind == "text":
+        text = _decode(path)
+        report = inspect_text(text, aggressive=aggressive)
+        out.update(
+            {
+                "format": "text",
+                "text_report": report,
+                "findings": [
+                    f"{h['label']} x{h['count']}" for h in report["hits"]
+                ],
+                "has_c2pa": False,
+                "has_ai_metadata": report["suspicious_total"] > 0,
+                "clean": report["clean"],
+            }
+        )
+        return out
+
+    if kind == "image":
+        synthid_dir = os.environ.get("REVERSE_SYNTHID_DIR") if synthid else None
+        report = image_meta.inspect_image(path, synthid_dir=synthid_dir)
+        data = report.to_dict()
+        out.update(data)
+        out["clean"] = not (data["has_c2pa"] or data["has_ai_metadata"])
+        return out
+
+    report = container_meta.inspect_container(path)
+    data = report.to_dict()
+    out.update(data)
+    # inspect_container only looks at metadata. Surface the text body too:
+    # for md/html because clean_container already scrubs it, and for Office
+    # files because that is where their prose actually lives.
+    fmt = data.get("format", "")
+    if _is_texty_container(fmt):
+        try:
+            text = _decode(path)
+        except OSError:
+            text = ""
+        if text:
+            out["text_report"] = inspect_text(text, aggressive=aggressive)
+            out["text_source"] = "file text"
+    elif is_office_container(fmt):
+        text = office_text(path.read_bytes(), fmt)
+        if text:
+            out["text_report"] = inspect_text(text, aggressive=aggressive)
+            out["text_source"] = "document body"
+    text_dirty = bool(out.get("text_report") and not out["text_report"]["clean"])
+    out["clean"] = not (data["has_c2pa"] or data["has_ai_metadata"] or text_dirty)
+    return out
+
+
+def clean_file(
+    path: Path,
+    dest: Path,
+    *,
+    force_type: str = "auto",
+    nfkc: bool = False,
+    aggressive_homoglyphs: bool = False,
+    keep_non_ai_metadata: bool = False,
+    synthid: bool = False,
+    scrub_document_text: bool = False,
+    convert_nbsp: bool = False,
+) -> dict[str, Any]:
+    path = Path(path)
+    dest = Path(dest)
+    if not path.is_file():
+        raise ValueError(f"Not a file: {path}")
+    _guard_size(path)
+
+    kind = force_type if force_type != "auto" else classify(path)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+
+    if kind == "text":
+        text = _decode(path)
+        cleaned, stats = text_unicode.clean_text(
+            text, nfkc=nfkc, aggressive_homoglyphs=aggressive_homoglyphs
+        )
+        common.safe_write_text(dest, cleaned)
+        actions = []
+        if stats["removed_count"]:
+            actions.append(f"removed {stats['removed_count']} invisible characters")
+        if stats["replaced_count"]:
+            actions.append(f"replaced {stats['replaced_count']} look-alike characters")
+        if nfkc and stats["replaced"].get("NFKC_normalize"):
+            actions.append("applied NFKC normalisation")
+        if not actions:
+            actions.append("nothing to remove — copied as-is")
+        return {
+            "kind": "text",
+            "input": str(path),
+            "output": str(dest),
+            "format": "text",
+            "actions": actions,
+            "stats": stats,
+            "bytes_in": path.stat().st_size,
+            "bytes_out": dest.stat().st_size,
+            "still_has_c2pa": False,
+            "still_has_ai_metadata": False,
+            "residual": False,
+        }
+
+    if kind == "image":
+        synthid_dir = os.environ.get("REVERSE_SYNTHID_DIR") if synthid else None
+        result = image_meta.clean_image(
+            path,
+            dest,
+            strip_all_metadata=not keep_non_ai_metadata,
+            synthid_dir=synthid_dir,
+        )
+        result = {"kind": "image", **result}
+        result["residual"] = bool(result["still_has_c2pa"] or result["still_has_ai_metadata"])
+        if not result["actions"]:
+            result["actions"] = ["no metadata segments found — re-encoded container"]
+        return result
+
+    result = container_meta.clean_container(path, dest)
+    result = {"kind": "container", **result}
+
+    if scrub_document_text and is_office_container(result.get("format", "")):
+        scrubbed, totals = scrub_office_text(
+            dest.read_bytes(),
+            result["format"],
+            nfkc=nfkc,
+            aggressive_homoglyphs=aggressive_homoglyphs,
+            normalize_spaces=convert_nbsp,
+        )
+        if totals["removed_count"] or totals["replaced_count"]:
+            common.safe_write_bytes(dest, scrubbed)
+            result["bytes_out"] = dest.stat().st_size
+            result["actions"].append(
+                f"document text: removed {totals['removed_count']}, "
+                f"replaced {totals['replaced_count']} "
+                f"in {', '.join(totals['parts'])}"
+            )
+        else:
+            result["actions"].append("document text: nothing to remove")
+
+    result["residual"] = bool(result["still_has_c2pa"] or result["still_has_ai_metadata"])
+    if result.get("meta", {}).get("degraded"):
+        result["degraded"] = True
+    if not result["actions"]:
+        result["actions"] = ["no metadata found — copied as-is"]
+    return result
+
+
+def cleaned_path(path: Path) -> Path:
+    return common.cleaned_path(Path(path))
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics
+# ---------------------------------------------------------------------------
+
+def _tool_version(name: str, args: list[str]) -> dict[str, Any]:
+    exe = shutil.which(name)
+    if not exe:
+        return {"available": False, "path": None, "version": None}
+    version = None
+    try:
+        r = subprocess.run([exe, *args], capture_output=True, text=True, timeout=15)
+        version = ((r.stdout or "") + (r.stderr or "")).strip().splitlines()
+        version = version[0][:120] if version else None
+    except Exception:
+        pass
+    return {"available": True, "path": exe, "version": version}
+
+
+def diagnostics() -> dict[str, Any]:
+    synthid_dir = os.environ.get("REVERSE_SYNTHID_DIR")
+    return {
+        "python": sys.version.split()[0],
+        "platform": f"{platform.system()} {platform.release()}",
+        "scripts_dir": str(SCRIPTS_DIR),
+        "max_input_mib": MAX_INPUT_BYTES // (1 << 20),
+        "compat_notes": compat.notes(),
+        "tools": {
+            "exiftool": _tool_version("exiftool", ["-ver"]),
+            "c2patool": _tool_version("c2patool", ["--version"]),
+        },
+        "synthid": {
+            "configured": bool(synthid_dir),
+            "dir": synthid_dir,
+            "exists": bool(synthid_dir and Path(synthid_dir).is_dir()),
+        },
+    }

--- a/gui/server/bridge.py
+++ b/gui/server/bridge.py
@@ -53,6 +53,7 @@ if str(SCRIPTS_DIR) not in sys.path:
 import common  # noqa: E402
 import container_meta  # noqa: E402
 import image_meta  # noqa: E402
+import rewrite_text as rewrite_mod  # noqa: E402
 import text_unicode  # noqa: E402
 
 MAX_INPUT_BYTES = common.MAX_INPUT_BYTES
@@ -64,6 +65,8 @@ TEXT_EXTS = {
     ".json", ".yaml", ".yml", ".toml", ".csv",
 }
 
+REWRITE_STRENGTHS = ("paraphrase", "humanize", "code", "backtranslate", "structural")
+REWRITE_BACKENDS = ("print-prompt", "ollama", "openai-compatible")
 
 # Compact names for the reveal view. Unicode's official names are too long to
 # sit inline in a paragraph, and "U+200B" alone tells a non-expert nothing.
@@ -519,6 +522,84 @@ def cleaned_path(path: Path) -> Path:
 
 
 # ---------------------------------------------------------------------------
+# Layer B rewrite
+# ---------------------------------------------------------------------------
+
+def build_prompt(text: str, *, strength: str, lang: str, original_lang: str) -> str:
+    return rewrite_mod.build_prompt(strength, text, lang=lang, original_lang=original_lang)
+
+
+def rewrite(
+    text: str,
+    *,
+    backend: str,
+    model: str | None,
+    base_url: str | None,
+    api_key: str | None,
+    strength: str,
+    lang: str,
+    original_lang: str,
+    timeout: float,
+    temperature: float,
+    candidates: int,
+    layer_a_after: bool,
+    allow_remote: bool,
+) -> dict[str, Any]:
+    if backend not in REWRITE_BACKENDS:
+        raise ValueError(f"Unknown backend: {backend}")
+    if strength not in REWRITE_STRENGTHS:
+        raise ValueError(f"Unknown strength: {strength}")
+
+    out, info = rewrite_mod.rewrite(
+        text,
+        backend=backend,
+        model=model or None,
+        base_url=base_url or None,
+        api_key=api_key or None,
+        strength=strength,
+        lang=lang,
+        original_lang=original_lang,
+        timeout=timeout,
+        layer_a_after=layer_a_after,
+        temperature=temperature,
+        candidates=candidates,
+        allow_remote=allow_remote,
+    )
+    divergence = None
+    if info.get("mode") == "rewritten":
+        divergence = rewrite_mod._lexical_divergence(text, out)
+    return {"text": out, "info": info, "divergence": divergence}
+
+
+def probe_endpoint(base_url: str, backend: str, timeout: float = 5.0) -> dict[str, Any]:
+    """Cheap reachability check for the rewrite endpoint, used by the UI."""
+    import json
+    import urllib.error
+    import urllib.request
+
+    url = base_url.rstrip("/")
+    probe = f"{url}/api/tags" if backend == "ollama" else f"{url}/models"
+    try:
+        with urllib.request.urlopen(probe, timeout=timeout) as resp:
+            raw = resp.read(1 << 20)
+    except urllib.error.HTTPError as e:
+        return {"ok": False, "error": f"HTTP {e.code} from {probe}"}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+    models: list[str] = []
+    try:
+        payload = json.loads(raw.decode("utf-8", errors="replace"))
+        if backend == "ollama":
+            models = [m.get("name", "") for m in payload.get("models", [])]
+        else:
+            models = [m.get("id", "") for m in payload.get("data", [])]
+    except Exception:
+        pass
+    return {"ok": True, "models": [m for m in models if m][:80]}
+
+
+# ---------------------------------------------------------------------------
 # Diagnostics
 # ---------------------------------------------------------------------------
 
@@ -552,5 +633,12 @@ def diagnostics() -> dict[str, Any]:
             "configured": bool(synthid_dir),
             "dir": synthid_dir,
             "exists": bool(synthid_dir and Path(synthid_dir).is_dir()),
+        },
+        "rewrite_env": {
+            "backend": os.environ.get("WATERMARKS_REWRITE_BACKEND"),
+            "model": os.environ.get("WATERMARKS_REWRITE_MODEL"),
+            "base_url": os.environ.get("WATERMARKS_REWRITE_BASE_URL"),
+            "api_key_set": bool(os.environ.get("WATERMARKS_REWRITE_API_KEY")),
+            "allow_remote": os.environ.get("WATERMARKS_REWRITE_ALLOW_REMOTE", ""),
         },
     }

--- a/gui/server/bridge.py
+++ b/gui/server/bridge.py
@@ -642,3 +642,21 @@ def diagnostics() -> dict[str, Any]:
             "allow_remote": os.environ.get("WATERMARKS_REWRITE_ALLOW_REMOTE", ""),
         },
     }
+
+
+def reference_docs() -> list[dict[str, str]]:
+    """The repo's own reference notes, so the GUI can show them offline."""
+    refs = REPO_ROOT / "skills" / "remove-ai-marks" / "references"
+    docs = []
+    if refs.is_dir():
+        for p in sorted(refs.glob("*.md")):
+            docs.append({"id": p.stem, "title": p.stem.replace("-", " ").title()})
+    return docs
+
+
+def reference_body(doc_id: str) -> str:
+    refs = (REPO_ROOT / "skills" / "remove-ai-marks" / "references").resolve()
+    target = (refs / f"{doc_id}.md").resolve()
+    if target.parent != refs or not target.is_file():
+        raise ValueError("Unknown document")
+    return target.read_text(encoding="utf-8", errors="replace")

--- a/gui/server/compat.py
+++ b/gui/server/compat.py
@@ -1,0 +1,64 @@
+"""Cross-platform shims that let the skill scripts run unchanged on Windows.
+
+Two upstream behaviours are POSIX-only:
+
+* ``preexec_fn=subprocess_rlimits`` — ``subprocess`` raises ``ValueError`` for
+  ``preexec_fn`` on Windows, so every ``exiftool``/``c2patool`` call would fail
+  there. The callers catch the exception, which means the tools silently look
+  broken instead of working.
+* Child processes pop up a console window on Windows.
+
+Both are fixed here by wrapping ``subprocess.run`` for this process only. The
+skill scripts are imported afterwards and pick the wrapper up through the
+module object they already hold.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+IS_WINDOWS = os.name == "nt"
+IS_MACOS = sys.platform == "darwin"
+
+_applied = False
+_notes: list[str] = []
+
+
+def _patch_subprocess() -> None:
+    original_run = subprocess.run
+    if getattr(original_run, "_watermarks_gui_patched", False):
+        return
+
+    no_window = getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)
+
+    def run(*args, **kwargs):
+        # preexec_fn is a POSIX-only knob; the resource caps it applies simply
+        # do not exist on Windows.
+        kwargs.pop("preexec_fn", None)
+        flags = kwargs.get("creationflags", 0)
+        kwargs["creationflags"] = flags | no_window
+        return original_run(*args, **kwargs)
+
+    run._watermarks_gui_patched = True  # type: ignore[attr-defined]
+    subprocess.run = run  # type: ignore[assignment]
+
+
+def apply() -> list[str]:
+    """Install the shims once. Returns human-readable notes for diagnostics."""
+    global _applied
+    if _applied:
+        return list(_notes)
+    _applied = True
+
+    if IS_WINDOWS:
+        _patch_subprocess()
+        _notes.append("Windows: subprocess resource limits skipped (POSIX-only)")
+        _notes.append("Windows: helper tools run without a console window")
+
+    return list(_notes)
+
+
+def notes() -> list[str]:
+    return list(_notes)

--- a/gui/web/app.css
+++ b/gui/web/app.css
@@ -1,0 +1,796 @@
+/* watermarks-remover GUI
+   Visual language: a lab instrument printed on warm paper.
+   Hairline rules instead of shadows, mono micro-labels, one signal colour. */
+
+:root {
+  --paper:      #f4f1ea;
+  --panel:      #fffdf8;
+  --panel-2:    #faf7f0;
+  --ink:        #16120e;
+  --ink-2:      #4b4239;
+  --ink-3:      #8c8175;
+  --rule:       #ded5c6;
+  --rule-soft:  #ebe4d8;
+  --accent:     #b8390b;
+  --accent-2:   #8f2c08;
+  --accent-soft:#fbe3d4;
+  --ok:         #1a6b3c;
+  --ok-soft:    #ddefe2;
+  --warn:       #91650a;
+  --warn-soft:  #f7ecd3;
+  --focus:      #1d4ed8;
+  --mono: ui-monospace, "Cascadia Mono", "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+  --sans: -apple-system, BlinkMacSystemFont, "Segoe UI Variable Text", "Segoe UI", Roboto,
+          "Helvetica Neue", Arial, sans-serif;
+  --rail-w: 132px;
+  --radius: 3px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --paper:      #14120f;
+    --panel:      #1c1915;
+    --panel-2:    #201c17;
+    --ink:        #f2ede3;
+    --ink-2:      #c3b9a9;
+    --ink-3:      #8b8073;
+    --rule:       #35302a;
+    --rule-soft:  #2a2620;
+    --accent:     #f0803e;
+    --accent-2:   #ffa066;
+    --accent-soft:#3a2015;
+    --ok:         #63c48c;
+    --ok-soft:    #16281d;
+    --warn:       #d8a84a;
+    --warn-soft:  #2b2313;
+    --focus:      #7ea2ff;
+  }
+}
+
+:root[data-theme="dark"] {
+  --paper:      #14120f;
+  --panel:      #1c1915;
+  --panel-2:    #201c17;
+  --ink:        #f2ede3;
+  --ink-2:      #c3b9a9;
+  --ink-3:      #8b8073;
+  --rule:       #35302a;
+  --rule-soft:  #2a2620;
+  --accent:     #f0803e;
+  --accent-2:   #ffa066;
+  --accent-soft:#3a2015;
+  --ok:         #63c48c;
+  --ok-soft:    #16281d;
+  --warn:       #d8a84a;
+  --warn-soft:  #2b2313;
+  --focus:      #7ea2ff;
+}
+
+* { box-sizing: border-box; }
+
+/* Elements below set display:, which would otherwise beat the UA rule for
+   [hidden] and leak empty panels into the layout. */
+[hidden] { display: none !important; }
+
+html, body {
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 15px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
+}
+
+.label {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+}
+
+/* ---------- shell ---------- */
+
+.app { display: flex; flex-direction: column; height: 100%; }
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 0 18px;
+  height: 52px;
+  border-bottom: 1px solid var(--rule);
+  background: var(--panel);
+  flex: none;
+}
+
+.brand { display: flex; align-items: center; gap: 10px; min-width: 0; }
+
+.brand-mark {
+  width: 20px; height: 20px; flex: none;
+  fill: none; stroke: var(--accent); stroke-width: 1.5;
+  stroke-linecap: round;
+}
+
+.brand-name {
+  font-family: var(--mono);
+  font-size: 13px;
+  letter-spacing: .02em;
+  font-weight: 600;
+}
+.brand-dash { color: var(--accent); }
+
+.brand-tag {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  border: 1px solid var(--rule);
+  border-radius: 999px;
+  padding: 1px 8px;
+  margin-left: 4px;
+}
+
+.topbar-right { display: flex; align-items: center; gap: 12px; }
+
+.toolstrip { display: flex; gap: 12px; }
+
+.tool-dot {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: .06em;
+  color: var(--ink-3);
+  display: flex; align-items: center; gap: 5px;
+}
+.tool-dot i {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--ink-3); display: inline-block;
+}
+.tool-dot.on i { background: var(--ok); }
+.tool-dot.off i { background: transparent; border: 1px solid var(--ink-3); }
+
+.icon-btn {
+  background: none;
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  color: var(--ink-2);
+  width: 30px; height: 28px;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+}
+.icon-btn:hover { border-color: var(--ink-3); color: var(--ink); }
+
+.body { display: flex; flex: 1; min-height: 0; }
+
+/* ---------- rail ---------- */
+
+.rail {
+  width: var(--rail-w);
+  flex: none;
+  border-right: 1px solid var(--rule);
+  background: var(--panel-2);
+  padding: 14px 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.rail-item {
+  appearance: none;
+  background: none;
+  border: 0;
+  border-left: 2px solid transparent;
+  width: 100%;
+  text-align: left;
+  padding: 9px 14px 9px 16px;
+  cursor: pointer;
+  color: var(--ink-2);
+  display: flex;
+  align-items: baseline;
+  gap: 9px;
+  font-family: var(--sans);
+  font-size: 14px;
+}
+.rail-item em {
+  font-family: var(--mono);
+  font-style: normal;
+  font-size: 10px;
+  letter-spacing: .1em;
+  color: var(--ink-3);
+}
+.rail-item:hover { color: var(--ink); background: var(--panel); }
+.rail-item.is-active {
+  color: var(--ink);
+  border-left-color: var(--accent);
+  background: var(--panel);
+  font-weight: 600;
+}
+.rail-item.is-active em { color: var(--accent); }
+
+.rail-foot { margin-top: auto; padding: 14px 16px 4px; }
+.rail-note {
+  font-family: var(--mono);
+  font-size: 10px;
+  line-height: 1.6;
+  letter-spacing: .04em;
+  color: var(--ink-3);
+}
+
+/* ---------- stage ---------- */
+
+.stage { flex: 1; min-width: 0; overflow-y: auto; }
+
+.view { display: none; padding: 26px 30px 60px; max-width: 1180px; }
+.view.is-active { display: block; }
+
+.view-head { margin-bottom: 20px; }
+.view-head h1 {
+  margin: 0 0 4px;
+  font-size: 26px;
+  font-weight: 600;
+  letter-spacing: -.015em;
+}
+.view-head p { margin: 0; color: var(--ink-2); font-size: 14px; max-width: 68ch; }
+
+.head-badge {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  color: var(--accent);
+  border: 1px solid var(--accent);
+  border-radius: 999px;
+  padding: 2px 8px;
+  vertical-align: middle;
+  margin-left: 6px;
+  font-weight: 500;
+}
+
+/* ---------- controls ---------- */
+
+.btn {
+  appearance: none;
+  font: inherit;
+  font-size: 13.5px;
+  padding: 7px 14px;
+  border: 1px solid var(--rule);
+  background: var(--panel);
+  color: var(--ink);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: border-color .12s, background .12s;
+}
+.btn:hover:not(:disabled) { border-color: var(--ink-3); }
+.btn:disabled { opacity: .45; cursor: default; }
+
+.btn-primary {
+  background: var(--ink);
+  border-color: var(--ink);
+  color: var(--paper);
+  font-weight: 500;
+}
+.btn-primary:hover:not(:disabled) { background: var(--accent); border-color: var(--accent); }
+
+.btn-sm { padding: 4px 10px; font-size: 12.5px; }
+.btn-quiet { border-color: transparent; color: var(--ink-3); }
+.btn-quiet:hover:not(:disabled) { color: var(--ink); border-color: var(--rule); }
+.btn-block { width: 100%; margin-top: 14px; }
+.btn-test { align-self: end; margin-bottom: 1px; }
+
+input[type="text"], input[type="password"], input[type="number"], select, textarea {
+  font: inherit;
+  font-size: 13.5px;
+  color: var(--ink);
+  background: var(--panel);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  padding: 6px 9px;
+  width: 100%;
+}
+select { cursor: pointer; }
+textarea { resize: vertical; }
+
+.field { display: block; margin-bottom: 12px; }
+.field-label {
+  display: block;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  margin-bottom: 5px;
+}
+.field-label .hint { text-transform: none; letter-spacing: 0; opacity: .8; }
+.field-row { display: flex; gap: 10px; align-items: start; }
+.field-row .field { flex: 1; }
+.field-slim { max-width: 92px; }
+
+.check {
+  display: flex;
+  align-items: start;
+  gap: 8px;
+  font-size: 13.5px;
+  color: var(--ink-2);
+  cursor: pointer;
+  margin-bottom: 9px;
+  line-height: 1.45;
+}
+.check input { margin: 3px 0 0; accent-color: var(--accent); flex: none; }
+.check.inline { margin: 0; align-items: center; }
+.check.sub { margin-left: 22px; }
+.sub-note {
+  display: block;
+  font-style: normal;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: .02em;
+  color: var(--ink-3);
+  margin-top: 1px;
+}
+/* The remedy sits next to the finding, not in a collapsed options panel. */
+.inline-action {
+  margin-top: 12px;
+  padding: 12px 14px;
+  border: 1px solid var(--rule);
+  border-left: 3px solid var(--warn);
+  background: var(--warn-soft);
+  border-radius: 0 var(--radius) var(--radius) 0;
+}
+.inline-action p { margin: 0 0 10px; font-size: 13px; color: var(--ink-2); }
+.inline-action-row { display: flex; align-items: center; gap: 14px; flex-wrap: wrap; }
+
+.legend {
+  display: flex; align-items: center; gap: 14px; flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+.legend-item { display: flex; align-items: center; gap: 6px; font-size: 12px; color: var(--ink-2); }
+.legend-swatch { cursor: default; }
+
+.tag {
+  font-family: var(--mono); font-size: 9.5px; letter-spacing: .08em; text-transform: uppercase;
+  border: 1px solid var(--rule); border-radius: 999px; padding: 1px 7px;
+  color: var(--ink-3); white-space: nowrap;
+}
+.tag.t-space { color: var(--warn); border-color: var(--warn); }
+.tag.t-bidi, .tag.t-tag_chars { color: var(--accent); border-color: var(--accent); }
+
+.detail-section.fold > summary {
+  list-style: none; cursor: pointer; display: flex; align-items: center; gap: 8px;
+}
+.detail-section.fold > summary::-webkit-details-marker { display: none; }
+.detail-section.fold > summary::before {
+  content: "+"; font-family: var(--mono); color: var(--accent); font-size: 13px;
+}
+.detail-section.fold[open] > summary::before { content: "−"; }
+.detail-section.fold > summary h3 { margin: 0; }
+
+.table-scroll { overflow-x: auto; }
+
+.visually-hidden, .offscreen {
+  position: absolute !important;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+}
+
+.actionbar-gap { flex: 1; }
+
+/* ---------- shortcuts modal ---------- */
+
+.modal {
+  position: fixed; inset: 0; z-index: 60;
+  display: flex; align-items: center; justify-content: center;
+  background: rgba(0, 0, 0, .32);
+  padding: 20px;
+}
+.modal-card {
+  background: var(--panel);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  width: min(420px, 100%);
+  max-height: 80vh; overflow-y: auto;
+}
+.modal-head {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--rule-soft);
+  background: var(--panel-2);
+}
+.keys {
+  display: grid; grid-template-columns: auto 1fr; gap: 8px 18px;
+  margin: 0; padding: 16px 18px;
+  align-items: center;
+}
+.keys dt { display: flex; gap: 3px; align-items: center; }
+.keys dd { margin: 0; font-size: 13.5px; color: var(--ink-2); }
+kbd {
+  font-family: var(--mono); font-size: 10.5px;
+  border: 1px solid var(--rule); border-bottom-width: 2px;
+  border-radius: 3px; padding: 1px 6px;
+  background: var(--panel-2); color: var(--ink);
+}
+
+.options {
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  background: var(--panel);
+  margin-bottom: 18px;
+}
+.options > summary {
+  cursor: pointer;
+  padding: 9px 14px;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.options > summary::-webkit-details-marker { display: none; }
+.options > summary::before {
+  content: "+";
+  font-family: var(--mono);
+  color: var(--accent);
+  font-size: 13px;
+}
+.options[open] > summary::before { content: "−"; }
+.options-grid {
+  border-top: 1px solid var(--rule-soft);
+  padding: 16px 14px 8px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 4px 26px;
+}
+
+/* ---------- dropzone ---------- */
+
+.dropzone {
+  border: 1.5px dashed var(--rule);
+  border-radius: var(--radius);
+  background: var(--panel);
+  transition: border-color .12s, background .12s;
+  margin-bottom: 16px;
+}
+.dropzone.is-over { border-color: var(--accent); background: var(--accent-soft); }
+.dropzone-inner { padding: 34px 20px; text-align: center; }
+
+.drop-icon {
+  width: 40px; height: 40px;
+  fill: none; stroke: var(--ink-3); stroke-width: 1.5;
+  stroke-linecap: round; stroke-linejoin: round;
+  margin-bottom: 10px;
+}
+.dropzone.is-over .drop-icon { stroke: var(--accent); }
+.drop-title { margin: 0 0 4px; font-size: 16px; font-weight: 600; }
+.drop-sub {
+  margin: 0 0 16px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: .04em;
+  color: var(--ink-3);
+}
+.drop-actions { display: flex; gap: 8px; justify-content: center; }
+
+/* ---------- summary bar ---------- */
+
+.summary {
+  position: relative;
+  display: flex; align-items: center; justify-content: space-between;
+  flex-wrap: wrap; gap: 10px;
+  padding: 9px 14px;
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  background: var(--panel);
+  margin-bottom: 14px;
+}
+.summary-stats { display: flex; flex-wrap: wrap; gap: 0 18px; }
+.summary-right { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+
+.stat { font-size: 13px; color: var(--ink-2); }
+.stat b { font-family: var(--mono); font-size: 14px; color: var(--ink); font-weight: 600; }
+.stat-found b { color: var(--accent); }
+.stat-ok b { color: var(--ok); }
+.stat.muted, .muted { color: var(--ink-3); }
+
+.progress {
+  position: absolute; left: 0; right: 0; bottom: 0; height: 2px;
+  background: var(--rule-soft);
+}
+.progress-bar { height: 100%; width: 0; background: var(--accent); transition: width .18s; }
+
+/* ---------- file list + detail ---------- */
+
+.split { display: grid; grid-template-columns: minmax(260px, 340px) 1fr; gap: 18px; align-items: start; }
+
+.file-list {
+  list-style: none; margin: 0 0 18px; padding: 0;
+  max-height: 64vh; overflow-y: auto;
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  background: var(--panel);
+}
+.file-list:focus-visible { outline: 2px solid var(--focus); outline-offset: 2px; }
+.list-empty { padding: 22px 14px; text-align: center; color: var(--ink-3); font-size: 13px; }
+
+.file-row {
+  display: flex; align-items: center; gap: 10px;
+  padding: 9px 12px;
+  border-bottom: 1px solid var(--rule-soft);
+  cursor: pointer;
+  border-left: 2px solid transparent;
+}
+.file-row:last-child { border-bottom: 0; }
+.file-row:hover { background: var(--panel-2); }
+.file-row.is-active { border-left-color: var(--accent); background: var(--panel-2); }
+
+.file-name { flex: 1; min-width: 0; font-size: 13.5px; }
+.file-title { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.file-sub {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--ink-3);
+  letter-spacing: .04em;
+}
+
+.chip {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  padding: 2px 7px;
+  border-radius: 999px;
+  border: 1px solid;
+  white-space: nowrap;
+  flex: none;
+}
+.chip-found { color: var(--accent); border-color: var(--accent); background: var(--accent-soft); }
+.chip-clean { color: var(--ok); border-color: var(--ok); background: var(--ok-soft); }
+.chip-busy  { color: var(--ink-3); border-color: var(--rule); }
+.chip-error { color: var(--accent); border-color: var(--accent); }
+.chip-done  { color: var(--ok); border-color: var(--ok); background: var(--ok-soft); }
+
+.detail {
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  background: var(--panel);
+  min-height: 320px;
+  padding: 0;
+  overflow: hidden;
+}
+
+.empty { padding: 46px 24px; text-align: center; }
+.empty-title { margin: 0 0 4px; font-size: 15px; font-weight: 600; }
+.empty-sub { margin: 0 0 14px; color: var(--ink-3); font-size: 13.5px; }
+
+.farewell { padding: 80px 20px; text-align: center; color: var(--ink-3); font-family: var(--sans); }
+
+.skeleton { padding: 18px; }
+.sk-band, .sk-line {
+  background: linear-gradient(90deg, var(--rule-soft), var(--rule), var(--rule-soft));
+  background-size: 200% 100%;
+  animation: sweep 1.2s linear infinite;
+  border-radius: 2px;
+}
+.sk-band { height: 46px; margin-bottom: 14px; }
+.sk-line { height: 11px; margin-bottom: 8px; }
+.sk-line.short { width: 55%; }
+@keyframes sweep { from { background-position: 200% 0; } to { background-position: -200% 0; } }
+
+.detail-head {
+  padding: 16px 18px 0;
+  position: sticky; top: 0; z-index: 2;
+  background: var(--panel);
+}
+.detail-title {
+  font-size: 16px; font-weight: 600;
+  word-break: break-all;
+  margin: 0 0 2px;
+}
+.detail-path {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--ink-3);
+  word-break: break-all;
+  margin: 0 0 14px;
+}
+
+/* verdict band */
+.verdict {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  padding: 12px 16px;
+  border-left: 3px solid var(--ink-3);
+  background: var(--panel-2);
+  margin: 0 18px 16px;
+  border-radius: 0 var(--radius) var(--radius) 0;
+}
+.verdict.found { border-left-color: var(--accent); background: var(--accent-soft); }
+.verdict.clean { border-left-color: var(--ok); background: var(--ok-soft); }
+.verdict.error { border-left-color: var(--accent); background: var(--accent-soft); }
+.verdict-title { font-size: 15px; font-weight: 600; margin: 0; }
+.verdict.found .verdict-title { color: var(--accent-2); }
+.verdict.clean .verdict-title { color: var(--ok); }
+.verdict-sub { font-size: 13px; color: var(--ink-2); margin: 0; }
+
+#textVerdict { margin: 0 0 14px; }
+
+.readout {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0 26px;
+  padding: 10px 18px;
+  border-top: 1px solid var(--rule-soft);
+  border-bottom: 1px solid var(--rule-soft);
+  background: var(--panel-2);
+}
+.readout-cell { padding: 3px 0; }
+.readout-k {
+  display: block;
+  font-family: var(--mono);
+  font-size: 9.5px;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+}
+.readout-v { font-family: var(--mono); font-size: 12.5px; }
+
+.detail-section { padding: 16px 18px; border-bottom: 1px solid var(--rule-soft); }
+.detail-section:last-child { border-bottom: 0; }
+.detail-section h3 {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  font-weight: 500;
+  margin: 0 0 10px;
+}
+
+.findings { list-style: none; margin: 0; padding: 0; }
+.findings li {
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.65;
+  color: var(--ink-2);
+  padding-left: 16px;
+  position: relative;
+  word-break: break-word;
+}
+.findings li::before {
+  content: "▸";
+  position: absolute; left: 0;
+  color: var(--accent);
+}
+.findings.plain li::before { content: "·"; color: var(--ink-3); }
+
+.detail-actions { padding: 14px 18px; display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
+
+/* ---------- hits table ---------- */
+
+.hitlist { margin: 16px 0 0; }
+.hit-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+.hit-table th {
+  text-align: left;
+  font-family: var(--mono);
+  font-size: 9.5px;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  font-weight: 500;
+  padding: 6px 10px 6px 0;
+  border-bottom: 1px solid var(--rule);
+}
+.hit-table td {
+  padding: 7px 10px 7px 0;
+  border-bottom: 1px solid var(--rule-soft);
+  vertical-align: top;
+}
+.hit-cp { font-family: var(--mono); font-size: 12px; color: var(--accent); white-space: nowrap; }
+.hit-count { font-family: var(--mono); font-size: 12px; text-align: right; }
+.hit-what { color: var(--ink-2); }
+.hit-help { color: var(--ink-3); font-size: 12.5px; }
+
+/* ---------- reveal ---------- */
+
+.reveal-area {
+  min-height: 300px;
+  max-height: 60vh;
+  overflow-y: auto;
+  padding: 16px 18px;
+  font-family: var(--mono);
+  font-size: 13px;
+  line-height: 2.1;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.mark {
+  display: inline-block;
+  font-family: var(--mono);
+  font-size: 9.5px;
+  letter-spacing: .08em;
+  line-height: 1.3;
+  padding: 1px 4px;
+  margin: 0 1px;
+  border-radius: 2px;
+  background: var(--accent-soft);
+  color: var(--accent-2);
+  border: 1px solid var(--accent);
+  vertical-align: 1px;
+  cursor: help;
+  user-select: none;
+}
+.mark.k-space { background: var(--warn-soft); color: var(--warn); border-color: var(--warn); }
+.mark.k-confusable { background: transparent; border-style: dashed; }
+
+
+.actionbar {
+  display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+  margin-top: 16px;
+}
+
+/* ---------- notices ---------- */
+
+.notice {
+  border: 1px solid var(--rule);
+  border-left: 3px solid var(--warn);
+  background: var(--warn-soft);
+  border-radius: 0 var(--radius) var(--radius) 0;
+  padding: 12px 16px;
+  font-size: 13.5px;
+  color: var(--ink-2);
+  margin-bottom: 20px;
+  max-width: 92ch;
+}
+.notice strong { color: var(--ink); }
+
+/* ---------- toast ---------- */
+
+.toast {
+  position: fixed;
+  left: 50%;
+  bottom: 26px;
+  transform: translateX(-50%);
+  background: var(--ink);
+  color: var(--paper);
+  font-size: 13.5px;
+  padding: 9px 18px;
+  border-radius: var(--radius);
+  z-index: 50;
+  max-width: 74ch;
+}
+.toast.bad { background: var(--accent-2); }
+
+/* ---------- responsive ---------- */
+
+@media (max-width: 960px) {
+  .split, .two-col, .guide-layout { grid-template-columns: 1fr; }
+  .col-narrow { border-left: 0; padding-left: 0; border-top: 1px solid var(--rule); padding-top: 18px; }
+  .doc-list { border-right: 0; border-bottom: 1px solid var(--rule); display: flex; flex-wrap: wrap; }
+  .doc-list button { width: auto; border-left: 0; border-bottom: 2px solid transparent; }
+  .doc-list button.is-active { border-left: 0; border-bottom-color: var(--accent); }
+}
+
+@media (max-width: 720px) {
+  :root { --rail-w: 60px; }
+  .rail-item span, .rail-note { display: none; }
+  .rail-item { justify-content: center; padding: 12px 4px; }
+  .rail-item em { font-size: 12px; }
+  .view { padding: 20px 16px 50px; }
+  .toolstrip { display: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * { transition: none !important; }
+}

--- a/gui/web/app.css
+++ b/gui/web/app.css
@@ -839,6 +839,101 @@ kbd {
   overflow-y: auto;
 }
 
+/* ---------- setup ---------- */
+
+.setup-body { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 16px; }
+
+.card {
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  background: var(--panel);
+  padding: 16px 18px;
+}
+.card h3 {
+  margin: 0 0 2px;
+  font-size: 15px;
+  display: flex; align-items: center; gap: 8px; justify-content: space-between;
+}
+.card p { margin: 6px 0 0; font-size: 13.5px; color: var(--ink-2); }
+.card .kv { margin-top: 12px; }
+
+.kv { display: grid; grid-template-columns: auto 1fr; gap: 4px 14px; }
+.kv dt {
+  font-family: var(--mono); font-size: 10px; letter-spacing: .1em;
+  text-transform: uppercase; color: var(--ink-3); padding-top: 2px;
+}
+.kv dd { margin: 0; font-family: var(--mono); font-size: 12px; word-break: break-all; }
+
+.snippet {
+  display: flex; align-items: center; gap: 8px;
+  margin-top: 10px;
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  background: var(--panel-2);
+  padding: 6px 8px 6px 10px;
+}
+.snippet code {
+  font-family: var(--mono); font-size: 12px; flex: 1;
+  overflow-x: auto; white-space: nowrap;
+}
+
+.status-pill {
+  font-family: var(--mono); font-size: 9.5px; letter-spacing: .1em; text-transform: uppercase;
+  border: 1px solid; border-radius: 999px; padding: 2px 8px; flex: none;
+}
+.status-pill.on { color: var(--ok); border-color: var(--ok); background: var(--ok-soft); }
+.status-pill.off { color: var(--ink-3); border-color: var(--rule); }
+
+/* ---------- guide ---------- */
+
+.guide-layout { display: grid; grid-template-columns: 200px 1fr; gap: 22px; align-items: start; }
+.doc-list { list-style: none; margin: 0; padding: 0; border-right: 1px solid var(--rule); }
+.doc-list button {
+  appearance: none; background: none; border: 0;
+  border-left: 2px solid transparent;
+  padding: 7px 12px; width: 100%; text-align: left;
+  font: inherit; font-size: 13.5px; color: var(--ink-2); cursor: pointer;
+}
+.doc-list button:hover { color: var(--ink); }
+.doc-list button.is-active { color: var(--ink); border-left-color: var(--accent); font-weight: 600; }
+
+.doc-body { max-width: 78ch; font-size: 14.5px; line-height: 1.68; }
+.doc-body h1 { font-size: 22px; margin: 0 0 12px; }
+.doc-body h2 {
+  font-size: 16px; margin: 26px 0 8px; padding-bottom: 5px;
+  border-bottom: 1px solid var(--rule);
+}
+.doc-body h3 { font-size: 14.5px; margin: 20px 0 6px; }
+.doc-body p { margin: 0 0 12px; color: var(--ink-2); }
+.doc-body ul, .doc-body ol { margin: 0 0 12px; padding-left: 22px; color: var(--ink-2); }
+.doc-body li { margin-bottom: 4px; }
+.doc-body code {
+  font-family: var(--mono); font-size: 12.5px;
+  background: var(--panel-2); border: 1px solid var(--rule-soft);
+  border-radius: 2px; padding: 0 4px;
+}
+.doc-body pre {
+  background: var(--panel); border: 1px solid var(--rule);
+  border-radius: var(--radius); padding: 12px 14px;
+  overflow-x: auto; font-size: 12.5px; margin: 0 0 14px;
+}
+.doc-body pre code { background: none; border: 0; padding: 0; }
+.doc-body blockquote {
+  margin: 0 0 14px; padding: 2px 0 2px 14px;
+  border-left: 3px solid var(--rule); color: var(--ink-3);
+}
+.doc-body table { border-collapse: collapse; width: 100%; margin: 0 0 16px; font-size: 13.5px; }
+.doc-body th, .doc-body td {
+  border-bottom: 1px solid var(--rule-soft); padding: 7px 10px 7px 0; text-align: left;
+  vertical-align: top;
+}
+.doc-body th {
+  font-family: var(--mono); font-size: 10px; letter-spacing: .1em; text-transform: uppercase;
+  color: var(--ink-3); font-weight: 500; border-bottom-color: var(--rule);
+}
+.doc-body a { color: var(--accent); }
+.doc-body hr { border: 0; border-top: 1px solid var(--rule); margin: 22px 0; }
+
 /* ---------- toast ---------- */
 
 .toast {

--- a/gui/web/app.css
+++ b/gui/web/app.css
@@ -701,7 +701,48 @@ kbd {
 .hit-what { color: var(--ink-2); }
 .hit-help { color: var(--ink-3); font-size: 12.5px; }
 
-/* ---------- reveal ---------- */
+/* ---------- editor + reveal ---------- */
+
+.editor {
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  background: var(--panel);
+  overflow: hidden;
+}
+.editor-bar {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--rule-soft);
+  background: var(--panel-2);
+}
+.editor-meta { font-family: var(--mono); font-size: 10.5px; color: var(--ink-3); letter-spacing: .06em; }
+
+.seg { display: flex; border: 1px solid var(--rule); border-radius: var(--radius); overflow: hidden; }
+.seg-btn {
+  appearance: none; border: 0; background: var(--panel);
+  font-family: var(--mono); font-size: 10.5px; letter-spacing: .1em; text-transform: uppercase;
+  color: var(--ink-3); padding: 4px 12px; cursor: pointer;
+}
+.seg-btn + .seg-btn { border-left: 1px solid var(--rule); }
+.seg-btn.is-active { background: var(--ink); color: var(--paper); }
+
+.editor-area {
+  border: 0;
+  border-radius: 0;
+  width: 100%;
+  min-height: 300px;
+  padding: 16px 18px;
+  font-family: var(--mono);
+  font-size: 13px;
+  line-height: 1.7;
+  background: var(--panel);
+}
+.editor-area:focus { outline: none; }
+.editor-area.standalone {
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  min-height: 340px;
+}
 
 .reveal-area {
   min-height: 300px;

--- a/gui/web/app.css
+++ b/gui/web/app.css
@@ -796,6 +796,49 @@ kbd {
 }
 .notice strong { color: var(--ink); }
 
+/* ---------- rewrite ---------- */
+
+.two-col { display: grid; grid-template-columns: 1fr minmax(300px, 380px); gap: 22px; align-items: start; }
+.col-narrow { border-left: 1px solid var(--rule); padding-left: 22px; }
+
+.probe-result {
+  font-family: var(--mono);
+  font-size: 11.5px;
+  padding: 8px 10px;
+  border-radius: var(--radius);
+  border: 1px solid var(--rule);
+  margin-bottom: 10px;
+  word-break: break-word;
+}
+.probe-result.ok { color: var(--ok); border-color: var(--ok); background: var(--ok-soft); }
+.probe-result.bad { color: var(--accent-2); border-color: var(--accent); background: var(--accent-soft); }
+
+.result-panel {
+  margin-top: 22px;
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  background: var(--panel);
+  overflow: hidden;
+}
+.result-head {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 8px 14px;
+  background: var(--panel-2);
+  border-bottom: 1px solid var(--rule-soft);
+}
+.result-actions { display: flex; gap: 6px; }
+.result-body {
+  margin: 0;
+  padding: 16px 18px;
+  font-family: var(--mono);
+  font-size: 12.5px;
+  line-height: 1.7;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 52vh;
+  overflow-y: auto;
+}
+
 /* ---------- toast ---------- */
 
 .toast {

--- a/gui/web/app.js
+++ b/gui/web/app.js
@@ -1,0 +1,731 @@
+/* watermarks-remover GUI — front end.
+   Talks to the local server only; every action maps to a skill script call. */
+
+(() => {
+"use strict";
+
+// ---------------------------------------------------------------- session
+
+const url = new URL(location.href);
+const urlToken = url.searchParams.get("t");
+if (urlToken) {
+  sessionStorage.setItem("wm-token", urlToken);
+  history.replaceState({}, "", url.pathname);
+}
+const TOKEN = sessionStorage.getItem("wm-token") || "";
+
+async function api(path, body) {
+  const res = await fetch(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "X-WM-Token": TOKEN },
+    body: JSON.stringify(body || {}),
+  });
+  const data = await res.json().catch(() => ({ error: `Server returned ${res.status}` }));
+  if (!res.ok) throw new Error(data.error || `Server returned ${res.status}`);
+  return data;
+}
+
+async function upload(file) {
+  const res = await fetch("/api/upload", {
+    method: "POST",
+    headers: {
+      "X-WM-Token": TOKEN,
+      "X-WM-Filename": encodeURIComponent(file.name),
+      "Content-Type": "application/octet-stream",
+    },
+    body: file,
+  });
+  const data = await res.json().catch(() => ({ error: `Server returned ${res.status}` }));
+  if (!res.ok) throw new Error(data.error || `Upload failed (${res.status})`);
+  return data;
+}
+
+async function download(path, fallbackName) {
+  const res = await fetch(path, { headers: { "X-WM-Token": TOKEN } });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(data.error || `Download failed (${res.status})`);
+  }
+  const blob = await res.blob();
+  const disp = res.headers.get("Content-Disposition") || "";
+  const match = /filename="([^"]+)"/.exec(disp);
+  const href = URL.createObjectURL(blob);
+  const a = el("a", { href, download: match ? match[1] : fallbackName || "download" });
+  document.body.append(a);
+  a.click();
+  a.remove();
+  setTimeout(() => URL.revokeObjectURL(href), 4000);
+}
+
+// ---------------------------------------------------------------- helpers
+
+const $ = (sel) => document.querySelector(sel);
+const $$ = (sel) => Array.from(document.querySelectorAll(sel));
+
+function el(tag, props, ...kids) {
+  const node = document.createElement(tag);
+  for (const [k, v] of Object.entries(props || {})) {
+    if (v == null || v === false) continue;
+    if (k === "class") node.className = v;
+    else if (k === "text") node.textContent = v;
+    else if (k.startsWith("on") && typeof v === "function") {
+      node.addEventListener(k.slice(2).toLowerCase(), v);
+    } else if (v === true) node.setAttribute(k, "");
+    else node.setAttribute(k, v);
+  }
+  for (const kid of kids.flat(3)) {
+    if (kid == null || kid === false || kid === "") continue;
+    node.append(kid.nodeType ? kid : document.createTextNode(String(kid)));
+  }
+  return node;
+}
+
+function bytes(n) {
+  if (n == null) return "—";
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / 1048576).toFixed(1)} MB`;
+}
+
+const plural = (n, one, many) => `${n} ${n === 1 ? one : many}`;
+
+let toastTimer = null;
+function toast(message, bad) {
+  const node = $("#toast");
+  node.textContent = message;
+  node.classList.toggle("bad", !!bad);
+  node.hidden = false;
+  clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => { node.hidden = true; }, bad ? 7000 : 3200);
+}
+
+async function copyText(text) {
+  try {
+    await navigator.clipboard.writeText(text);
+    toast("Copied to clipboard");
+  } catch {
+    const ta = el("textarea", { class: "offscreen" });
+    ta.value = text;
+    document.body.append(ta);
+    ta.select();
+    try { document.execCommand("copy"); toast("Copied to clipboard"); }
+    catch { toast("Could not copy — select the text manually", true); }
+    ta.remove();
+  }
+}
+
+function verdictBand(state, title, sub) {
+  return el("div", { class: `verdict ${state}` },
+    el("p", { class: "verdict-title", text: title }),
+    sub ? el("p", { class: "verdict-sub", text: sub }) : null);
+}
+
+function readout(pairs) {
+  return el("div", { class: "readout" },
+    pairs.filter(Boolean).map(([k, v]) =>
+      el("div", { class: "readout-cell" },
+        el("span", { class: "readout-k", text: k }),
+        el("span", { class: "readout-v", text: String(v) }))));
+}
+
+function emptyState(title, sub, action) {
+  return el("div", { class: "empty" },
+    el("p", { class: "empty-title", text: title }),
+    sub ? el("p", { class: "empty-sub", text: sub }) : null,
+    action || null);
+}
+
+// Plain-language names for the mark categories, used by the legend and table.
+const KIND_LABEL = {
+  strip: "Invisible",
+  bidi: "Text direction",
+  tag_chars: "Tag characters",
+  variation_selector: "Variation selector",
+  zwj_family: "Zero-width",
+  space: "Look-alike space",
+  confusable: "Look-alike letter",
+  other_cf: "Other invisible",
+};
+
+function revealNode(reveal) {
+  const wrap = el("div", { class: "reveal-area" });
+  if (!reveal || !reveal.segments.length) {
+    wrap.append(el("span", { class: "muted", text: "Nothing to show." }));
+    return wrap;
+  }
+  for (const seg of reveal.segments) {
+    if (seg.t === "text") {
+      wrap.append(document.createTextNode(seg.v));
+    } else {
+      wrap.append(el("span", {
+        class: `mark k-${seg.kind}`,
+        title: `${seg.cp} · ${seg.label}`,
+        text: seg.v,
+      }));
+      if (seg.sub) wrap.append(document.createTextNode(seg.sub));
+    }
+  }
+  if (reveal.truncated) {
+    wrap.append(el("p", { class: "muted", text: "… preview truncated." }));
+  }
+  return wrap;
+}
+
+function legendNode(hits) {
+  const kinds = [...new Set(hits.map((h) => h.kind))];
+  if (!kinds.length) return null;
+  return el("div", { class: "legend" },
+    el("span", { class: "label", text: "Legend" }),
+    kinds.map((k) => el("span", { class: "legend-item" },
+      el("span", { class: `mark k-${k} legend-swatch`, text: "abc" }),
+      el("span", { text: KIND_LABEL[k] || k }))));
+}
+
+function hitsTable(hits) {
+  return el("table", { class: "hit-table" },
+    el("thead", {}, el("tr", {},
+      el("th", { text: "Code point" }),
+      el("th", { text: "Count" }),
+      el("th", { text: "Category" }),
+      el("th", { text: "What it is" }))),
+    el("tbody", {}, hits.map((h) => el("tr", {},
+      el("td", { class: "hit-cp", text: h.codepoint }),
+      el("td", { class: "hit-count", text: h.count }),
+      el("td", {}, el("span", { class: `tag t-${h.kind}`, text: KIND_LABEL[h.kind] || h.kind })),
+      el("td", {},
+        el("div", { class: "hit-what", text: h.label }),
+        h.help ? el("div", { class: "hit-help", text: h.help }) : null)))));
+}
+
+// ---------------------------------------------------------------- chrome
+
+function showView(name) {
+  $$(".rail-item").forEach((b) => {
+    const on = b.dataset.view === name;
+    b.classList.toggle("is-active", on);
+    b.setAttribute("aria-selected", on ? "true" : "false");
+  });
+  $$(".view").forEach((v) => v.classList.toggle("is-active", v.dataset.view === name));
+  $("#stage").scrollTop = 0;
+  if (name === "setup") loadSetup();
+  if (name === "guide") loadDocs();
+}
+
+$("#rail").addEventListener("click", (e) => {
+  const item = e.target.closest(".rail-item");
+  if (item) showView(item.dataset.view);
+});
+
+const savedTheme = localStorage.getItem("wm-theme");
+if (savedTheme) document.documentElement.dataset.theme = savedTheme;
+$("#themeBtn").addEventListener("click", () => {
+  const current = document.documentElement.dataset.theme
+    || (matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+  const next = current === "dark" ? "light" : "dark";
+  document.documentElement.dataset.theme = next;
+  localStorage.setItem("wm-theme", next);
+});
+
+const keysModal = $("#keysModal");
+const toggleKeys = (show) => { keysModal.hidden = !show; };
+$("#keysBtn").addEventListener("click", () => toggleKeys(true));
+$("#keysClose").addEventListener("click", () => toggleKeys(false));
+keysModal.addEventListener("click", (e) => { if (e.target === keysModal) toggleKeys(false); });
+
+const VIEW_ORDER = ["files"];
+
+document.addEventListener("keydown", (e) => {
+  const typing = /^(INPUT|TEXTAREA|SELECT)$/.test(document.activeElement?.tagName || "")
+    || document.activeElement?.isContentEditable;
+
+  if (e.key === "Escape") { toggleKeys(false); return; }
+  if (typing) return;
+
+  if (e.key === "?" ) { toggleKeys(true); e.preventDefault(); return; }
+  if (!e.ctrlKey && !e.metaKey && /^[1-5]$/.test(e.key)) {
+    showView(VIEW_ORDER[Number(e.key) - 1]);
+    e.preventDefault();
+    return;
+  }
+  if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "o") {
+    showView("files");
+    $("#browseBtn").click();
+    e.preventDefault();
+    return;
+  }
+  if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+    if (files.length) { $("#cleanAllBtn").click(); e.preventDefault(); }
+    return;
+  }
+});
+
+// ---------------------------------------------------------------- 01 files
+
+const files = [];
+let activeKey = null;
+let keySeq = 0;
+let filter = "all";
+let scanQueue = Promise.resolve();
+
+const opts = () => ({
+  as: $("#optAs").value,
+  aggressive: $("#optAggressive").checked,
+  aggressive_homoglyphs: $("#optAggressiveClean").checked,
+  nfkc: $("#optNfkc").checked,
+  keep_non_ai_metadata: $("#optKeepMeta").checked,
+  synthid: $("#optSynthid").checked,
+  scrub_document_text: $("#optScrubDoc").checked,
+  convert_nbsp: $("#optConvertNbsp").checked,
+});
+
+const visible = () => files.filter((f) =>
+  filter === "all"
+  || (filter === "found" && (f.status === "found" || f.status === "error"))
+  || (filter === "clean" && (f.status === "clean" || f.status === "done")));
+
+const CHIP = {
+  busy: ["chip-busy", "scanning"],
+  found: ["chip-found", "marks"],
+  clean: ["chip-clean", "clean"],
+  error: ["chip-error", "error"],
+  done: ["chip-done", "cleaned"],
+  working: ["chip-busy", "cleaning"],
+};
+
+function renderSummary() {
+  const wrap = $("#summary");
+  wrap.hidden = files.length === 0;
+  if (!files.length) return;
+
+  const marks = files.filter((f) => f.status === "found").length;
+  const cleaned = files.filter((f) => f.status === "done").length;
+  const errors = files.filter((f) => f.status === "error").length;
+  const scanning = files.filter((f) => f.status === "busy" || f.status === "working").length;
+
+  const stat = (n, cls, noun) =>
+    el("span", { class: `stat ${cls}` }, el("b", { text: n }), ` ${noun}`);
+
+  $("#summaryStats").replaceChildren(...[
+    stat(files.length, "", files.length === 1 ? "file" : "files"),
+    marks ? stat(marks, "stat-found", "with marks") : null,
+    cleaned ? stat(cleaned, "stat-ok", "cleaned") : null,
+    errors ? stat(errors, "stat-found", "failed") : null,
+    scanning ? stat(scanning, "muted", "working") : null,
+  ].filter(Boolean));
+
+  $("#downloadAllBtn").hidden = !files.some((f) => f.clean && f.clean.download_id);
+}
+
+function renderList() {
+  const list = $("#fileList");
+  const rows = visible();
+  $("#filesSplit").hidden = files.length === 0;
+  renderSummary();
+
+  if (!rows.length) {
+    list.replaceChildren(el("li", { class: "list-empty", text: "No files match this filter." }));
+    return;
+  }
+
+  list.replaceChildren(...rows.map((f) => {
+    const [chipClass, chipText] = CHIP[f.status] || CHIP.busy;
+    return el("li", {
+      class: `file-row${f.key === activeKey ? " is-active" : ""}`,
+      role: "option",
+      "aria-selected": f.key === activeKey ? "true" : "false",
+      "data-key": f.key,
+      onclick: () => select(f.key),
+    },
+      el("div", { class: "file-name" },
+        el("div", { class: "file-title", text: f.name }),
+        el("span", { class: "file-sub", text: bytes(f.size) })),
+      el("span", { class: `chip ${chipClass}`, text: chipText }));
+  }));
+}
+
+function select(key) {
+  activeKey = key;
+  renderList();
+  renderDetail();
+}
+
+function moveSelection(delta) {
+  const rows = visible();
+  if (!rows.length) return;
+  const i = rows.findIndex((f) => f.key === activeKey);
+  const next = rows[Math.max(0, Math.min(rows.length - 1, (i < 0 ? 0 : i + delta)))];
+  if (next) select(next.key);
+}
+
+$("#fileList").addEventListener("keydown", (e) => {
+  if (e.key === "ArrowDown") { moveSelection(1); e.preventDefault(); }
+  else if (e.key === "ArrowUp") { moveSelection(-1); e.preventDefault(); }
+  else if (e.key === "Enter") {
+    const f = files.find((x) => x.key === activeKey);
+    if (f) cleanOne(f);
+    e.preventDefault();
+  }
+});
+
+$("#filterSeg").addEventListener("click", (e) => {
+  const btn = e.target.closest(".seg-btn");
+  if (!btn) return;
+  filter = btn.dataset.filter;
+  $$("#filterSeg .seg-btn").forEach((b) => b.classList.toggle("is-active", b === btn));
+  const rows = visible();
+  if (!rows.some((f) => f.key === activeKey)) activeKey = rows.length ? rows[0].key : null;
+  renderList();
+  renderDetail();
+});
+
+function detailActions(f) {
+  const row = el("div", { class: "detail-actions" });
+  const cleanBtn = el("button", {
+    class: "btn btn-primary",
+    text: f.clean ? "Clean again" : "Clean this file",
+    onclick: () => cleanOne(f, cleanBtn),
+  });
+  row.append(cleanBtn);
+
+  if (f.clean && f.clean.download_id) {
+    row.append(el("button", {
+      class: "btn",
+      text: "Download result",
+      onclick: () => download(`/api/download?id=${encodeURIComponent(f.clean.download_id)}`,
+        f.clean.output_name).catch((e) => toast(e.message, true)),
+    }));
+  }
+  row.append(el("button", {
+    class: "btn btn-quiet",
+    text: "Remove",
+    onclick: () => {
+      const i = files.indexOf(f);
+      if (i >= 0) files.splice(i, 1);
+      if (activeKey === f.key) activeKey = files.length ? files[0].key : null;
+      renderList();
+      renderDetail();
+    },
+  }));
+  return row;
+}
+
+// The remedy belongs next to the finding. Burying it in Advanced options is
+// exactly how a document-text hit goes unnoticed.
+function remedyNode(f, tr, inBody) {
+  if (!inBody) return null;
+  const done = f.cleanOpts || {};
+  const spaces = tr.hits.some((h) => h.kind === "space");
+
+  if (!done.scrub_document_text) {
+    return el("div", { class: "inline-action" },
+      el("p", { text: f.clean
+        ? "Cleaning removed metadata only — these are still in the text."
+        : "Cleaning removes metadata only. These live in the document text itself." }),
+      el("div", { class: "inline-action-row" },
+        el("button", {
+          class: "btn btn-sm btn-primary",
+          text: "Strip these from the document text",
+          onclick: (e) => cleanOne(f, e.currentTarget, { scrub_document_text: true }),
+        }),
+        spaces ? el("label", { class: "check inline" },
+          el("input", { type: "checkbox", id: `nbsp-${f.key}` }),
+          el("span", { text: "also convert no-break spaces" })) : null));
+  }
+
+  if (spaces && !done.convert_nbsp) {
+    return el("div", { class: "inline-action" },
+      el("p", { text: "What is left are no-break spaces, kept because they are "
+        + "usually deliberate typography. Converting them changes how the document wraps." }),
+      el("div", { class: "inline-action-row" },
+        el("button", {
+          class: "btn btn-sm",
+          text: "Convert them to plain spaces too",
+          onclick: (e) => cleanOne(f, e.currentTarget,
+            { scrub_document_text: true, convert_nbsp: true }),
+        })));
+  }
+  return null;
+}
+
+function renderDetail() {
+  const panel = $("#detail");
+  const f = files.find((x) => x.key === activeKey);
+  panel.replaceChildren();
+
+  if (!f) {
+    panel.append(emptyState("Nothing selected",
+      files.length ? "Pick a file on the left." : "Drop a file above to scan it."));
+    return;
+  }
+
+  panel.append(el("div", { class: "detail-head" },
+    el("h2", { class: "detail-title", text: f.name })));
+
+  if (f.status === "busy" || f.status === "working") {
+    panel.append(el("div", { class: "skeleton" },
+      el("div", { class: "sk-band" }),
+      el("div", { class: "sk-line" }),
+      el("div", { class: "sk-line short" })));
+    return;
+  }
+  if (f.status === "error") {
+    panel.append(verdictBand("error", "Could not read this file", f.error));
+    panel.append(detailActions(f));
+    return;
+  }
+
+  const r = f.report || {};
+  const kindWord = { text: "Plain text", image: "Image", container: "Document" }[r.kind] || r.kind;
+  const tr = r.text_report;
+  const inBody = r.text_source === "document body";
+
+  if (f.clean) {
+    const c = f.clean;
+    panel.append(verdictBand(
+      c.residual ? "error" : "clean",
+      c.residual ? "Cleaned, but signals remain" : "Cleaned",
+      "Ready to download."));
+  } else {
+    panel.append(r.clean
+      ? verdictBand("clean", "Nothing found",
+          "No provenance metadata and no hidden characters.")
+      : verdictBand("found", "Marks found",
+          "This file carries provenance metadata or hidden characters."));
+  }
+
+  panel.append(readout([
+    ["Kind", kindWord],
+    ["Format", r.format || "—"],
+    ["Size", bytes(f.size)],
+    r.kind !== "text" ? ["C2PA", r.has_c2pa ? "yes" : "no"] : null,
+    r.kind !== "text" ? ["AI metadata", r.has_ai_metadata ? "yes" : "no"] : null,
+    tr ? ["Hidden chars", tr.suspicious_total] : null,
+  ]));
+
+  if (f.clean && f.clean.actions && f.clean.actions.length) {
+    panel.append(el("div", { class: "detail-section" },
+      el("h3", { text: "What was done" }),
+      el("ul", { class: "findings" }, f.clean.actions.map((a) => el("li", { text: a })))));
+  }
+
+  if (r.findings && r.findings.length) {
+    panel.append(el("div", { class: "detail-section" },
+      el("h3", { text: "Metadata findings" }),
+      el("ul", { class: "findings" }, r.findings.map((x) => el("li", { text: x })))));
+  }
+
+  if (tr && tr.hits.length) {
+    panel.append(el("div", { class: "detail-section" },
+      el("h3", { text: inBody
+        ? `Hidden characters inside the document text — ${tr.suspicious_total} total`
+        : `Hidden characters — ${tr.suspicious_total} total` }),
+      legendNode(tr.hits),
+      hitsTable(tr.hits),
+      remedyNode(f, tr, inBody)));
+    panel.append(el("div", { class: "detail-section" },
+      el("h3", { text: inBody ? "In context (document text)" : "In context" }),
+      revealNode(tr.reveal)));
+  }
+
+  if (r.synthid) {
+    panel.append(el("div", { class: "detail-section" },
+      el("h3", { text: "SynthID score" }),
+      el("pre", { class: "result-body", text: JSON.stringify(r.synthid, null, 2) })));
+  }
+
+  const toolNotes = [];
+  for (const [name, info] of Object.entries(r.tools || {})) {
+    if (!info || typeof info !== "object") continue;
+    if (!info.available) { toolNotes.push(`${name}: not installed`); continue; }
+    if (info.error) { toolNotes.push(`${name}: ${info.error}`); continue; }
+    if (name === "c2patool") toolNotes.push(`c2patool: ${info.has_manifest ? "manifest found" : "no manifest"}`);
+    if (name === "exiftool" && info.interesting_lines) {
+      toolNotes.push(...info.interesting_lines.map((l) => `exiftool: ${l.trim()}`));
+    }
+  }
+  if (toolNotes.length) {
+    panel.append(el("details", { class: "detail-section fold" },
+      el("summary", {}, el("h3", { text: "External tools" })),
+      el("ul", { class: "findings plain" }, toolNotes.slice(0, 40).map((t) => el("li", { text: t })))));
+  }
+
+  panel.append(detailActions(f));
+}
+
+async function inspectOne(f) {
+  f.status = "busy";
+  renderList();
+  if (f.key === activeKey) renderDetail();
+  try {
+    const o = opts();
+    const report = await api("/api/inspect", {
+      file: f.ref, aggressive: o.aggressive, as: o.as, synthid: o.synthid,
+    });
+    f.report = report;
+    f.status = report.clean ? "clean" : "found";
+    f.error = null;
+  } catch (e) {
+    f.status = "error";
+    f.error = e.message;
+  }
+  renderList();
+  if (f.key === activeKey) renderDetail();
+}
+
+async function cleanOne(f, button, override) {
+  if (f.status === "working") return;
+  const o = { ...opts(), ...(override || {}) };
+  const nbspBox = $(`#nbsp-${f.key}`);
+  if (override && nbspBox && override.convert_nbsp == null) o.convert_nbsp = nbspBox.checked;
+
+  const label = button ? button.textContent : null;
+  if (button) { button.disabled = true; button.textContent = "Working…"; }
+  const previous = f.status;
+  f.status = "working";
+  renderList();
+
+  try {
+    f.clean = await api("/api/clean", {
+      file: f.ref,
+      as: o.as,
+      nfkc: o.nfkc,
+      aggressive_homoglyphs: o.aggressive_homoglyphs,
+      keep_non_ai_metadata: o.keep_non_ai_metadata,
+      synthid: o.synthid,
+      scrub_document_text: o.scrub_document_text,
+      convert_nbsp: o.convert_nbsp,
+    });
+    f.cleanOpts = o;
+    f.status = "done";
+    if (f.clean.download_id) {
+      const after = await api("/api/inspect", {
+        file: { id: f.clean.download_id }, aggressive: o.aggressive, as: o.as,
+      });
+      f.report = after;
+    }
+  } catch (e) {
+    f.status = previous;
+    toast(e.message, true);
+  } finally {
+    if (button) { button.disabled = false; if (label) button.textContent = label; }
+  }
+  renderList();
+  renderDetail();
+}
+
+function addFiles(entries) {
+  const fresh = entries.map((entry) => {
+    const f = {
+      key: ++keySeq,
+      name: entry.name,
+      size: entry.size,
+      ref: { id: entry.id },
+      status: "busy",
+    };
+    files.push(f);
+    return f;
+  });
+  if (activeKey == null && fresh.length) activeKey = fresh[0].key;
+  renderList();
+  renderDetail();
+  // Serialised so a 50-file drop cannot open 50 sockets at once.
+  scanQueue = scanQueue.then(async () => {
+    for (const f of fresh) await inspectOne(f);
+  });
+  return scanQueue;
+}
+
+const dropzone = $("#dropzone");
+["dragenter", "dragover"].forEach((ev) => dropzone.addEventListener(ev, (e) => {
+  e.preventDefault();
+  dropzone.classList.add("is-over");
+}));
+["dragleave", "drop"].forEach((ev) => dropzone.addEventListener(ev, (e) => {
+  e.preventDefault();
+  if (ev === "dragleave" && dropzone.contains(e.relatedTarget)) return;
+  dropzone.classList.remove("is-over");
+}));
+async function uploadAll(list) {
+  const added = [];
+  for (const file of list) {
+    try {
+      added.push(await upload(file));
+    } catch (err) {
+      toast(`${file.name}: ${err.message}`, true);
+    }
+  }
+  if (added.length) addFiles(added);
+}
+
+dropzone.addEventListener("drop", (e) => uploadAll(Array.from(e.dataTransfer.files || [])));
+window.addEventListener("dragover", (e) => e.preventDefault());
+window.addEventListener("drop", (e) => e.preventDefault());
+
+$("#browseBtn").addEventListener("click", () => $("#fileInput").click());
+
+$("#fileInput").addEventListener("change", (e) => {
+  const list = Array.from(e.target.files || []);
+  e.target.value = "";  // so picking the same file twice still fires
+  uploadAll(list);
+});
+
+$("#clearBtn").addEventListener("click", () => {
+  files.length = 0;
+  activeKey = null;
+  renderList();
+  renderDetail();
+});
+
+$("#cleanAllBtn").addEventListener("click", async (e) => {
+  const btn = e.currentTarget;
+  const targets = files.filter((f) => f.status !== "error");
+  if (!targets.length) { toast("Nothing to clean"); return; }
+  btn.disabled = true;
+  const bar = $("#progressBar");
+  $("#progress").hidden = false;
+  let done = 0;
+  for (const f of targets) {
+    await cleanOne(f, null);
+    done += 1;
+    bar.style.width = `${Math.round((done / targets.length) * 100)}%`;
+  }
+  $("#progress").hidden = true;
+  bar.style.width = "0%";
+  btn.disabled = false;
+  toast(`Cleaned ${plural(done, "file", "files")}`);
+});
+
+$("#downloadAllBtn").addEventListener("click", () => {
+  const ids = files.filter((f) => f.clean && f.clean.download_id).map((f) => f.clean.download_id);
+  if (!ids.length) return;
+  download(`/api/download-all?ids=${ids.map(encodeURIComponent).join(",")}`, "cleaned-files.zip")
+    .catch((err) => toast(err.message, true));
+});
+
+for (const id of ["#optAggressive", "#optAs"]) {
+  $(id).addEventListener("change", () => {
+    scanQueue = scanQueue.then(async () => {
+      for (const f of files) if (f.status !== "error") await inspectOne(f);
+    });
+  });
+}
+
+// ---------------------------------------------------------------- boot
+
+(async function boot() {
+  try {
+    const d = await api("/api/diagnostics", {});
+    $("#toolStrip").replaceChildren(
+      el("span", { class: `tool-dot ${d.tools.exiftool.available ? "on" : "off"}` },
+        el("i", {}), "exiftool"),
+      el("span", { class: `tool-dot ${d.tools.c2patool.available ? "on" : "off"}` },
+        el("i", {}), "c2patool"));
+    $("#synthidRow").hidden = !(d.synthid.configured && d.synthid.exists);
+  } catch (e) {
+    toast(`Cannot reach the local server: ${e.message}`, true);
+  }
+  renderList();
+  renderDetail();
+})();
+
+})();

--- a/gui/web/app.js
+++ b/gui/web/app.js
@@ -232,7 +232,7 @@ $("#keysBtn").addEventListener("click", () => toggleKeys(true));
 $("#keysClose").addEventListener("click", () => toggleKeys(false));
 keysModal.addEventListener("click", (e) => { if (e.target === keysModal) toggleKeys(false); });
 
-const VIEW_ORDER = ["files", "text", "rewrite"];
+const VIEW_ORDER = ["files", "text", "rewrite", "setup", "guide"];
 
 document.addEventListener("keydown", (e) => {
   const typing = /^(INPUT|TEXTAREA|SELECT)$/.test(document.activeElement?.tagName || "")
@@ -964,6 +964,241 @@ $("#rwDownloadBtn").addEventListener("click", async () => {
     toast(e.message, true);
   }
 });
+
+// ---------------------------------------------------------------- 04 setup
+
+const INSTALL = {
+  Windows: {
+    exiftool: "winget install -e --id OliverBetz.ExifTool",
+    c2patool: "cargo install c2patool",
+  },
+  Darwin: {
+    exiftool: "brew install exiftool",
+    c2patool: "cargo install c2patool",
+  },
+  Linux: {
+    exiftool: "sudo apt install libimage-exiftool-perl",
+    c2patool: "cargo install c2patool",
+  },
+};
+
+function osKey(platformString) {
+  if (/windows/i.test(platformString)) return "Windows";
+  if (/darwin|mac/i.test(platformString)) return "Darwin";
+  return "Linux";
+}
+
+function snippet(command) {
+  return el("div", { class: "snippet" },
+    el("code", { text: command }),
+    el("button", { class: "btn btn-sm", text: "Copy", onclick: () => copyText(command) }));
+}
+
+function toolCard(name, info, blurb, command) {
+  return el("div", { class: "card" },
+    el("h3", {},
+      el("span", { text: name }),
+      el("span", { class: `status-pill ${info.available ? "on" : "off"}`,
+        text: info.available ? "installed" : "missing" })),
+    el("p", { text: blurb }),
+    info.available
+      ? el("dl", { class: "kv" },
+          el("dt", { text: "Version" }), el("dd", { text: info.version || "unknown" }),
+          el("dt", { text: "Path" }), el("dd", { text: info.path }))
+      : snippet(command));
+}
+
+async function loadSetup() {
+  const body = $("#setupBody");
+  body.replaceChildren(el("div", { class: "skeleton" },
+    el("div", { class: "sk-line" }), el("div", { class: "sk-line short" })));
+  try {
+    const d = await api("/api/diagnostics", {});
+    const os = osKey(d.platform);
+    const install = INSTALL[os];
+
+    const cards = [
+      el("div", { class: "card" },
+        el("h3", {}, el("span", { text: "This machine" })),
+        el("dl", { class: "kv" },
+          el("dt", { text: "Python" }), el("dd", { text: d.python }),
+          el("dt", { text: "System" }), el("dd", { text: d.platform }),
+          el("dt", { text: "Size limit" }), el("dd", { text: `${d.max_input_mib} MiB per file` }),
+          el("dt", { text: "Scripts" }), el("dd", { text: d.scripts_dir }))),
+
+      toolCard("exiftool", d.tools.exiftool,
+        "Strips residual metadata that pure-Python passes cannot reach — the difference between a best-effort and a reliable PDF clean.",
+        install.exiftool),
+
+      toolCard("c2patool", d.tools.c2patool,
+        "Reads C2PA / Content Credentials manifests, so inspection reports what a verifier would actually see.",
+        install.c2patool),
+
+      el("div", { class: "card" },
+        el("h3", {},
+          el("span", { text: "SynthID pixel scoring" }),
+          el("span", { class: `status-pill ${d.synthid.configured && d.synthid.exists ? "on" : "off"}`,
+            text: d.synthid.configured && d.synthid.exists ? "ready" : "not set up" })),
+        el("p", { text: "Optional, heavy, and third-party: scores images for Google’s pixel watermark. Point REVERSE_SYNTHID_DIR at a reverse-SynthID checkout, then restart this app." }),
+        d.synthid.dir ? el("dl", { class: "kv" },
+          el("dt", { text: "Dir" }), el("dd", { text: d.synthid.dir }),
+          el("dt", { text: "Exists" }), el("dd", { text: d.synthid.exists ? "yes" : "no" })) : null,
+        snippet(os === "Windows"
+          ? "set REVERSE_SYNTHID_DIR=C:\\path\\to\\reverse-SynthID"
+          : "export REVERSE_SYNTHID_DIR=~/reverse-SynthID")),
+    ];
+
+    if (d.compat_notes && d.compat_notes.length) {
+      cards.push(el("div", { class: "card" },
+        el("h3", {}, el("span", { text: "Platform notes" })),
+        el("ul", { class: "findings plain" }, d.compat_notes.map((n) => el("li", { text: n })))));
+    }
+
+    body.replaceChildren(...cards);
+  } catch (e) {
+    body.replaceChildren(emptyState("Cannot reach the local server", e.message,
+      el("button", { class: "btn", text: "Try again", onclick: loadSetup })));
+  }
+}
+
+$("#setupRefresh").addEventListener("click", loadSetup);
+$("#quitBtn").addEventListener("click", async () => {
+  try { await api("/api/shutdown", {}); } catch { /* the server is going away */ }
+  document.body.replaceChildren(el("div", { class: "farewell" },
+    el("p", { text: "watermarks-remover has stopped. You can close this window." })));
+});
+
+// ---------------------------------------------------------------- 05 guide
+
+let docsLoaded = false;
+
+async function loadDocs() {
+  if (docsLoaded) return;
+  try {
+    const res = await api("/api/refs", {});
+    $("#docList").replaceChildren(...res.docs.map((doc) => el("li", {},
+      el("button", {
+        type: "button",
+        text: doc.title,
+        onclick: (e) => {
+          $$("#docList button").forEach((b) => b.classList.toggle("is-active", b === e.currentTarget));
+          showDoc(doc.id);
+        },
+      }))));
+    docsLoaded = true;
+    const first = $("#docList button");
+    if (first) first.click();
+  } catch (e) {
+    $("#docBody").replaceChildren(emptyState("Could not load the notes", e.message));
+  }
+}
+
+async function showDoc(id) {
+  try {
+    const res = await api("/api/refs", { id });
+    $("#docBody").replaceChildren(...markdownNodes(res.body));
+  } catch (e) {
+    $("#docBody").replaceChildren(emptyState("Could not load that document", e.message));
+  }
+}
+
+// Small markdown renderer. Builds DOM nodes rather than HTML strings, so
+// nothing in a document can turn into markup.
+function markdownNodes(src) {
+  const out = [];
+  const lines = src.split(/\r?\n/);
+  let para = [];
+  let list = null;
+  let quote = [];
+
+  const inline = (text) => {
+    const nodes = [];
+    const re = /`([^`]+)`|\*\*([^*]+)\*\*|\*([^*\n]+)\*|\[([^\]]+)\]\(([^)\s]+)\)/g;
+    let last = 0;
+    let m;
+    while ((m = re.exec(text))) {
+      if (m.index > last) nodes.push(text.slice(last, m.index));
+      if (m[1] != null) nodes.push(el("code", { text: m[1] }));
+      else if (m[2] != null) nodes.push(el("strong", { text: m[2] }));
+      else if (m[3] != null) nodes.push(el("em", { text: m[3] }));
+      else {
+        const href = /^(https?:|#|\.|\/)/.test(m[5]) ? m[5] : "#";
+        nodes.push(el("a", { href, target: "_blank", rel: "noopener noreferrer", text: m[4] }));
+      }
+      last = re.lastIndex;
+    }
+    if (last < text.length) nodes.push(text.slice(last));
+    return nodes;
+  };
+
+  const flushPara = () => {
+    if (para.length) { out.push(el("p", {}, inline(para.join(" ")))); para = []; }
+  };
+  const flushList = () => { list = null; };
+  const flushQuote = () => {
+    if (quote.length) { out.push(el("blockquote", {}, inline(quote.join(" ")))); quote = []; }
+  };
+  const flushAll = () => { flushPara(); flushList(); flushQuote(); };
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    const fence = /^```(\w*)\s*$/.exec(line);
+    if (fence) {
+      flushAll();
+      const buf = [];
+      i += 1;
+      while (i < lines.length && !/^```/.test(lines[i])) buf.push(lines[i++]);
+      out.push(el("pre", {}, el("code", { text: buf.join("\n") })));
+      continue;
+    }
+    if (!line.trim()) { flushAll(); continue; }
+
+    const heading = /^(#{1,6})\s+(.*)$/.exec(line);
+    if (heading) {
+      flushAll();
+      out.push(el(`h${Math.min(heading[1].length, 6)}`, {}, inline(heading[2])));
+      continue;
+    }
+    if (/^(-{3,}|\*{3,}|_{3,})\s*$/.test(line)) { flushAll(); out.push(el("hr", {})); continue; }
+
+    if (line.trim().startsWith("|") && /^\s*\|[\s:|-]+\|\s*$/.test(lines[i + 1] || "")) {
+      flushAll();
+      const cells = (row) => row.trim().replace(/^\||\|$/g, "").split("|").map((c) => c.trim());
+      const head = cells(line);
+      const rows = [];
+      i += 2;
+      while (i < lines.length && lines[i].trim().startsWith("|")) rows.push(cells(lines[i++]));
+      i -= 1;
+      out.push(el("div", { class: "table-scroll" },
+        el("table", {},
+          el("thead", {}, el("tr", {}, head.map((c) => el("th", {}, inline(c))))),
+          el("tbody", {}, rows.map((r) => el("tr", {}, r.map((c) => el("td", {}, inline(c)))))))));
+      continue;
+    }
+
+    const quoted = /^>\s?(.*)$/.exec(line);
+    if (quoted) { flushPara(); flushList(); quote.push(quoted[1]); continue; }
+
+    const bullet = /^\s*[-*+]\s+(.*)$/.exec(line);
+    const numbered = /^\s*\d+[.)]\s+(.*)$/.exec(line);
+    if (bullet || numbered) {
+      flushPara(); flushQuote();
+      const want = bullet ? "ul" : "ol";
+      if (!list || list.tagName.toLowerCase() !== want) {
+        list = el(want, {});
+        out.push(list);
+      }
+      list.append(el("li", {}, inline((bullet || numbered)[1])));
+      continue;
+    }
+
+    flushList(); flushQuote();
+    para.push(line.trim());
+  }
+  flushAll();
+  return out;
+}
 
 // ---------------------------------------------------------------- boot
 

--- a/gui/web/app.js
+++ b/gui/web/app.js
@@ -232,7 +232,7 @@ $("#keysBtn").addEventListener("click", () => toggleKeys(true));
 $("#keysClose").addEventListener("click", () => toggleKeys(false));
 keysModal.addEventListener("click", (e) => { if (e.target === keysModal) toggleKeys(false); });
 
-const VIEW_ORDER = ["files"];
+const VIEW_ORDER = ["files", "text"];
 
 document.addEventListener("keydown", (e) => {
   const typing = /^(INPUT|TEXTAREA|SELECT)$/.test(document.activeElement?.tagName || "")
@@ -256,6 +256,11 @@ document.addEventListener("keydown", (e) => {
   if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
     if (files.length) { $("#cleanAllBtn").click(); e.preventDefault(); }
     return;
+  }
+  if (e.key.toLowerCase() === "r" && $(".view.is-active")?.dataset.view === "text") {
+    const next = textMode === "edit" ? "reveal" : "edit";
+    $(`#textModeSeg .seg-btn[data-mode="${next}"]`).click();
+    e.preventDefault();
   }
 });
 
@@ -709,6 +714,137 @@ for (const id of ["#optAggressive", "#optAs"]) {
     });
   });
 }
+
+// ---------------------------------------------------------------- 02 text
+
+const textInput = $("#textInput");
+let textReport = null;
+let textMode = "edit";
+let textTimer = null;
+let textSeq = 0;
+
+function renderText() {
+  const value = textInput.value;
+  $("#textMeta").textContent = `${value.length.toLocaleString()} characters`;
+
+  const verdict = $("#textVerdict");
+  const hitsWrap = $("#textHits");
+  const legendWrap = $("#textLegend");
+  const revealWrap = $("#revealArea");
+
+  if (!value) {
+    verdict.hidden = true;
+    hitsWrap.hidden = true;
+    legendWrap.hidden = true;
+    revealWrap.replaceChildren();
+    return;
+  }
+  if (!textReport) return;
+
+  verdict.hidden = false;
+  verdict.className = `verdict ${textReport.clean ? "clean" : "found"}`;
+  verdict.replaceChildren(
+    el("p", {
+      class: "verdict-title",
+      text: textReport.clean
+        ? "Nothing hidden in here"
+        : `${plural(textReport.suspicious_total, "hidden character", "hidden characters")} found`,
+    }),
+    el("p", {
+      class: "verdict-sub",
+      text: textReport.clean
+        ? "No invisible or look-alike characters. Statistical watermarks are invisible to this check — see Rewrite."
+        : "Switch to Reveal (or press R) to see exactly where they sit.",
+    }));
+
+  const hasHits = textReport.hits.length > 0;
+  hitsWrap.hidden = !hasHits;
+  legendWrap.hidden = !hasHits;
+  if (hasHits) {
+    hitsWrap.replaceChildren(hitsTable(textReport.hits));
+    const lg = legendNode(textReport.hits);
+    legendWrap.replaceChildren(...(lg ? lg.childNodes : []));
+  }
+
+  revealWrap.replaceChildren(...revealNode(textReport.reveal).childNodes);
+}
+
+async function inspectTextNow() {
+  const value = textInput.value;
+  if (!value) { textReport = null; renderText(); return; }
+  const seq = ++textSeq;
+  try {
+    const report = await api("/api/text/inspect", {
+      text: value, aggressive: $("#textAggressive").checked,
+    });
+    if (seq !== textSeq) return;  // a newer keystroke already won
+    textReport = report;
+  } catch (e) {
+    if (seq !== textSeq) return;
+    toast(e.message, true);
+    textReport = null;
+  }
+  renderText();
+}
+
+textInput.addEventListener("input", () => {
+  $("#textMeta").textContent = `${textInput.value.length.toLocaleString()} characters`;
+  clearTimeout(textTimer);
+  textTimer = setTimeout(inspectTextNow, 350);
+});
+$("#textAggressive").addEventListener("change", inspectTextNow);
+
+$("#textModeSeg").addEventListener("click", (e) => {
+  const btn = e.target.closest(".seg-btn");
+  if (!btn) return;
+  textMode = btn.dataset.mode;
+  $$("#textModeSeg .seg-btn").forEach((b) => b.classList.toggle("is-active", b === btn));
+  textInput.hidden = textMode !== "edit";
+  $("#revealArea").hidden = textMode !== "reveal";
+});
+
+$("#textCleanBtn").addEventListener("click", async (e) => {
+  if (!textInput.value) { toast("Paste some text first"); return; }
+  const btn = e.currentTarget;
+  btn.disabled = true;
+  try {
+    const res = await api("/api/text/clean", {
+      text: textInput.value,
+      nfkc: $("#textNfkc").checked,
+      aggressive_homoglyphs: $("#textAggressive").checked,
+      aggressive: $("#textAggressive").checked,
+    });
+    textInput.value = res.text;
+    textSeq += 1;
+    textReport = res.report;
+    renderText();
+    const s = res.stats;
+    toast(s.removed_count || s.replaced_count
+      ? `Removed ${s.removed_count}, replaced ${s.replaced_count}`
+      : "Nothing needed removing");
+  } catch (err) {
+    toast(err.message, true);
+  } finally {
+    btn.disabled = false;
+  }
+});
+
+$("#textCopyBtn").addEventListener("click", () => copyText(textInput.value));
+$("#textClearBtn").addEventListener("click", () => {
+  textInput.value = "";
+  textSeq += 1;
+  textReport = null;
+  renderText();
+});
+$("#textDownloadBtn").addEventListener("click", async () => {
+  if (!textInput.value) { toast("Nothing to save"); return; }
+  try {
+    const res = await api("/api/text/save", { text: textInput.value, name: "cleaned.txt" });
+    await download(`/api/download?id=${encodeURIComponent(res.download_id)}`, res.name);
+  } catch (e) {
+    toast(e.message, true);
+  }
+});
 
 // ---------------------------------------------------------------- boot
 

--- a/gui/web/app.js
+++ b/gui/web/app.js
@@ -232,7 +232,7 @@ $("#keysBtn").addEventListener("click", () => toggleKeys(true));
 $("#keysClose").addEventListener("click", () => toggleKeys(false));
 keysModal.addEventListener("click", (e) => { if (e.target === keysModal) toggleKeys(false); });
 
-const VIEW_ORDER = ["files", "text"];
+const VIEW_ORDER = ["files", "text", "rewrite"];
 
 document.addEventListener("keydown", (e) => {
   const typing = /^(INPUT|TEXTAREA|SELECT)$/.test(document.activeElement?.tagName || "")
@@ -840,6 +840,125 @@ $("#textDownloadBtn").addEventListener("click", async () => {
   if (!textInput.value) { toast("Nothing to save"); return; }
   try {
     const res = await api("/api/text/save", { text: textInput.value, name: "cleaned.txt" });
+    await download(`/api/download?id=${encodeURIComponent(res.download_id)}`, res.name);
+  } catch (e) {
+    toast(e.message, true);
+  }
+});
+
+// ---------------------------------------------------------------- 03 rewrite
+
+const DEFAULT_URLS = {
+  ollama: "http://127.0.0.1:11434",
+  "openai-compatible": "http://127.0.0.1:8080/v1",
+};
+
+function syncRewriteControls() {
+  const backend = $("#rwBackend").value;
+  const strength = $("#rwStrength").value;
+  $("#rwLangRow").hidden = strength !== "backtranslate";
+  $("#rwModelBox").hidden = backend === "print-prompt";
+  $("#rwKeyRow").hidden = backend !== "openai-compatible";
+  $("#rwRunBtn").textContent = backend === "print-prompt" ? "Build prompt" : "Rewrite";
+  if (backend !== "print-prompt" && DEFAULT_URLS[backend]) {
+    const current = $("#rwBaseUrl").value.trim();
+    if (!current || Object.values(DEFAULT_URLS).includes(current)) {
+      $("#rwBaseUrl").value = DEFAULT_URLS[backend];
+    }
+  }
+}
+$("#rwBackend").addEventListener("change", syncRewriteControls);
+$("#rwStrength").addEventListener("change", syncRewriteControls);
+syncRewriteControls();
+
+$("#rwProbeBtn").addEventListener("click", async (e) => {
+  const btn = e.currentTarget;
+  const box = $("#rwProbe");
+  btn.disabled = true;
+  box.hidden = false;
+  box.className = "probe-result";
+  box.textContent = "Checking…";
+  try {
+    const res = await api("/api/rewrite/probe", {
+      base_url: $("#rwBaseUrl").value, backend: $("#rwBackend").value,
+    });
+    if (res.ok) {
+      box.className = "probe-result ok";
+      box.textContent = res.models && res.models.length
+        ? `Reachable. Models: ${res.models.join(", ")}`
+        : "Reachable.";
+      $("#rwModelList").replaceChildren(...(res.models || []).map((m) => el("option", { value: m })));
+      if (!$("#rwModel").value && res.models && res.models.length) $("#rwModel").value = res.models[0];
+    } else {
+      box.className = "probe-result bad";
+      box.textContent = res.error || "Not reachable.";
+    }
+  } catch (err) {
+    box.className = "probe-result bad";
+    box.textContent = err.message;
+  } finally {
+    btn.disabled = false;
+  }
+});
+
+$("#rwRunBtn").addEventListener("click", async (e) => {
+  const text = $("#rwInput").value;
+  if (!text.trim()) { toast("Paste some text first"); return; }
+  const backend = $("#rwBackend").value;
+  const btn = e.currentTarget;
+  btn.disabled = true;
+  btn.textContent = backend === "print-prompt" ? "Building…" : "Rewriting…";
+  try {
+    const res = await api("/api/rewrite", {
+      text,
+      backend,
+      strength: $("#rwStrength").value,
+      model: $("#rwModel").value,
+      base_url: $("#rwBaseUrl").value,
+      api_key: $("#rwApiKey").value,
+      lang: $("#rwLang").value,
+      original_lang: $("#rwOriginalLang").value,
+      temperature: parseFloat($("#rwTemp").value) || 0.9,
+      candidates: parseInt($("#rwCandidates").value, 10) || 1,
+      timeout: parseFloat($("#rwTimeout").value) || 120,
+      layer_a_after: $("#rwLayerA").checked,
+      allow_remote: $("#rwAllowRemote").checked,
+    });
+    showRewrite(res);
+  } catch (err) {
+    toast(err.message, true);
+  } finally {
+    btn.disabled = false;
+    syncRewriteControls();
+  }
+});
+
+function showRewrite(res) {
+  const info = res.info || {};
+  const isPrompt = info.mode === "print-prompt";
+  $("#rwResult").hidden = false;
+  $("#rwResultLabel").textContent = isPrompt
+    ? "Prompt — paste this into any chat model"
+    : "Rewritten text";
+  $("#rwOutput").textContent = res.text;
+  $("#rwReadout").replaceChildren(...readout([
+    ["Mode", info.mode || "—"],
+    ["Approach", info.strength || "—"],
+    info.model ? ["Model", info.model] : null,
+    ["Chars in", info.input_chars],
+    info.output_chars ? ["Chars out", info.output_chars] : null,
+    res.divergence != null ? ["Divergence", `${Math.round(res.divergence * 100)}%`] : null,
+    info.candidates ? ["Tries", info.candidates] : null,
+  ]).childNodes);
+  $("#rwResult").scrollIntoView({ behavior: "smooth", block: "nearest" });
+}
+
+$("#rwCopyBtn").addEventListener("click", () => copyText($("#rwOutput").textContent));
+$("#rwDownloadBtn").addEventListener("click", async () => {
+  try {
+    const res = await api("/api/text/save", {
+      text: $("#rwOutput").textContent, name: "rewritten.txt",
+    });
     await download(`/api/download?id=${encodeURIComponent(res.download_id)}`, res.name);
   } catch (e) {
     toast(e.message, true);

--- a/gui/web/index.html
+++ b/gui/web/index.html
@@ -1,0 +1,163 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>watermarks-remover</title>
+<link rel="stylesheet" href="/assets/app.css">
+</head>
+<body>
+<div class="app">
+
+  <header class="topbar">
+    <div class="brand">
+      <svg class="brand-mark" viewBox="0 0 24 24" aria-hidden="true">
+        <rect x="2.5" y="2.5" width="19" height="19" rx="1"></rect>
+        <path d="M6 12h4M14 12h4M12 6v4M12 14v4"></path>
+      </svg>
+      <span class="brand-name">watermarks<span class="brand-dash">-</span>remover</span>
+      <span class="brand-tag">local only</span>
+    </div>
+    <div class="topbar-right">
+      <div class="toolstrip" id="toolStrip"></div>
+      <button class="icon-btn" id="keysBtn" type="button" title="Keyboard shortcuts"
+        aria-label="Keyboard shortcuts">⌘</button>
+      <button class="icon-btn" id="themeBtn" type="button" title="Switch light and dark"
+        aria-label="Switch light and dark">◐</button>
+    </div>
+  </header>
+
+  <div class="body">
+    <nav class="rail" id="rail" role="tablist" aria-label="Sections">
+      <button type="button" class="rail-item is-active" data-view="files"
+        role="tab" aria-selected="true" aria-controls="view-files">
+        <em>01</em><span>Files</span>
+      </button>
+      <div class="rail-foot">
+        <span class="rail-note">Nothing leaves<br>this computer.</span>
+      </div>
+    </nav>
+
+    <main class="stage" id="stage">
+
+      <!-- 01 FILES ---------------------------------------------------- -->
+      <section class="view is-active" data-view="files" id="view-files" role="tabpanel"
+        aria-labelledby="tab-files">
+        <div class="view-head">
+          <h1>Files</h1>
+          <p>Scan documents and images for hidden provenance marks, then strip them.</p>
+        </div>
+
+        <div class="dropzone" id="dropzone">
+          <div class="dropzone-inner">
+            <svg class="drop-icon" viewBox="0 0 48 48" aria-hidden="true">
+              <path d="M24 32V10M24 10l-8 8M24 10l8 8"></path>
+              <path d="M8 30v6a2 2 0 0 0 2 2h28a2 2 0 0 0 2-2v-6"></path>
+            </svg>
+            <p class="drop-title">Drop files here</p>
+            <p class="drop-sub">PNG · JPEG · PDF · DOCX · ODT · SVG · HTML · Markdown · plain text</p>
+            <div class="drop-actions">
+              <button class="btn btn-primary" id="browseBtn" type="button">Browse…</button>
+              <input type="file" id="fileInput" multiple hidden>
+            </div>
+          </div>
+        </div>
+
+        <div class="summary" id="summary" hidden>
+          <div class="summary-stats" id="summaryStats"></div>
+          <div class="summary-right">
+            <div class="seg" id="filterSeg" role="group" aria-label="Filter files">
+              <button type="button" class="seg-btn is-active" data-filter="all">All</button>
+              <button type="button" class="seg-btn" data-filter="found">Marks</button>
+              <button type="button" class="seg-btn" data-filter="clean">Clean</button>
+            </div>
+            <button class="btn btn-sm" id="cleanAllBtn" type="button">Clean all</button>
+            <button class="btn btn-sm" id="downloadAllBtn" type="button" hidden>Download all</button>
+            <button class="btn btn-sm btn-quiet" id="clearBtn" type="button">Clear</button>
+          </div>
+          <div class="progress" id="progress" hidden><div class="progress-bar" id="progressBar"></div></div>
+        </div>
+
+        <div class="split" id="filesSplit" hidden>
+          <ul class="file-list" id="fileList" role="listbox" tabindex="0"
+            aria-label="Scanned files"></ul>
+          <div class="detail" id="detail" aria-live="polite"></div>
+        </div>
+
+        <details class="options" id="fileOptions">
+          <summary><span class="label">Advanced options</span></summary>
+          <div class="options-grid">
+            <label class="field">
+              <span class="field-label">Treat file as</span>
+              <select id="optAs">
+                <option value="auto">Detect automatically</option>
+                <option value="text">Plain text</option>
+                <option value="image">Image (PNG / JPEG)</option>
+                <option value="container">Document (PDF, DOCX, …)</option>
+              </select>
+            </label>
+            <label class="check">
+              <input type="checkbox" id="optAggressive">
+              <span>Flag look-alike letters (Cyrillic “а”, Greek “ο”, …)</span>
+            </label>
+            <label class="check">
+              <input type="checkbox" id="optAggressiveClean">
+              <span>Also replace those letters when cleaning</span>
+            </label>
+            <label class="check">
+              <input type="checkbox" id="optNfkc">
+              <span>Normalise text (NFKC) — fixes ﬁ, ①, full-width forms</span>
+            </label>
+            <label class="check">
+              <input type="checkbox" id="optKeepMeta">
+              <span>Images: keep camera metadata, drop only AI / C2PA</span>
+            </label>
+            <label class="check">
+              <input type="checkbox" id="optScrubDoc">
+              <span>Word / ODT: also strip invisible characters from the document text
+                <em class="sub-note">off by default — the scripts never touch document text</em></span>
+            </label>
+            <label class="check sub">
+              <input type="checkbox" id="optConvertNbsp">
+              <span>…and turn no-break spaces into plain spaces
+                <em class="sub-note">usually deliberate typography (“Table 1”, “p = 0.05”)</em></span>
+            </label>
+            <label class="check" id="synthidRow" hidden>
+              <input type="checkbox" id="optSynthid">
+              <span>Images: score SynthID pixels (slow, needs setup)</span>
+            </label>
+          </div>
+        </details>
+      </section>
+
+      <!-- 02 TEXT ----------------------------------------------------- -->
+
+      <!-- 03 REWRITE -------------------------------------------------- -->
+
+      <!-- 04 SETUP ---------------------------------------------------- -->
+
+    </main>
+  </div>
+
+  <div class="toast" id="toast" role="status" aria-live="polite" hidden></div>
+
+  <div class="modal" id="keysModal" hidden>
+    <div class="modal-card" role="dialog" aria-modal="true" aria-label="Keyboard shortcuts">
+      <div class="modal-head">
+        <span class="label">Keyboard</span>
+        <button class="icon-btn" id="keysClose" type="button" aria-label="Close">×</button>
+      </div>
+      <dl class="keys">
+        <dt><kbd>Ctrl</kbd><kbd>O</kbd></dt><dd>Browse for files</dd>
+        <dt><kbd>↑</kbd><kbd>↓</kbd></dt><dd>Move through the file list</dd>
+        <dt><kbd>Enter</kbd></dt><dd>Clean the selected file</dd>
+        <dt><kbd>Ctrl</kbd><kbd>Enter</kbd></dt><dd>Clean every file in the list</dd>
+        <dt><kbd>?</kbd></dt><dd>This list</dd>
+        <dt><kbd>Esc</kbd></dt><dd>Close</dd>
+      </dl>
+    </div>
+  </div>
+</div>
+<script src="/assets/app.js"></script>
+</body>
+</html>

--- a/gui/web/index.html
+++ b/gui/web/index.html
@@ -41,6 +41,14 @@
         role="tab" aria-selected="false" aria-controls="view-rewrite">
         <em>03</em><span>Rewrite</span>
       </button>
+      <button type="button" class="rail-item" data-view="setup"
+        role="tab" aria-selected="false" aria-controls="view-setup">
+        <em>04</em><span>Setup</span>
+      </button>
+      <button type="button" class="rail-item" data-view="guide"
+        role="tab" aria-selected="false" aria-controls="view-guide">
+        <em>05</em><span>Guide</span>
+      </button>
       <div class="rail-foot">
         <span class="rail-note">Nothing leaves<br>this computer.</span>
       </div>
@@ -294,6 +302,29 @@
       </section>
 
       <!-- 04 SETUP ---------------------------------------------------- -->
+      <section class="view" data-view="setup" id="view-setup" role="tabpanel">
+        <div class="view-head">
+          <h1>Setup</h1>
+          <p>What this machine can do right now, and how to unlock the rest.</p>
+        </div>
+        <div id="setupBody" class="setup-body"></div>
+        <div class="actionbar">
+          <button class="btn" id="setupRefresh" type="button">Re-check</button>
+          <button class="btn btn-quiet" id="quitBtn" type="button">Quit app</button>
+        </div>
+      </section>
+
+      <!-- 05 GUIDE ---------------------------------------------------- -->
+      <section class="view" data-view="guide" id="view-guide" role="tabpanel">
+        <div class="view-head">
+          <h1>Guide</h1>
+          <p>The project’s own notes on what can and cannot be removed.</p>
+        </div>
+        <div class="guide-layout">
+          <ul class="doc-list" id="docList"></ul>
+          <article class="doc-body" id="docBody"></article>
+        </div>
+      </section>
 
     </main>
   </div>
@@ -307,7 +338,7 @@
         <button class="icon-btn" id="keysClose" type="button" aria-label="Close">×</button>
       </div>
       <dl class="keys">
-        <dt><kbd>1</kbd>–<kbd>3</kbd></dt><dd>Switch section</dd>
+        <dt><kbd>1</kbd>–<kbd>5</kbd></dt><dd>Switch section</dd>
         <dt><kbd>Ctrl</kbd><kbd>O</kbd></dt><dd>Browse for files</dd>
         <dt><kbd>↑</kbd><kbd>↓</kbd></dt><dd>Move through the file list</dd>
         <dt><kbd>Enter</kbd></dt><dd>Clean the selected file</dd>

--- a/gui/web/index.html
+++ b/gui/web/index.html
@@ -33,6 +33,10 @@
         role="tab" aria-selected="true" aria-controls="view-files">
         <em>01</em><span>Files</span>
       </button>
+      <button type="button" class="rail-item" data-view="text"
+        role="tab" aria-selected="false" aria-controls="view-text">
+        <em>02</em><span>Text</span>
+      </button>
       <div class="rail-foot">
         <span class="rail-note">Nothing leaves<br>this computer.</span>
       </div>
@@ -131,6 +135,45 @@
       </section>
 
       <!-- 02 TEXT ----------------------------------------------------- -->
+      <section class="view" data-view="text" id="view-text" role="tabpanel">
+        <div class="view-head">
+          <h1>Text</h1>
+          <p>Paste anything you copied out of a chat window. Hidden characters show up as chips.</p>
+        </div>
+
+        <div class="verdict" id="textVerdict" aria-live="polite" hidden></div>
+
+        <div class="editor">
+          <div class="editor-bar">
+            <div class="seg" id="textModeSeg" role="group" aria-label="View mode">
+              <button type="button" class="seg-btn is-active" data-mode="edit">Edit</button>
+              <button type="button" class="seg-btn" data-mode="reveal">Reveal</button>
+            </div>
+            <span class="editor-meta" id="textMeta">0 characters</span>
+          </div>
+          <label class="visually-hidden" for="textInput">Text to inspect</label>
+          <textarea id="textInput" class="editor-area" spellcheck="false"
+            placeholder="Paste your text here…"></textarea>
+          <div class="reveal-area" id="revealArea" hidden></div>
+        </div>
+
+        <div class="legend" id="textLegend" hidden></div>
+        <div class="hitlist" id="textHits" hidden></div>
+
+        <div class="actionbar">
+          <button class="btn btn-primary" id="textCleanBtn" type="button">Clean text</button>
+          <button class="btn" id="textCopyBtn" type="button">Copy</button>
+          <button class="btn" id="textDownloadBtn" type="button">Download .txt</button>
+          <button class="btn btn-quiet" id="textClearBtn" type="button">Clear</button>
+          <span class="actionbar-gap"></span>
+          <label class="check inline">
+            <input type="checkbox" id="textNfkc"><span>NFKC</span>
+          </label>
+          <label class="check inline">
+            <input type="checkbox" id="textAggressive"><span>Look-alike letters</span>
+          </label>
+        </div>
+      </section>
 
       <!-- 03 REWRITE -------------------------------------------------- -->
 
@@ -148,10 +191,12 @@
         <button class="icon-btn" id="keysClose" type="button" aria-label="Close">×</button>
       </div>
       <dl class="keys">
+        <dt><kbd>1</kbd>–<kbd>2</kbd></dt><dd>Switch section</dd>
         <dt><kbd>Ctrl</kbd><kbd>O</kbd></dt><dd>Browse for files</dd>
         <dt><kbd>↑</kbd><kbd>↓</kbd></dt><dd>Move through the file list</dd>
         <dt><kbd>Enter</kbd></dt><dd>Clean the selected file</dd>
         <dt><kbd>Ctrl</kbd><kbd>Enter</kbd></dt><dd>Clean every file in the list</dd>
+        <dt><kbd>R</kbd></dt><dd>Toggle Reveal in the Text screen</dd>
         <dt><kbd>?</kbd></dt><dd>This list</dd>
         <dt><kbd>Esc</kbd></dt><dd>Close</dd>
       </dl>

--- a/gui/web/index.html
+++ b/gui/web/index.html
@@ -37,6 +37,10 @@
         role="tab" aria-selected="false" aria-controls="view-text">
         <em>02</em><span>Text</span>
       </button>
+      <button type="button" class="rail-item" data-view="rewrite"
+        role="tab" aria-selected="false" aria-controls="view-rewrite">
+        <em>03</em><span>Rewrite</span>
+      </button>
       <div class="rail-foot">
         <span class="rail-note">Nothing leaves<br>this computer.</span>
       </div>
@@ -176,6 +180,118 @@
       </section>
 
       <!-- 03 REWRITE -------------------------------------------------- -->
+      <section class="view" data-view="rewrite" id="view-rewrite" role="tabpanel">
+        <div class="view-head">
+          <h1>Rewrite <span class="head-badge">Layer B</span></h1>
+          <p>Statistical watermarks live in word choice itself, so the only way out is rewording.</p>
+        </div>
+
+        <div class="notice">
+          <strong>Best effort, and it costs you something.</strong>
+          Removing a token-sampling watermark means rewriting a large share of the text, which
+          replaces your wording with the rewriting model’s. No tool can certify that the result
+          passes a vendor’s detector — including this one.
+        </div>
+
+        <div class="two-col">
+          <div class="col">
+            <label class="field">
+              <span class="field-label">Text to rewrite</span>
+              <textarea id="rwInput" class="editor-area standalone" spellcheck="false"
+                placeholder="Paste the text…"></textarea>
+            </label>
+          </div>
+          <div class="col col-narrow">
+            <label class="field">
+              <span class="field-label">Approach</span>
+              <select id="rwStrength">
+                <option value="paraphrase">Paraphrase — different wording, same shape</option>
+                <option value="humanize">Humanize — rewrite as if written from scratch</option>
+                <option value="backtranslate">Back-translate — through another language</option>
+                <option value="structural">Structural — outline, then rewrite</option>
+                <option value="code">Code — comments, strings and local names</option>
+              </select>
+            </label>
+
+            <div class="field-row" id="rwLangRow" hidden>
+              <label class="field">
+                <span class="field-label">Pivot language</span>
+                <input type="text" id="rwLang" value="French">
+              </label>
+              <label class="field">
+                <span class="field-label">Back to</span>
+                <input type="text" id="rwOriginalLang" value="English">
+              </label>
+            </div>
+
+            <label class="field">
+              <span class="field-label">Who does the rewriting</span>
+              <select id="rwBackend">
+                <option value="print-prompt">Nobody — just give me the prompt</option>
+                <option value="ollama">Ollama on this machine</option>
+                <option value="openai-compatible">OpenAI-compatible endpoint</option>
+              </select>
+            </label>
+
+            <div id="rwModelBox" hidden>
+              <div class="field-row">
+                <label class="field">
+                  <span class="field-label">Model</span>
+                  <input type="text" id="rwModel" placeholder="llama3.2" list="rwModelList">
+                  <datalist id="rwModelList"></datalist>
+                </label>
+                <label class="field field-slim">
+                  <span class="field-label">Temp.</span>
+                  <input type="number" id="rwTemp" value="0.9" min="0" max="2" step="0.1">
+                </label>
+              </div>
+              <label class="field">
+                <span class="field-label">Endpoint</span>
+                <input type="text" id="rwBaseUrl" value="http://127.0.0.1:11434">
+              </label>
+              <div class="field-row">
+                <label class="field field-slim">
+                  <span class="field-label">Tries</span>
+                  <input type="number" id="rwCandidates" value="1" min="1" max="8" step="1">
+                </label>
+                <label class="field field-slim">
+                  <span class="field-label">Timeout s</span>
+                  <input type="number" id="rwTimeout" value="120" min="5" max="1800" step="5">
+                </label>
+                <button class="btn btn-sm btn-test" id="rwProbeBtn" type="button">Test</button>
+              </div>
+              <label class="field" id="rwKeyRow" hidden>
+                <span class="field-label">API key <span class="hint">memory only, never saved</span></span>
+                <input type="password" id="rwApiKey" autocomplete="off">
+              </label>
+              <label class="check">
+                <input type="checkbox" id="rwAllowRemote">
+                <span>Allow a non-local endpoint — <strong>your text leaves this machine</strong></span>
+              </label>
+              <div class="probe-result" id="rwProbe" hidden></div>
+            </div>
+
+            <label class="check">
+              <input type="checkbox" id="rwLayerA" checked>
+              <span>Strip invisible characters from the result too</span>
+            </label>
+
+            <button class="btn btn-primary btn-block" id="rwRunBtn" type="button">Rewrite</button>
+          </div>
+        </div>
+
+        <div class="result-panel" id="rwResult" hidden>
+          <div class="result-head">
+            <span class="label" id="rwResultLabel">Result</span>
+            <div class="result-actions">
+              <button class="btn btn-sm" id="rwCopyBtn" type="button">Copy</button>
+              <button class="btn btn-sm" id="rwDownloadBtn" type="button">Download</button>
+            </div>
+          </div>
+          <div class="readout" id="rwReadout"></div>
+          <pre class="result-body" id="rwOutput"></pre>
+        </div>
+      </section>
 
       <!-- 04 SETUP ---------------------------------------------------- -->
 
@@ -191,7 +307,7 @@
         <button class="icon-btn" id="keysClose" type="button" aria-label="Close">×</button>
       </div>
       <dl class="keys">
-        <dt><kbd>1</kbd>–<kbd>2</kbd></dt><dd>Switch section</dd>
+        <dt><kbd>1</kbd>–<kbd>3</kbd></dt><dd>Switch section</dd>
         <dt><kbd>Ctrl</kbd><kbd>O</kbd></dt><dd>Browse for files</dd>
         <dt><kbd>↑</kbd><kbd>↓</kbd></dt><dd>Move through the file list</dd>
         <dt><kbd>Enter</kbd></dt><dd>Clean the selected file</dd>

--- a/tests/test_gui_server.py
+++ b/tests/test_gui_server.py
@@ -1,0 +1,93 @@
+"""Tests for the GUI server's static routes, headers and session guard."""
+
+from __future__ import annotations
+
+import http.client
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "gui"))
+
+from server import app  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def server():
+    srv = app.make_server()
+    thread = threading.Thread(target=srv.serve_forever, daemon=True)
+    thread.start()
+    yield srv
+    srv.shutdown()
+    thread.join(timeout=5)
+
+
+def request(server, path, headers=None):
+    conn = http.client.HTTPConnection("127.0.0.1", server.server_address[1], timeout=10)
+    try:
+        conn.request("GET", path, headers=headers or {})
+        resp = conn.getresponse()
+        return resp.status, dict(resp.getheaders()), resp.read()
+    finally:
+        conn.close()
+
+
+def test_serves_the_shipped_assets(server):
+    status, headers, body = request(server, "/")
+    assert status == 200
+    assert headers["Content-Type"] == "text/html; charset=utf-8"
+    assert b"<html" in body.lower()
+
+    status, headers, _ = request(server, "/assets/app.js")
+    assert status == 200
+    # nosniff is set, so the script type has to be right or the page won't run
+    assert headers["Content-Type"] == "text/javascript; charset=utf-8"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/assets/../server/app.py",
+        "/assets/%2e%2e/server/app.py",
+        "/assets/....//server/app.py",
+        "/assets/../../../../etc/passwd",
+        "/assets/C:/Windows/win.ini",
+        "/assets/",
+        "/assets/missing.css",
+    ],
+)
+def test_only_files_in_the_asset_table_are_served(server, path):
+    status, _, _ = request(server, path)
+    assert status == 404
+
+
+def test_asset_table_stays_inside_the_web_directory():
+    web = app.WEB_DIR.resolve()
+    assert app.ASSETS
+    for target in app.ASSETS.values():
+        assert target.is_relative_to(web)
+
+
+def test_control_characters_cannot_inject_a_header(tmp_path, server):
+    target = tmp_path / "report.txt"
+    target.write_text("ok", encoding="utf-8")
+    fid = app.register(target, 'a"\r\nSet-Cookie: pwned=1.txt')
+
+    status, headers, body = request(
+        server, f"/api/download?id={fid}", {"X-WM-Token": app.TOKEN}
+    )
+    assert status == 200
+    assert body == b"ok"
+    assert "Set-Cookie" not in headers
+    assert "\n" not in headers["Content-Disposition"]
+
+
+def test_api_needs_the_session_token(server):
+    status, _, _ = request(server, "/api/download?id=whatever")
+    assert status == 403
+
+    status, _, _ = request(server, "/api/download?id=whatever", {"X-WM-Token": "wrong"})
+    assert status == 403


### PR DESCRIPTION
> **Stacked on #45 — slice 4 of 5.** "Files changed" shows slices 1–4 together, because GitHub diffs against `main` and the earlier slices are not merged yet. **This slice is one commit: +412 −2.** Read it in the Commits tab. Merge after #43, #44 and #45.

## Setup

What this machine can actually do right now: Python and platform, whether `exiftool` and `c2patool` are on PATH, and whether SynthID scoring is configured — each with the exact install command for the running OS.

Those tools are the difference between a best-effort and a reliable clean, especially for PDFs. Their absence should be visible rather than inferred from a weaker result, which is the whole reason this screen exists.

It also carries the **Quit** button, which shuts the local server down — otherwise the only way to stop the app is Ctrl+C in a terminal the user was trying to avoid.

## Guide

Renders the project's own reference notes — ethics, mark classes, removal matrix, vendor notes — offline from `skills/remove-ai-marks/references/`, so the reasoning travels with the tool instead of living only in the repo. Read-only, resolved against a fixed directory.

## Notes

- Still stdlib only; no new dependencies.
- Nothing under `skills/` changes — the reference notes are read, never written. `python3 -m pytest -q` passes (156).
