### PR TITLE
fix: SECURITY.md only references the private advisories channel

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,11 +9,9 @@ GitHub Release (when releases exist). Older tags are not maintained.
 
 **Do not open a public issue for security problems.**
 
-Please report vulnerabilities privately using one of:
-
-1. **[GitHub Security Advisories](https://github.com/guillaumemeyer/watermarks-remover/security/advisories/new)**
-   (preferred) — "Report a vulnerability" on the repository Security tab
-2. A private message to the repository maintainers via GitHub
+Please report vulnerabilities privately via
+**[GitHub Security Advisories](https://github.com/guillaumemeyer/watermarks-remover/security/advisories/new)**
+— use the "Report a vulnerability" button on the repository Security tab.
 
 Include:
 


### PR DESCRIPTION
Closes #36

The issue reported that SECURITY.md pointed at private vulnerability reporting that was not enabled, plus a second option ('a private message via GitHub') that does not exist.

Private vulnerability reporting has now been enabled on the repo (Settings -> Security -> Advanced Security), so the advisories link is the single working channel. This PR removes the non-existent second option from SECURITY.md so the policy only points at a route that actually works.