### PR TITLE
fix: preserve load-bearing script invisibles, strip PUA in Layer A

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,11 +9,9 @@ GitHub Release (when releases exist). Older tags are not maintained.
 
 **Do not open a public issue for security problems.**
 
-Please report vulnerabilities privately using one of:
-
-1. **[GitHub Security Advisories](https://github.com/guillaumemeyer/watermarks-remover/security/advisories/new)**
-   (preferred) — "Report a vulnerability" on the repository Security tab
-2. A private message to the repository maintainers via GitHub
+Please report vulnerabilities privately via
+**[GitHub Security Advisories](https://github.com/guillaumemeyer/watermarks-remover/security/advisories/new)**
+— use the "Report a vulnerability" button on the repository Security tab.
 
 Include:
 

--- a/skills/remove-ai-marks/references/mark-classes.md
+++ b/skills/remove-ai-marks/references/mark-classes.md
@@ -10,12 +10,13 @@ Invisible or near-invisible characters, exotic spaces, bidi controls, tag charac
 | `bidi` | LRE/RLO/LRI/… |
 | `tag_chars` | U+E0001–U+E007F |
 | `variation_selector` | VS1–VS256 |
+| `private_use` | U+E000–F8FF, U+F0000–FFFFD, U+100000–10FFFD |
 | `space` | NBSP, em space, ideographic space |
 | `confusable` | Cyrillic/fullwidth Latin (aggressive) |
 
 **Removal:** `clean_text.py` / Layer A — deterministic, verifiable.
 
-Load-bearing invisibles are preserved by default so real text is not corrupted: emoji glue (ZWJ/VS after an emoji base), script joiners (ZWNJ/ZWJ inside complex scripts like Persian or Devanagari), flag tag-char sequences, and orthographic Arabic/Syriac `Cf` marks. The same characters between plain ASCII stay carriers and are still stripped. Use `--strip-emoji-glue` for paranoid mode (strips all of them).
+Load-bearing invisibles are preserved by default so real text is not corrupted: emoji glue (ZWJ/VS after an emoji base), script joiners (ZWNJ/ZWJ inside complex scripts like Persian or Devanagari), flag tag-char sequences, same-script fillers/selectors (Mongolian free variation selectors after a Mongolian letter, Khmer inherent vowels after a Khmer consonant, Hangul jamo fillers in a partial syllable), and orthographic Arabic/Syriac `Cf` marks. The same characters between plain ASCII stay carriers and are still stripped. Use `--strip-emoji-glue` for paranoid mode (strips all of them).
 
 Maps to Nature paper “edit-based watermarking.”
 

--- a/skills/remove-ai-marks/scripts/clean_text.py
+++ b/skills/remove-ai-marks/scripts/clean_text.py
@@ -32,7 +32,7 @@ def main() -> int:
     p.add_argument(
         "--strip-emoji-glue",
         action="store_true",
-        help="Paranoid: strip all load-bearing invisibles too (emoji glue, script joiners, flag tags, orthographic Cf)",
+        help="Paranoid: strip all load-bearing invisibles too (emoji glue, script joiners, flag tags, same-script fillers/selectors, orthographic Cf)",
     )
     p.add_argument("--stats", action="store_true", help="Print stats JSON to stderr")
     p.add_argument(

--- a/skills/remove-ai-marks/scripts/inspect_text.py
+++ b/skills/remove-ai-marks/scripts/inspect_text.py
@@ -26,7 +26,7 @@ def main() -> int:
     p.add_argument(
         "--strip-emoji-glue",
         action="store_true",
-        help="Paranoid: flag all load-bearing invisibles too (emoji glue, script joiners, flag tags, orthographic Cf)",
+        help="Paranoid: flag all load-bearing invisibles too (emoji glue, script joiners, flag tags, same-script fillers/selectors, orthographic Cf)",
     )
     p.add_argument(
         "--force-text",

--- a/skills/remove-ai-marks/scripts/text_unicode.py
+++ b/skills/remove-ai-marks/scripts/text_unicode.py
@@ -191,6 +191,11 @@ _ZW_FAMILY: frozenset[int] = frozenset(
 )
 
 
+def _is_private_use(cp: int) -> bool:
+    """BMP and supplementary private-use planes (Co: no portable meaning)."""
+    return 0xE000 <= cp <= 0xF8FF or 0xF0000 <= cp <= 0xFFFFD or 0x100000 <= cp <= 0x10FFFD
+
+
 def _is_strip_cp(cp: int) -> bool:
     if cp in STRIP_CODEPOINTS:
         return True
@@ -198,6 +203,8 @@ def _is_strip_cp(cp: int) -> bool:
         return True
     # Tag characters used in some stego schemes (U+E0001–U+E007F)
     if 0xE0001 <= cp <= 0xE007F:
+        return True
+    if _is_private_use(cp):
         return True
     return False
 
@@ -212,6 +219,8 @@ def _strip_kind(cp: int) -> str:
         return "bidi"
     if cp in _ZW_FAMILY:
         return "zwj_family"
+    if _is_private_use(cp):
+        return "private_use"
     return "strip"
 
 
@@ -244,11 +253,19 @@ def _is_emoji_base(cp: int) -> bool:
 # ZWNJ/ZWJ are orthographic inside complex scripts (Persian می‌روم, Devanagari
 # क्‍ष); flag emoji are an emoji base followed by tag chars (🏴󠁧󠁢󠁳󠁣󠁴󠁿); and a
 # handful of Cf codepoints are normal Arabic/Syriac orthography, not carriers.
+# So are Mongolian free variation selectors (choose a glyph of the preceding
+# letter), Khmer inherent vowels (invisible but phonemic), and Hangul fillers
+# (hold a jamo slot in a partial syllable). Each is only meaningful directly
+# after a base from its own script; isolated instances are contraband.
 _SCRIPT_JOINERS: frozenset[int] = frozenset({0x200C, 0x200D})
 _TAG_RANGE = range(0xE0020, 0xE0080)
 _ORTHOGRAPHIC_CF: frozenset[int] = frozenset(
     {0x0600, 0x0601, 0x0602, 0x0603, 0x0604, 0x0605, 0x06DD, 0x070F, 0x08E2, 0x110BD, 0x110CD}
 )
+_MONGOLIAN_FVS: frozenset[int] = frozenset({0x180B, 0x180C, 0x180D})
+_KHMER_VOWELS: frozenset[int] = frozenset({0x17B4, 0x17B5})
+_HANGUL_FILLERS: frozenset[int] = frozenset({0x115F, 0x1160})
+_SCRIPT_GLUE: frozenset[int] = _MONGOLIAN_FVS | _KHMER_VOWELS | _HANGUL_FILLERS
 
 
 def _is_joining_letter(cp: int) -> bool:
@@ -256,9 +273,31 @@ def _is_joining_letter(cp: int) -> bool:
     return cp > 0x7F and unicodedata.category(chr(cp))[0] in ("L", "M")
 
 
+def _is_mongolian_letter(cp: int) -> bool:
+    return 0x1800 <= cp <= 0x18AF and unicodedata.category(chr(cp))[0] == "L"
+
+
+def _is_khmer_letter(cp: int) -> bool:
+    return 0x1780 <= cp <= 0x17FF and unicodedata.category(chr(cp))[0] == "L"
+
+
+def _is_hangul_jamo(cp: int) -> bool:
+    return (
+        0x1100 <= cp <= 0x11FF
+        or 0xA960 <= cp <= 0xA97C  # Hangul Jamo Extended-A
+        or 0xD7B0 <= cp <= 0xD7C6  # Hangul Jamo Extended-B
+    )
+
+
 def _is_glue(cp: int) -> bool:
-    """Load-bearing invisible char: emoji glue, script joiner, or flag tag char."""
-    return _is_emoji_glue(cp) or cp in _SCRIPT_JOINERS or cp in _TAG_RANGE
+    """Load-bearing invisible char: emoji glue, script joiner, flag tag char,
+    or same-script filler/selector (Mongolian FVS, Khmer vowel, Hangul filler)."""
+    return (
+        _is_emoji_glue(cp)
+        or cp in _SCRIPT_JOINERS
+        or cp in _TAG_RANGE
+        or cp in _SCRIPT_GLUE
+    )
 
 
 def _decide(
@@ -283,6 +322,12 @@ def _decide(
         if cp in _SCRIPT_JOINERS and prev_kept is not None and _is_joining_letter(ord(prev_kept)):
             return ("keep", ch, None)
         if cp in _TAG_RANGE and prev_kept is not None and _is_emoji_base(ord(prev_kept)):
+            return ("keep", ch, None)
+        if cp in _MONGOLIAN_FVS and prev_kept is not None and _is_mongolian_letter(ord(prev_kept)):
+            return ("keep", ch, None)
+        if cp in _KHMER_VOWELS and prev_kept is not None and _is_khmer_letter(ord(prev_kept)):
+            return ("keep", ch, None)
+        if cp in _HANGUL_FILLERS and prev_kept is not None and _is_hangul_jamo(ord(prev_kept)):
             return ("keep", ch, None)
         if cp in _ORTHOGRAPHIC_CF:
             return ("keep", ch, None)
@@ -315,7 +360,7 @@ class CharHit:
     char: str
     label: str
     count: int
-    kind: str  # strip | bidi | tag_chars | variation_selector | zwj_family | space | confusable | other_cf
+    kind: str  # strip | bidi | tag_chars | variation_selector | zwj_family | private_use | space | confusable | other_cf
     samples: list[int] = field(default_factory=list)  # character offsets
 
 
@@ -392,8 +437,8 @@ def inspect_text(
     notes = [
         "Layer A only: invisible/format Unicode and space homoglyphs (edit-based carriers).",
         "Statistical (token-sampling) watermarks are not detectable here; use Layer B rewrite.",
-        "Inspect kinds: strip, bidi, tag_chars, variation_selector, zwj_family, space, confusable, other_cf.",
-        "Load-bearing invisibles are preserved by default: emoji glue (ZWJ/VS after an emoji base), script joiners (ZWNJ/ZWJ inside complex scripts), flag tag chars, and orthographic Arabic/Syriac Cf marks. Use --strip-emoji-glue for paranoid mode (strips them all).",
+        "Inspect kinds: strip, bidi, tag_chars, variation_selector, zwj_family, private_use, space, confusable, other_cf.",
+        "Load-bearing invisibles are preserved by default: emoji glue (ZWJ/VS after an emoji base), script joiners (ZWNJ/ZWJ inside complex scripts), flag tag chars, same-script fillers/selectors (Mongolian FVS, Khmer inherent vowels, Hangul jamo fillers), and orthographic Arabic/Syriac Cf marks. Use --strip-emoji-glue for paranoid mode (strips them all).",
     ]
     if not hits:
         notes.append(

--- a/tests/test_clean_text.py
+++ b/tests/test_clean_text.py
@@ -150,3 +150,67 @@ def test_strip_emoji_glue_flag_restores_blanket_strip():
     cleaned, _ = clean_text("\u0645\u06cc\u200c\u0631", strip_emoji_glue=True)
     assert "\u200c" not in cleaned
     assert clean_text("x\u0600y", strip_emoji_glue=True)[0] == "xy"
+
+
+def test_clean_preserves_mongolian_fvs():
+    # Mongolian letter + FVS1/2/3 selects a positional glyph variant.
+    for raw in ("\u1820\u180b\u1821", "\u1820\u180c\u1821", "\u1820\u180d\u1821"):
+        cleaned, _ = clean_text(raw)
+        assert cleaned == raw
+    # FVS can chain after a single letter; both must stay bound to the base.
+    raw = "\u1820\u180b\u180c\u1821"
+    cleaned, _ = clean_text(raw)
+    assert cleaned == raw
+
+
+def test_clean_preserves_khmer_inherent_vowels():
+    # Invisible but phonemic inherent vowels after a Khmer consonant.
+    for raw in ("\u1780\u17b4\u1781", "\u1780\u17b5\u1781"):
+        cleaned, _ = clean_text(raw)
+        assert cleaned == raw
+
+
+def test_clean_preserves_hangul_fillers():
+    # Fillers hold jamo slots in a partial syllable; removing them lets the
+    # jamo compose into a different syllable (ᄀᅟᅡ vs 가).
+    for raw in ("\u1100\u115f\u1161", "\u1100\u1160\u1161"):
+        cleaned, _ = clean_text(raw)
+        assert cleaned == raw
+
+
+def test_clean_still_strips_floating_script_glue():
+    # Isolated between Latin these are contraband, not orthography.
+    for raw in ("a\u180bb", "a\u17b4b", "a\u115fb", "\u180b", "\u1160"):
+        cleaned, _ = clean_text(raw)
+        assert cleaned == raw.replace("\u180b", "").replace("\u17b4", "").replace("\u115f", "").replace("\u1160", "")
+
+
+def test_clean_strip_emoji_glue_flag_strips_script_glue():
+    for raw in ("\u1820\u180b\u1821", "\u1780\u17b4\u1781", "\u1100\u115f\u1161"):
+        cleaned, _ = clean_text(raw, strip_emoji_glue=True)
+        assert "\u180b" not in cleaned and "\u17b4" not in cleaned and "\u115f" not in cleaned
+
+
+def test_clean_strips_private_use():
+    # BMP + both supplementary PUA planes: no portable meaning, so stripped.
+    raw = "a\ue000b\U000f0000c\U0010fffd"
+    cleaned, stats = clean_text(raw)
+    assert cleaned == "abc"
+    assert stats["removed_count"] >= 3
+
+
+def test_inspect_script_glue_not_suspicious_by_default():
+    raw = "\u1820\u180b\u1821\u1780\u17b4\u1781\u1100\u115f\u1161"
+    report = inspect_text(raw)
+    assert report.suspicious_total == 0
+
+
+def test_inspect_floating_script_glue_is_suspicious():
+    for raw in ("a\u180b", "a\u17b4", "a\u115f"):
+        report = inspect_text(raw)
+        assert report.suspicious_total >= 1
+
+
+def test_inspect_private_use():
+    report = inspect_text("a\ue000b")
+    assert any(h.kind == "private_use" for h in report.hits)


### PR DESCRIPTION
Fixes #38

## Summary

`STRIP_CODEPOINTS` treated Mongolian free variation selectors (U+180B–180D), Khmer inherent vowels (U+17B4/17B5), and Hangul fillers (U+115F/1160) as unconditional contraband, but each does script work when it follows the right base character — selecting a positional glyph variant, marking a phonemic inherent vowel, or holding a jamo slot in a partial syllable.

This extends the existing #28 glue machinery to these scripts:

- **Preserved** when preceded by a same-script base (Mongolian letter, Khmer consonant, Hangul jamo), so `ᠠ<U+180B>ᠡ`, `ក<U+17B4>ខ`, and `ᄀ<U+115F>ᅡ` are no longer corrupted.
- **Still stripped** when floating between unrelated characters (e.g. a lone U+180B between Latin letters) — same policy as emoji glue/script joiners.
- **`--strip-emoji-glue`** (paranoid mode) still strips all of them.
- Added to `_is_glue` so chained FVS (FVS1+FVS2) stay bound to their base.

Also: **private-use codepoints** (U+E000–F8FF and the supplementary PUA planes) are `Co` rather than `Cf`, so they survived cleaning and made a serviceable hiding place. They now strip by default with a new `private_use` inspect kind.

The unterminated emoji tag-sequence case from the issue is left unchanged — it's the intended tag-chars behavior (kept after an emoji base), and the reporter flagged it as reasonable either way.

## Changes

- `text_unicode.py`: `_SCRIPT_GLUE` set + same-script base helpers, PUA strip/kind, `_decide()` keep conditions, doc/notes
- `clean_text.py` / `inspect_text.py`: `--strip-emoji-glue` help text
- `mark-classes.md`: document `private_use` kind and the new preserved classes
- `tests/test_clean_text.py`: 10 regression tests

## Verification

- Issue's repro script now returns the expected output for all load-bearing cases; PUA stripped
- 156 tests pass; `make smoke` passes