### PR TITLE
fix(inspect): run Layer A scan on markdown/HTML containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,6 +669,10 @@ make smoke                          # quick CLI smoke on fixtures
 
 ## Changelog
 
+### Unreleased
+
+- **Fix `inspect` missing Layer A carriers in markdown/HTML**: `inspect_container` never scanned the document body, so a `.md` or `.html` file holding invisible Unicode came back `suspicious: false` while `clean_container` went on to strip it — the same bytes saved as `.txt` were correctly flagged. The scan now runs for exactly the formats `clean_container` scrubs, so inspect predicts clean. Container reports gain `suspicious_total` (the same key `TextInspectReport` uses, so the HTTP `suspicious` flag and the `inspect_file` exit code pick it up) and `layer_a_hits`
+
 ### [v0.5.0](https://github.com/guillaumemeyer/watermarks-remover/releases/tag/v0.5.0) — service & Docker distribution, HTTP API, and verification harnesses
 
 **Service / Docker distribution**

--- a/service/scripts/audit_lib.py
+++ b/service/scripts/audit_lib.py
@@ -84,30 +84,23 @@ def scan_file(
     report = inspect_container(path)
     findings = list(report.findings)
     confidences = [classify_finding_confidence(f) for f in report.findings]
-    suspicious = 0
+    # Layer A body-scan findings (and count) already come from
+    # inspect_container() for markdown/html; it mirrors clean_container().
+    suspicious = report.layer_a_total
     stylometry_dict = None
 
-    # Text-bearing containers also get a Layer A scan of their visible text,
-    # mirroring the skill's "container + Layer A" workflow.
-    if report.format in ("html", "markdown"):
+    if check_stylometry and report.format in ("html", "markdown"):
         try:
             text = path.read_text(encoding="utf-8", errors="surrogateescape")
         except OSError:
             text = ""
         if text:
-            t_report = inspect_text(text)
-            t_findings, t_confidences, t_suspicious = text_findings(t_report)
-            findings.extend(t_findings)
-            confidences.extend(t_confidences)
-            suspicious = t_suspicious
-
-            if check_stylometry:
-                s_rep = score_text_stylometry(text, path=name)
-                stylometry_dict = s_rep.to_dict()
-                if s_rep.score >= 0.65:
-                    findings.append(f"stylometry [high_probability] score {s_rep.score:.2f} ({s_rep.confidence_level})")
-                    confidences.append("probable")
-                    suspicious += 1
+            s_rep = score_text_stylometry(text, path=name)
+            stylometry_dict = s_rep.to_dict()
+            if s_rep.score >= 0.65:
+                findings.append(f"stylometry [high_probability] score {s_rep.score:.2f} ({s_rep.confidence_level})")
+                confidences.append("probable")
+                suspicious += 1
 
     item = {
         "path": name,

--- a/service/scripts/container_meta.py
+++ b/service/scripts/container_meta.py
@@ -67,6 +67,12 @@ class ContainerInspectReport:
     tools: dict[str, Any] = field(default_factory=dict)
     details: dict[str, Any] = field(default_factory=dict)
     notes: list[str] = field(default_factory=list)
+    # Layer A (invisible/format Unicode) scan of the text body, populated only
+    # for the formats clean_container() actually scrubs. Without it, inspect
+    # reported a markdown/html file carrying invisible carriers as clean while
+    # clean then went on to remove them.
+    layer_a_total: int = 0
+    layer_a_hits: list[dict] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         return {
@@ -81,6 +87,10 @@ class ContainerInspectReport:
             "tools": self.tools,
             "details": self.details,
             "notes": self.notes,
+            # Same key as TextInspectReport so every caller — including the
+            # HTTP server's `suspicious` flag — reads both report kinds alike.
+            "suspicious_total": self.layer_a_total,
+            "layer_a_hits": self.layer_a_hits,
         }
 
 
@@ -818,14 +828,31 @@ def inspect_container(path: Path) -> ContainerInspectReport:
     elif fmt == "odt":
         has_c2pa, has_ai, findings, details = inspect_odt(data)
     elif fmt == "html":
-        text = data.decode("utf-8", errors="replace")
-        has_c2pa, has_ai, findings, details = inspect_html(text)
+        # surrogateescape, not replace: clean_container() decodes the same way,
+        # and U+FFFD substitutions would make the two disagree on the counts.
+        body = data.decode("utf-8", errors="surrogateescape")
+        has_c2pa, has_ai, findings, details = inspect_html(body)
     elif fmt == "markdown":
-        text = data.decode("utf-8", errors="replace")
-        has_c2pa, has_ai, findings, details = inspect_markdown(text)
+        body = data.decode("utf-8", errors="surrogateescape")
+        has_c2pa, has_ai, findings, details = inspect_markdown(body)
     else:
         has_c2pa, has_ai, findings = False, False, [f"unsupported container: {fmt}"]
         details = {"unsupported": True}
+
+    # Layer A body scan for exactly the formats clean_container() scrubs, so
+    # inspect predicts clean rather than contradicting it.
+    layer_a_total = 0
+    layer_a_hits: list[dict] = []
+    if fmt in ("markdown", "html"):
+        from text_unicode import inspect_text  # local import to avoid cycles
+
+        ta = inspect_text(body).to_dict()
+        layer_a_total = ta["suspicious_total"]
+        layer_a_hits = ta["hits"]
+        for h in layer_a_hits:
+            findings.append(
+                f"layer-a: {h['codepoint']} {h['label']} x{h['count']} ({h['kind']})"
+            )
 
     notes: list[str] = []
     if fmt == "pdf":
@@ -834,6 +861,11 @@ def inspect_container(path: Path) -> ContainerInspectReport:
         notes.append("DOCX: only metadata/provenance parts are scanned; visible body text is ignored")
     if "unsupported" in details:
         notes.append(f"format not fully inspected: {fmt}")
+    if layer_a_total:
+        notes.append(
+            f"layer A: {layer_a_total} invisible/format codepoint(s) in body text; "
+            "clean removes these"
+        )
 
     if fmt in ("svg", "pdf", "docx") and not tools:
         tools = run_optional_tools(path)
@@ -847,6 +879,8 @@ def inspect_container(path: Path) -> ContainerInspectReport:
         tools=tools,
         details=details,
         notes=notes,
+        layer_a_total=layer_a_total,
+        layer_a_hits=layer_a_hits,
     )
 
 

--- a/service/scripts/inspect_file.py
+++ b/service/scripts/inspect_file.py
@@ -94,7 +94,11 @@ def main() -> int:
         print(f"AI metadata: {report.has_ai_metadata}")
         for f in report.findings:
             print(f"  - [{classify_finding_confidence(f)}] {f}")
-    return 0 if not (report.has_c2pa or report.has_ai_metadata) else 1
+    # layer_a_total counts body-text carriers that clean will strip; the text
+    # branch above already exits non-zero for those, so containers match.
+    if report.has_c2pa or report.has_ai_metadata or report.layer_a_total:
+        return 1
+    return 0
 
 
 if __name__ == "__main__":

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -108,6 +108,17 @@ def test_scan_file_text_and_html(tmp_path: Path):
     assert not is_actionable(item)
 
 
+def test_scan_file_container_layer_a_reported_once(tmp_path: Path):
+    """Layer A body findings come from inspect_container() exactly once."""
+    md = tmp_path / "post.md"
+    md.write_text("# Title\n\nHello\u200bWorld\n", encoding="utf-8")
+    item = scan_file(md)
+    layer_a = [f for f in item["findings"] if "layer-a" in f]
+    assert len(layer_a) == 1
+    assert item["suspicious_total"] == 1
+    assert is_actionable(item)
+
+
 def test_aggregate_summary():
     files = [
         {

--- a/tests/test_container_meta.py
+++ b/tests/test_container_meta.py
@@ -289,6 +289,43 @@ def test_clean_container_markdown_file(tmp_path: Path):
     assert result["format"] == "markdown"
 
 
+def test_inspect_container_reports_layer_a_body_text(tmp_path: Path):
+    """inspect must flag invisible carriers that clean would strip.
+
+    Regression: markdown/html routed to the container inspector, which never
+    ran the Layer A scan, so identical bytes were reported suspicious as .txt
+    and clean as .md while clean_container() went on to remove them.
+    """
+    body = "Hello​world‌ test⁠end.\n"
+    for name in ("x.md", "x.html"):
+        src = tmp_path / name
+        src.write_text(body, encoding="utf-8")
+        report = inspect_container(src)
+        assert report.layer_a_total == 3, name
+        assert report.to_dict()["suspicious_total"] == 3, name
+        codepoints = {h["codepoint"] for h in report.layer_a_hits}
+        assert {"U+200B", "U+200C", "U+2060"} <= codepoints, name
+        assert any(f.startswith("layer-a:") for f in report.findings), name
+
+
+def test_inspect_container_clean_leaves_no_layer_a(tmp_path: Path):
+    """The post-clean re-inspect must come back with nothing left."""
+    src = tmp_path / "x.md"
+    src.write_text("Hi​‌there\n", encoding="utf-8")
+    dest = tmp_path / "x.cleaned.md"
+    clean_container(src, dest)
+    assert inspect_container(dest).layer_a_total == 0
+
+
+def test_inspect_container_clean_file_stays_clean(tmp_path: Path):
+    """No false positives on ordinary prose."""
+    src = tmp_path / "x.md"
+    src.write_text("# Title\n\nOrdinary prose, nothing hidden.\n", encoding="utf-8")
+    report = inspect_container(src)
+    assert report.layer_a_total == 0
+    assert report.layer_a_hits == []
+
+
 def test_inspect_container_svg(tmp_path: Path):
     src = tmp_path / "a.svg"
     src.write_bytes(


### PR DESCRIPTION
## What

`inspect_container()` never scanned the document body for Layer A carriers, so it disagreed with `clean_container()` on the same file. The scan now runs for exactly the two formats `clean_container()` scrubs (markdown, html).

- `container_meta.py` — run `inspect_text()` on the body for markdown/html; decode with `surrogateescape` to match how `clean_container()` decodes, since `replace` turns undecodable bytes into U+FFFD and skews the counts
- `container_meta.py` — report the count as `suspicious_total`, the key `TextInspectReport` already uses, so `server.py`'s `suspicious` flag picks it up without special-casing; add `layer_a_hits` and `layer-a:` findings, which the existing `classify_finding_confidence()` already buckets
- `inspect_file.py` — the container branch had the same gap in its exit code; it now returns 1 on Layer A hits, matching the text branch
- three tests under `tests/test_container_meta.py`

## Why

The same bytes got opposite verdicts depending on the file extension:

```
t.txt   → kind=text       suspicious=true
t2.md   → kind=container  suspicious=false   findings=[]
t3.html → kind=container  suspicious=false   findings=[]
```

All three held `U+200B`, `U+200C`, and `U+2060`. `/clean` on that same `.md` then reported `layer A text: removed=3 replaced=1` and stripped them.

This matters because `SKILL.md` tells the agent to "Inspect first (decide, don't guess)" (lines 85 and 125). Following the skill on a `.md` or `.html`, an agent reads `suspicious: false`, reports the file clean, and skips cleaning — while the file still carries the marks. Markdown and HTML are the formats people are most likely to paste AI text into.

After the change:

```
t.txt    → kind=text       suspicious=true   total=3
t2.md    → kind=container  suspicious=true   total=3  hits=[U+200B, U+200C, U+2060]
t3.html  → kind=container  suspicious=true   total=3  hits=[U+200B, U+200C, U+2060]
clean.md → kind=container  suspicious=false  total=0
```

## Checklist

- [x] Behaviour matches `SKILL.md` / `references/removal-matrix.md` when relevant
- [x] Unit tests updated or added under `tests/`
- [x] `python3 -m pytest -q` passes — 230 passed, 1 skipped
- [x] Docs updated (README and/or skill references) if user-facing behaviour changes
- [x] No drive-by refactors unrelated to the fix or feature

## Notes for the reviewer

Layer involved: **A (Unicode)**, surfacing through the **Files** container path.

Scope is deliberately tied to `clean_container()`: markdown and html only, the two formats it Layer-A scrubs. SVG, PDF, DOCX, and ODT are untouched, so inspect keeps promising exactly what clean delivers.

Two follow-on effects worth a look:

- `clean_container()` ends with `after = inspect_container(dest)`, so `post_findings` now verifies the Layer A strip instead of returning an empty list either way.
- The `inspect_file.py` exit code for markdown/html carrying invisible codepoints changes from 0 to 1. That matches the text branch and `--json` behaviour from #30, but it is a behaviour change for anyone scripting against the container path.

I added an `Unreleased` changelog heading since v0.5.0 is already tagged — rename or fold it in as you prefer.

No fixture files added; the tests build their inputs inline.
