### PR TITLE
feat(server): opt-in CORS allow-list for browser clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ curl -s -X POST "$WM/clean" -H 'Content-Type: application/json' \
   -d "{\"file\": \"$(base64 -w0 notes.md)\", \"name\": \"notes.md\"}"
 ```
 
-The service routes by filename extension then magic bytes, so text / image / container are auto-detected. Set `WATERMARKS_SERVER_API_KEY` to require `Authorization: Bearer <key>` on every request. Loopback-only bind by default (`--host` to override); intended for a trusted network.
+The service routes by filename extension then magic bytes, so text / image / container are auto-detected. Set `WATERMARKS_SERVER_API_KEY` to require `Authorization: Bearer <key>` on every request. Loopback-only bind by default (`--host` to override); intended for a trusted network. Browser clients on another origin are blocked by default (no CORS headers); to allow one, pass `--cors-origin https://your.app` (repeatable) or set `WATERMARKS_SERVER_CORS_ORIGINS` to a comma-separated list of exact origins — wildcards are refused.
 
 ## Docker / compose
 
@@ -202,6 +202,7 @@ set -a; . ./.env; set +a; python3 service/scripts/rewrite_text.py /tmp/x.txt -o 
 | Var | Reaches | Purpose |
 | --- | --- | --- |
 | `WATERMARKS_SERVER_API_KEY` | `wr-core` (via compose `environment`) | Require `Authorization: Bearer <key>` on the HTTP API |
+| `WATERMARKS_SERVER_CORS_ORIGINS` | `wr-core` | Comma-separated exact browser origins allowed to call the API (default: none, no CORS headers) |
 | `HF_TOKEN` | harness/heavy services | Hugging Face token for gated models |
 | `WATERMARKS_SERVICE_URL` | client only (skill / curl) | Where to reach the service; default `http://127.0.0.1:8765` |
 | `WATERMARKS_REWRITE_BACKEND` | `rewrite_text.py` hook | `print-prompt` (default) / `ollama` / `openai-compatible` |

--- a/service/scripts/server.py
+++ b/service/scripts/server.py
@@ -52,6 +52,15 @@ VERSION = os.environ.get("WATERMARKS_SERVER_VERSION", "dev")
 # `Authorization: Bearer <key>`. Empty means no auth (default).
 API_KEY = os.environ.get("WATERMARKS_SERVER_API_KEY", "").strip()
 
+# Optional CORS allow-list for browser clients (comma-separated exact origins,
+# e.g. "http://localhost:8766,https://example.github.io"). Empty (default) means
+# no CORS headers at all, i.e. browsers on other origins cannot read responses.
+# "*" is deliberately not special-cased: an open allow-list on an API that reads
+# arbitrary files is the wrong default, so it must be an explicit origin list.
+CORS_ORIGINS: frozenset[str] = frozenset(
+    o.strip().rstrip("/") for o in os.environ.get("WATERMARKS_SERVER_CORS_ORIGINS", "").split(",") if o.strip()
+)
+
 # Body cap for the JSON envelope. Base64 inflates by 4/3, so the decoded file
 # stays well under MAX_INPUT_BYTES for the same cap.
 MAX_BODY_BYTES = MAX_INPUT_BYTES + (MAX_INPUT_BYTES >> 1)
@@ -324,6 +333,38 @@ class Handler(BaseHTTPRequestHandler):
         header = self.headers.get("Authorization", "")
         return header == f"Bearer {API_KEY}"
 
+    def _cors_origin(self) -> str | None:
+        """Return the request Origin if it is on the allow-list, else None."""
+        if not CORS_ORIGINS:
+            return None
+        origin = self.headers.get("Origin", "").strip().rstrip("/")
+        return origin if origin and origin in CORS_ORIGINS else None
+
+    def _send_cors_headers(self) -> None:
+        if not CORS_ORIGINS:
+            return
+        self.send_header("Vary", "Origin")  # responses differ per Origin once CORS is on
+        origin = self._cors_origin()
+        if origin is not None:
+            self.send_header("Access-Control-Allow-Origin", origin)
+
+    def do_OPTIONS(self) -> None:  # noqa: N802 (http.server API)
+        # Preflight carries no credentials by definition, so it is answered
+        # before auth — but only for allow-listed origins; everyone else gets
+        # the same 404 an unknown route would.
+        origin = self._cors_origin()
+        if origin is None:
+            self._respond(HTTPStatus.NOT_FOUND, {"ok": False, "error": "not found"})
+            return
+        self.send_response(HTTPStatus.NO_CONTENT)
+        self.send_header("Access-Control-Allow-Origin", origin)
+        self.send_header("Vary", "Origin")
+        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type, Authorization")
+        self.send_header("Access-Control-Max-Age", "600")
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
     def _read_json(self) -> dict[str, Any] | None:
         raw = self.headers.get("Content-Length")
         if raw is None or not raw.isdigit():
@@ -345,6 +386,7 @@ class Handler(BaseHTTPRequestHandler):
         self.send_header("Content-Type", "application/json; charset=utf-8")
         self.send_header("Content-Length", str(len(data)))
         self.send_header("Cache-Control", "no-store")
+        self._send_cors_headers()
         self.end_headers()
         self.wfile.write(data)
 
@@ -474,11 +516,19 @@ class Handler(BaseHTTPRequestHandler):
 
 
 def main() -> int:
-    global API_KEY  # noqa: PLW0603 — CLI overrides env
+    global API_KEY, CORS_ORIGINS  # noqa: PLW0603 — CLI overrides env
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--host", default=os.environ.get("WATERMARKS_SERVER_HOST", "127.0.0.1"))
     p.add_argument("--port", type=int, default=int(os.environ.get("WATERMARKS_SERVER_PORT", "8765")))
     p.add_argument("--api-key", default=API_KEY, help="require this bearer token (default: none)")
+    p.add_argument(
+        "--cors-origin",
+        action="append",
+        default=None,
+        metavar="ORIGIN",
+        help="allow this browser origin to call the API (repeatable; exact match, no wildcard). "
+        "Default: none — no CORS headers are sent. Env: WATERMARKS_SERVER_CORS_ORIGINS (comma-separated).",
+    )
     p.add_argument("-V", "--version", action="store_true", help="print version and exit")
     args = p.parse_args()
 
@@ -487,6 +537,11 @@ def main() -> int:
         return 0
 
     API_KEY = args.api_key
+    if args.cors_origin:
+        CORS_ORIGINS = frozenset(o.strip().rstrip("/") for o in args.cors_origin if o.strip())
+    if "*" in CORS_ORIGINS:
+        eprint("error: --cors-origin must be an explicit origin, '*' is not allowed")
+        return 2
 
     if args.host not in ("127.0.0.1", "localhost", "::1"):
         eprint(f"warning: binding {args.host} — intended for a trusted network only")
@@ -494,6 +549,8 @@ def main() -> int:
         eprint("API key required for requests")
     else:
         eprint("warning: no API key set — only bind to loopback or a trusted network")
+    if CORS_ORIGINS:
+        eprint("CORS enabled for: " + ", ".join(sorted(CORS_ORIGINS)))
 
     server = ThreadingHTTPServer((args.host, args.port), Handler)
     eprint(f"watermarks-remover service {VERSION} on http://{args.host}:{args.port}")

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -295,5 +295,9 @@ def test_cors_other_origin_gets_nothing(conn, monkeypatch):
 
 def test_cors_wildcard_rejected_on_cli(monkeypatch, capsys):
     monkeypatch.setattr(sys, "argv", ["server.py", "--cors-origin", "*"])
+    # main() rebinds the module globals it parses; monkeypatch restores them afterwards
+    monkeypatch.setattr(server, "CORS_ORIGINS", server.CORS_ORIGINS)
+    monkeypatch.setattr(server, "API_KEY", server.API_KEY)
     assert server.main() == 2
     assert "not allowed" in capsys.readouterr().err
+    assert "*" in server.CORS_ORIGINS  # (until teardown) proves main() really parsed it

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -237,3 +237,63 @@ def test_404(conn):
     assert status == 404
     status, body = _post(conn, "/nope", {"file": _b64(b"x")})
     assert status == 404
+
+
+# --- CORS allow-list (opt-in) --------------------------------------------------
+
+
+def _headers(conn, method: str, path: str, **hdrs) -> tuple[int, dict]:
+    conn.request(method, path, headers=hdrs)
+    resp = conn.getresponse()
+    resp.read()
+    return resp.status, {k.lower(): v for k, v in resp.getheaders()}
+
+
+def test_cors_off_by_default(conn):
+    status, hdrs = _headers(conn, "GET", "/health", Origin="http://localhost:8766")
+    assert status == 200
+    assert "access-control-allow-origin" not in hdrs
+    assert "vary" not in hdrs
+    status, hdrs = _headers(conn, "OPTIONS", "/clean", Origin="http://localhost:8766")
+    assert status == 404
+    assert "access-control-allow-origin" not in hdrs
+
+
+def test_cors_allowlisted_origin(conn, monkeypatch):
+    monkeypatch.setattr(server, "CORS_ORIGINS", frozenset({"http://localhost:8766"}))
+    status, hdrs = _headers(conn, "GET", "/health", Origin="http://localhost:8766")
+    assert status == 200
+    assert hdrs["access-control-allow-origin"] == "http://localhost:8766"
+    assert hdrs["vary"] == "Origin"
+    # preflight for an allowed origin succeeds without auth (browsers never send it there)
+    monkeypatch.setattr(server, "API_KEY", "sekret")
+    status, hdrs = _headers(conn, "OPTIONS", "/clean", Origin="http://localhost:8766")
+    assert status == 204
+    assert hdrs["access-control-allow-origin"] == "http://localhost:8766"
+    assert "authorization" in hdrs["access-control-allow-headers"].lower()
+    assert "POST" in hdrs["access-control-allow-methods"]
+    # ...but the real request still needs the key
+    status, hdrs = _headers(conn, "GET", "/health", Origin="http://localhost:8766")
+    assert status == 401
+    assert hdrs["access-control-allow-origin"] == "http://localhost:8766"  # so the browser can read the 401
+
+
+def test_cors_other_origin_gets_nothing(conn, monkeypatch):
+    monkeypatch.setattr(server, "CORS_ORIGINS", frozenset({"http://localhost:8766"}))
+    status, hdrs = _headers(conn, "GET", "/health", Origin="https://evil.example")
+    assert status == 200
+    assert "access-control-allow-origin" not in hdrs
+    assert hdrs["vary"] == "Origin"
+    status, hdrs = _headers(conn, "OPTIONS", "/clean", Origin="https://evil.example")
+    assert status == 404
+    assert "access-control-allow-origin" not in hdrs
+    # no Origin header at all (curl / same-origin) -> unchanged behaviour
+    status, hdrs = _headers(conn, "GET", "/health")
+    assert status == 200
+    assert "access-control-allow-origin" not in hdrs
+
+
+def test_cors_wildcard_rejected_on_cli(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["server.py", "--cors-origin", "*"])
+    assert server.main() == 2
+    assert "not allowed" in capsys.readouterr().err


### PR DESCRIPTION
## What

Opt-in CORS allow-list for `service/scripts/server.py`. Default behaviour is unchanged (no new headers at all).

- `--cors-origin ORIGIN` (repeatable) or `WATERMARKS_SERVER_CORS_ORIGINS=a,b`
- exact-match origins only; `*` is refused on the CLI and never emitted
- allowed origin → `Access-Control-Allow-Origin: <that origin>` + `Vary: Origin` on every JSON response (including 401s, so a browser can show the auth error)
- `OPTIONS` preflight → `204` with `GET, POST, OPTIONS` / `Content-Type, Authorization` / `Max-Age: 600`, **only** for allow-listed origins; any other origin (or no `Origin`) gets the usual `404`. Preflight is pre-auth by nature — browsers never attach `Authorization` to it — the actual request still needs the bearer key.

## Why

`server.py` is loopback-only and CORS-less by design, which is right as a default. But any external browser client (a static web UI, a desktop webview, GitHub Pages) can only reach it through a same-origin proxy today. This makes that an explicit operator decision instead of something clients work around with a wildcard. Related: #77, #43 (option 2 = external UIs).

## Tests

`tests/test_http_server.py`: off by default (no headers, preflight 404), allow-listed origin (with and without `API_KEY`), foreign origin (no ACAO, `Vary` still set, preflight 404), wildcard rejected on the CLI. `python3 -m pytest -q` passes.

## Docs

README service paragraph + env table row for `WATERMARKS_SERVER_CORS_ORIGINS`.
