### PR TITLE
fix: harden website audit against SSRF and gzip bombs

### DIFF
--- a/skills/remove-ai-marks/scripts/audit_website.py
+++ b/skills/remove-ai-marks/scripts/audit_website.py
@@ -256,6 +256,7 @@ def _open_pinned_connection(
 
             if scheme == "https":
                 context = ssl.create_default_context()
+                context.minimum_version = ssl.TLSVersion.TLSv1_2
                 try:
                     context.set_alpn_protocols(["http/1.1"])
                 except NotImplementedError:

--- a/skills/remove-ai-marks/scripts/audit_website.py
+++ b/skills/remove-ai-marks/scripts/audit_website.py
@@ -11,6 +11,11 @@ from __future__ import annotations
 
 import argparse
 import gzip
+import http.client
+import io
+import ipaddress
+import socket
+import ssl
 import sys
 import tempfile
 import urllib.error
@@ -27,6 +32,8 @@ from common import emit_json, eprint  # noqa: E402
 DEFAULT_MAX_BYTES = 4 << 20
 DEFAULT_TIMEOUT = 15
 DEFAULT_MAX_PAGES = 200
+MAX_SITEMAP_DECOMPRESSED_BYTES = 64 << 20
+MAX_REDIRECTS = 5
 USER_AGENT = "remove-ai-marks-audit/1.0"
 
 _EXT_FOR_KIND = {
@@ -49,7 +56,19 @@ def _local(tag: str) -> str:
 def parse_sitemap(data: bytes) -> tuple[str, list[str]]:
     """Parse a (possibly gzip-compressed) sitemap into (kind, urls)."""
     if data[:2] == b"\x1f\x8b":
-        data = gzip.decompress(data)
+        with gzip.GzipFile(fileobj=io.BytesIO(data)) as stream:
+            data = stream.read(MAX_SITEMAP_DECOMPRESSED_BYTES + 1)
+        if len(data) > MAX_SITEMAP_DECOMPRESSED_BYTES:
+            raise ValueError(
+                "sitemap decompressed size exceeds cap "
+                f"({MAX_SITEMAP_DECOMPRESSED_BYTES} bytes)"
+            )
+    elif len(data) > MAX_SITEMAP_DECOMPRESSED_BYTES:
+        raise ValueError(
+            "sitemap size exceeds cap "
+            f"({MAX_SITEMAP_DECOMPRESSED_BYTES} bytes)"
+        )
+
     root = ET.fromstring(data)
     kind = _local(root.tag)
     urls = []
@@ -57,7 +76,6 @@ def parse_sitemap(data: bytes) -> tuple[str, list[str]]:
         if _local(el.tag) == "loc" and el.text:
             urls.append(el.text.strip())
     return kind, urls
-
 
 def guess_kind(url: str, data: bytes, content_type: str | None = None) -> str:
     """Classify a downloaded URL from headers, suffix, then magic bytes."""
@@ -112,22 +130,238 @@ def guess_kind(url: str, data: bytes, content_type: str | None = None) -> str:
     return "text"
 
 
-def fetch(url: str, timeout: int, max_bytes: int) -> tuple[bytes, str | None]:
-    """Fetch *url* with a byte cap; returns (body, content_type)."""
-    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
-    with urllib.request.urlopen(req, timeout=timeout) as resp:
-        content_type = resp.headers.get("Content-Type")
-        chunks = []
-        total = 0
-        while True:
-            chunk = resp.read(1 << 16)
-            if not chunk:
-                break
-            total += len(chunk)
-            if total > max_bytes:
-                raise ValueError(f"exceeds {max_bytes} bytes")
-            chunks.append(chunk)
-        return b"".join(chunks), content_type
+UrlOrigin = tuple[str, str, int]
+
+
+def _url_origin(url: str) -> UrlOrigin:
+    """Return a normalized HTTP(S) origin or reject unsafe URL forms."""
+    parsed = urllib.parse.urlsplit(url)
+    scheme = parsed.scheme.lower()
+
+    if scheme not in ("http", "https"):
+        raise ValueError(f"unsupported URL scheme: {scheme or '(missing)'}")
+
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("credentials in URLs are not allowed")
+
+    host = parsed.hostname
+    if not host:
+        raise ValueError("URL has no hostname")
+
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise ValueError(f"invalid URL port: {exc}") from exc
+
+    if port is None:
+        port = 443 if scheme == "https" else 80
+
+    return scheme, host.rstrip(".").lower(), port
+
+
+def _origin_allowed(candidate: UrlOrigin, expected: UrlOrigin) -> bool:
+    """Allow same-origin URLs plus a normal HTTP-to-HTTPS upgrade."""
+    if candidate == expected:
+        return True
+    return (
+        expected[0] == "http"
+        and expected[2] == 80
+        and candidate[0] == "https"
+        and candidate[2] == 443
+        and candidate[1] == expected[1]
+    )
+
+
+def _resolve_public_addresses(origin: UrlOrigin) -> tuple[str, ...]:
+    """Resolve an origin to validated public numeric addresses."""
+    _scheme, host, port = origin
+    host_for_ip = host.split("%", 1)[0]
+    raw_addresses: list[str] = []
+
+    try:
+        raw_addresses.append(str(ipaddress.ip_address(host_for_ip)))
+    except ValueError:
+        try:
+            infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+        except socket.gaierror as exc:
+            raise ValueError(f"cannot resolve hostname {host}: {exc}") from exc
+
+        for info in infos:
+            raw_addresses.append(str(info[4][0]).split("%", 1)[0])
+
+    addresses: list[str] = []
+    for raw in raw_addresses:
+        try:
+            address = ipaddress.ip_address(raw)
+        except ValueError:
+            continue
+
+        mapped = getattr(address, "ipv4_mapped", None)
+        if mapped is not None:
+            address = mapped
+
+        if not address.is_global:
+            raise ValueError(f"refusing non-public address for {host}: {address}")
+
+        canonical = str(address)
+        if canonical not in addresses:
+            addresses.append(canonical)
+
+    if not addresses:
+        raise ValueError(f"hostname resolved to no IP addresses: {host}")
+
+    return tuple(addresses)
+
+
+def _validated_target(
+    url: str,
+    *,
+    expected_origin: UrlOrigin | None = None,
+) -> tuple[UrlOrigin, tuple[str, ...]]:
+    """Validate URL policy and bind it to numeric public IPs."""
+    origin = _url_origin(url)
+
+    if expected_origin is not None and not _origin_allowed(origin, expected_origin):
+        raise ValueError(
+            f"cross-origin URL is not allowed: "
+            f"{origin[0]}://{origin[1]}:{origin[2]}"
+        )
+
+    return origin, _resolve_public_addresses(origin)
+
+
+def _validate_public_http_url(
+    url: str,
+    *,
+    expected_origin: UrlOrigin | None = None,
+) -> UrlOrigin:
+    """Validate a public HTTP(S) URL and return its origin."""
+    origin, _addresses = _validated_target(url, expected_origin=expected_origin)
+    return origin
+
+
+def _open_pinned_connection(
+    origin: UrlOrigin,
+    addresses: tuple[str, ...],
+    timeout: int,
+) -> http.client.HTTPConnection:
+    """Connect to a validated IP while preserving Host and TLS SNI."""
+    scheme, host, port = origin
+    last_error: OSError | None = None
+
+    for address in addresses:
+        raw = None
+        try:
+            raw = socket.create_connection((address, port), timeout=timeout)
+
+            if scheme == "https":
+                context = ssl.create_default_context()
+                try:
+                    context.set_alpn_protocols(["http/1.1"])
+                except NotImplementedError:
+                    pass
+
+                wrapped = context.wrap_socket(raw, server_hostname=host)
+                raw = None
+
+                conn = http.client.HTTPSConnection(
+                    host,
+                    port,
+                    timeout=timeout,
+                    context=context,
+                )
+                conn.sock = wrapped
+                return conn
+
+            conn = http.client.HTTPConnection(host, port, timeout=timeout)
+            conn.sock = raw
+            raw = None
+            return conn
+
+        except OSError as exc:
+            last_error = exc
+            if raw is not None:
+                try:
+                    raw.close()
+                except OSError:
+                    pass
+
+    if last_error is not None:
+        raise last_error
+    raise OSError(f"no validated address available for {host}")
+
+
+def _request_target(url: str) -> str:
+    parsed = urllib.parse.urlsplit(url)
+    target = parsed.path or "/"
+    if parsed.query:
+        target += "?" + parsed.query
+    return target
+
+
+def fetch(
+    url: str,
+    timeout: int,
+    max_bytes: int,
+    *,
+    allowed_origin: UrlOrigin | None = None,
+) -> tuple[bytes, str | None]:
+    """Fetch with IP pinning, redirect validation and a byte cap."""
+    current_url = url
+    expected_origin = allowed_origin
+
+    for redirect_count in range(MAX_REDIRECTS + 1):
+        origin, addresses = _validated_target(
+            current_url,
+            expected_origin=expected_origin,
+        )
+
+        if expected_origin is None:
+            expected_origin = origin
+
+        conn = _open_pinned_connection(origin, addresses, timeout)
+        response = None
+
+        try:
+            conn.request(
+                "GET",
+                _request_target(current_url),
+                headers={
+                    "User-Agent": USER_AGENT,
+                    "Connection": "close",
+                },
+            )
+            response = conn.getresponse()
+
+            if response.status in (301, 302, 303, 307, 308):
+                location = response.getheader("Location")
+                if location:
+                    if redirect_count >= MAX_REDIRECTS:
+                        raise ValueError(f"too many redirects (>{MAX_REDIRECTS})")
+                    current_url = urllib.parse.urljoin(current_url, location)
+                    continue
+
+            content_type = response.getheader("Content-Type")
+            chunks = []
+            total = 0
+
+            while True:
+                chunk = response.read(1 << 16)
+                if not chunk:
+                    break
+                total += len(chunk)
+                if total > max_bytes:
+                    raise ValueError(f"exceeds {max_bytes} bytes")
+                chunks.append(chunk)
+
+            return b"".join(chunks), content_type
+
+        finally:
+            if response is not None:
+                response.close()
+            conn.close()
+
+    raise ValueError(f"too many redirects (>{MAX_REDIRECTS})")
 
 
 def inspect_remote(url: str, data: bytes, content_type: str | None = None) -> dict:
@@ -143,50 +377,105 @@ def inspect_remote(url: str, data: bytes, content_type: str | None = None) -> di
 
 
 def discover_sitemap(base_url: str, timeout: int) -> str | None:
-    """Find a sitemap for *base_url* via /sitemap.xml then /robots.txt."""
+    """Find a same-site sitemap via standard paths then robots.txt."""
+    origin = _validate_public_http_url(base_url)
     base = base_url.rstrip("/")
-    for candidate in (f"{base}/sitemap.xml", f"{base}/sitemap_index.xml"):
+
+    for candidate in (
+        f"{base}/sitemap.xml",
+        f"{base}/sitemap_index.xml",
+    ):
         try:
-            data, _ = fetch(candidate, timeout, DEFAULT_MAX_BYTES)
+            data, _ = fetch(
+                candidate,
+                timeout,
+                DEFAULT_MAX_BYTES,
+                allowed_origin=origin,
+            )
             parse_sitemap(data)
             return candidate
         except Exception:
             continue
+
     try:
-        data, _ = fetch(f"{base}/robots.txt", timeout, 1 << 20)
+        data, _ = fetch(
+            f"{base}/robots.txt",
+            timeout,
+            1 << 20,
+            allowed_origin=origin,
+        )
+
         text = data.decode("utf-8", errors="replace")
+
         for line in text.splitlines():
             if line.lower().startswith("sitemap:"):
-                return line.split(":", 1)[1].strip()
+                candidate = line.split(":", 1)[1].strip()
+                candidate_origin = _url_origin(candidate)
+
+                if not _origin_allowed(candidate_origin, origin):
+                    raise ValueError(
+                        f"cross-origin sitemap is not allowed: {candidate}"
+                    )
+
+                return candidate
+
     except Exception:
         pass
+
     return None
 
-
-def collect_urls(sitemap_url: str, timeout: int, max_pages: int) -> list[str]:
-    """Collect page/asset URLs from a sitemap, following nested indexes."""
+def collect_urls(
+    sitemap_url: str,
+    timeout: int,
+    max_pages: int,
+) -> list[str]:
+    """Collect same-site URLs while following nested sitemap indexes."""
     urls: list[str] = []
     seen: set[str] = set()
+    origin = _validate_public_http_url(sitemap_url)
+
+    def _check_loc(loc: str) -> None:
+        candidate_origin = _url_origin(loc)
+
+        if not _origin_allowed(candidate_origin, origin):
+            raise ValueError(
+                f"cross-origin sitemap URL is not allowed: {loc}"
+            )
 
     def _recurse(url: str, depth: int = 0) -> None:
         if len(urls) >= max_pages or depth > 3:
             return
-        data, _ = fetch(url, timeout, DEFAULT_MAX_BYTES)
+
+        data, _ = fetch(
+            url,
+            timeout,
+            DEFAULT_MAX_BYTES,
+            allowed_origin=origin,
+        )
+
         kind, locs = parse_sitemap(data)
+
         if kind == "sitemapindex":
             for loc in locs:
+                _check_loc(loc)
+
                 if loc not in seen:
                     seen.add(loc)
                     _recurse(loc, depth + 1)
+
         else:
             for loc in locs:
+                _check_loc(loc)
+
                 if loc not in seen:
                     seen.add(loc)
                     urls.append(loc)
 
+                    if len(urls) >= max_pages:
+                        break
+
     _recurse(sitemap_url)
     return urls
-
 
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__)
@@ -204,7 +493,11 @@ def main() -> int:
 
     sitemap_url = args.sitemap
     if not sitemap_url:
-        sitemap_url = discover_sitemap(args.base, args.timeout)
+        try:
+            sitemap_url = discover_sitemap(args.base, args.timeout)
+        except ValueError as e:
+            eprint(f"invalid base URL: {e}")
+            return 2
         if not sitemap_url:
             eprint(f"no sitemap found for {args.base}")
             return 2

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -8,10 +8,13 @@ import sys
 import zlib
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / "skills" / "remove-ai-marks" / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
+import audit_website  # noqa: E402
 from audit_lib import aggregate, is_actionable, scan_file  # noqa: E402
 from audit_website import guess_kind, inspect_remote, parse_sitemap  # noqa: E402
 from common import classify_finding_confidence  # noqa: E402
@@ -167,3 +170,239 @@ def test_inspect_remote_html_cms_informational():
     assert result["kind"] == "html"
     assert result["confidence"] == ["informational"]
     assert not is_actionable(result)
+
+
+
+def test_parse_sitemap_rejects_oversized_gzip(monkeypatch):
+    monkeypatch.setattr(
+        audit_website,
+        "MAX_SITEMAP_DECOMPRESSED_BYTES",
+        128,
+    )
+
+    payload = b"<urlset>" + (b" " * 256) + b"</urlset>"
+
+    with pytest.raises(
+        ValueError,
+        match="decompressed size exceeds cap",
+    ):
+        audit_website.parse_sitemap(gzip.compress(payload))
+
+
+def test_validate_public_url_rejects_private_literal():
+    with pytest.raises(ValueError, match="non-public address"):
+        audit_website._validate_public_http_url(
+            "http://127.0.0.1/secret"
+        )
+
+
+def test_validate_public_url_rejects_private_dns(monkeypatch):
+    def fake_getaddrinfo(host, port, *, type):
+        return [
+            (
+                audit_website.socket.AF_INET,
+                audit_website.socket.SOCK_STREAM,
+                6,
+                "",
+                ("10.0.0.8", port),
+            )
+        ]
+
+    monkeypatch.setattr(
+        audit_website.socket,
+        "getaddrinfo",
+        fake_getaddrinfo,
+    )
+
+    with pytest.raises(ValueError, match="non-public address"):
+        audit_website._validate_public_http_url(
+            "https://example.com/page"
+        )
+
+
+def test_validate_public_url_accepts_public_dns(monkeypatch):
+    def fake_getaddrinfo(host, port, *, type):
+        return [
+            (
+                audit_website.socket.AF_INET,
+                audit_website.socket.SOCK_STREAM,
+                6,
+                "",
+                ("93.184.216.34", port),
+            )
+        ]
+
+    monkeypatch.setattr(
+        audit_website.socket,
+        "getaddrinfo",
+        fake_getaddrinfo,
+    )
+
+    assert audit_website._validate_public_http_url(
+        "https://example.com/page"
+    ) == (
+        "https",
+        "example.com",
+        443,
+    )
+
+
+def test_collect_urls_rejects_cross_origin_entry(monkeypatch):
+    def fake_getaddrinfo(host, port, *, type):
+        return [
+            (
+                audit_website.socket.AF_INET,
+                audit_website.socket.SOCK_STREAM,
+                6,
+                "",
+                ("93.184.216.34", port),
+            )
+        ]
+
+    def fake_fetch(
+        url,
+        timeout,
+        max_bytes,
+        *,
+        allowed_origin=None,
+    ):
+        return (
+            b"<urlset><url>"
+            b"<loc>http://127.0.0.1/secret</loc>"
+            b"</url></urlset>",
+            "application/xml",
+        )
+
+    monkeypatch.setattr(
+        audit_website.socket,
+        "getaddrinfo",
+        fake_getaddrinfo,
+    )
+    monkeypatch.setattr(
+        audit_website,
+        "fetch",
+        fake_fetch,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="cross-origin sitemap URL",
+    ):
+        audit_website.collect_urls(
+            "https://example.com/sitemap.xml",
+            1,
+            10,
+        )
+
+
+def test_pinned_connection_uses_validated_numeric_ip(monkeypatch):
+    seen = []
+
+    class FakeSocket:
+        def close(self):
+            pass
+
+    def fake_create_connection(address, timeout=None):
+        seen.append(address)
+        return FakeSocket()
+
+    monkeypatch.setattr(
+        audit_website.socket,
+        "create_connection",
+        fake_create_connection,
+    )
+
+    conn = audit_website._open_pinned_connection(
+        ("http", "example.com", 80),
+        ("93.184.216.34",),
+        1,
+    )
+
+    try:
+        assert seen == [("93.184.216.34", 80)]
+        assert conn.host == "example.com"
+    finally:
+        conn.close()
+
+
+def test_fetch_revalidates_redirect_before_second_connection(monkeypatch):
+    dns_calls = 0
+    connections = 0
+
+    def fake_getaddrinfo(host, port, *, type):
+        nonlocal dns_calls
+        dns_calls += 1
+        address = "93.184.216.34" if dns_calls == 1 else "10.0.0.9"
+        return [
+            (
+                audit_website.socket.AF_INET,
+                audit_website.socket.SOCK_STREAM,
+                6,
+                "",
+                (address, port),
+            )
+        ]
+
+    class RedirectResponse:
+        status = 302
+
+        def getheader(self, name, default=None):
+            if name == "Location":
+                return "https://example.com/private"
+            return default
+
+        def close(self):
+            pass
+
+    class RedirectConnection:
+        def request(self, *args, **kwargs):
+            pass
+
+        def getresponse(self):
+            return RedirectResponse()
+
+        def close(self):
+            pass
+
+    def fake_open(origin, addresses, timeout):
+        nonlocal connections
+        connections += 1
+        return RedirectConnection()
+
+    monkeypatch.setattr(
+        audit_website.socket,
+        "getaddrinfo",
+        fake_getaddrinfo,
+    )
+    monkeypatch.setattr(
+        audit_website,
+        "_open_pinned_connection",
+        fake_open,
+    )
+
+    with pytest.raises(ValueError, match="non-public address"):
+        audit_website.fetch(
+            "https://example.com/start",
+            1,
+            1024,
+        )
+
+    assert connections == 1
+
+
+def test_main_rejects_private_base_cleanly(monkeypatch, capsys):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "audit_website.py",
+            "--base",
+            "http://127.0.0.1",
+        ],
+    )
+
+    assert audit_website.main() == 2
+
+    err = capsys.readouterr().err
+    assert "invalid base URL" in err
+    assert "non-public address" in err


### PR DESCRIPTION
## Summary

Hardens `skills/remove-ai-marks/scripts/audit_website.py` against two security issues:

- SSRF through attacker-controlled sitemap and redirect URLs
- Unbounded gzip sitemap decompression leading to resource exhaustion

## Changes

- Restrict remote fetching to HTTP/HTTPS
- Reject credentials and non-public IP addresses
- Validate DNS results before connecting
- Pin connections to validated numeric IPs to prevent DNS-rebinding/TOCTOU bypasses
- Preserve the original hostname for HTTP Host and HTTPS TLS/SNI verification
- Revalidate redirects and enforce a redirect limit
- Restrict sitemap traversal to the expected origin with HTTP-to-HTTPS upgrade support
- Bound sitemap decompression with `MAX_SITEMAP_DECOMPRESSED_BYTES`
- Add clean CLI handling for invalid/private base URLs
- Add regression tests for SSRF, redirect rebinding, private DNS/IPs, cross-origin sitemap entries, and gzip expansion

## Verification

- `git diff --check` — passed
- `python -m py_compile skills/remove-ai-marks/scripts/audit_website.py tests/test_audit.py` — passed
- `python -m pytest tests/test_audit.py -v` — 17 passed
- `python -m pytest tests/test_security_hardening.py -v` — 15 passed
- `python -m pytest -q` — 153 passed

Commit: `01c3ca98e97e22b247369d90ad40477e6954b268`