### PR TITLE
feat: print filename in inspect_file output

### DIFF
--- a/skills/remove-ai-marks/scripts/inspect_file.py
+++ b/skills/remove-ai-marks/scripts/inspect_file.py
@@ -72,6 +72,7 @@ def main() -> int:
         return 2
 
     kind = args.force_type if args.force_type != "auto" else classify(args.path)
+    file_label = str(args.path.resolve())
 
     if kind == "text":
         text = read_text_input(
@@ -81,18 +82,20 @@ def main() -> int:
         )
         report = inspect_text(text, aggressive=args.aggressive)
         if args.json:
-            emit_json({"kind": "text", **report.to_dict()})
+            emit_json({"kind": "text", "path": file_label, **report.to_dict()})
         else:
-            print(f"Kind: text")
+            print(f"File: {file_label}")
+            print("Kind: text")
             print(human_report(report))
         return 0 if report.suspicious_total == 0 else 1
 
     if kind == "image":
         report = inspect_image(args.path)
         if args.json:
-            emit_json({"kind": "image", **report.to_dict()})
+            emit_json({"kind": "image", "path": file_label, **report.to_dict()})
         else:
-            print(f"Kind: image")
+            print(f"File: {file_label}")
+            print("Kind: image")
             print(f"Path: {report.path}")
             print(f"Format: {report.format}")
             print(f"C2PA: {report.has_c2pa}")
@@ -103,9 +106,10 @@ def main() -> int:
 
     report = inspect_container(args.path)
     if args.json:
-        emit_json({"kind": "container", **report.to_dict()})
+        emit_json({"kind": "container", "path": file_label, **report.to_dict()})
     else:
-        print(f"Kind: container")
+        print(f"File: {file_label}")
+        print("Kind: container")
         print(f"Path: {report.path}")
         print(f"Format: {report.format}")
         print(f"C2PA: {report.has_c2pa}")

--- a/tests/test_inspect_file.py
+++ b/tests/test_inspect_file.py
@@ -1,0 +1,36 @@
+"""CLI inspect_file must name the file being inspected (issue #31)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "skills" / "remove-ai-marks" / "scripts"
+INSPECT = SCRIPTS / "inspect_file.py"
+FIXTURE = ROOT / "tests" / "fixtures" / "sample_watermarked.txt"
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(INSPECT), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_human_report_starts_with_file_line():
+    result = _run(str(FIXTURE))
+    first = result.stdout.splitlines()[0]
+    assert first == f"File: {FIXTURE.resolve()}"
+    assert "Kind: text" in result.stdout
+
+
+def test_json_report_includes_path():
+    result = _run("--json", str(FIXTURE))
+    payload = json.loads(result.stdout)
+    assert payload["path"] == str(FIXTURE.resolve())
+    assert payload["kind"] == "text"


### PR DESCRIPTION
Closes #31

## Problem

Running `inspect_file` over a codebase (e.g. via `find … -exec inspect_file.py {} \;`) produced a stream of results with no way to tell which filename the suspicious characters came from.

## Change

- Human output now starts with a `File: <resolved-path>` line for every kind (text, image, container), matching the format proposed in the issue.
- JSON output now includes `"path"` for text reports (image/container already carried it).

Example:

```
File: /path/to/codebase/ai_watermarked_file.py
Kind: text
Length: 29523 chars
…
```

## Tests

Added `tests/test_inspect_file.py` covering the `File:` header and JSON `path` field. Full suite passes (147 tests).