### PR TITLE
Add Codex and Claude installation for remove-ai-marks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 !/docs/**
 !/service/
 !/service/**
+!/skills/
 !/skills/remove-ai-marks/
 !/skills/remove-ai-marks/**
 !/tests/

--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ Service path: [`service/`](service/)
 The skill ships **no code** — it calls the service over HTTP. Install the skill (markdown only) and start the service, then set `WATERMARKS_SERVICE_URL` if it is not `http://127.0.0.1:8765`.
 
 ```bash
+# Codex (~/.codex/skills/remove-ai-marks)
+python3 install_skill.py --target codex --skill remove-ai-marks
+
+# Claude (~/.claude/skills/remove-ai-marks)
+python3 install_skill.py --target claude --skill remove-ai-marks
+
+# Codex + Claude + Cursor
+python3 install_skill.py --target all --skill remove-ai-marks
+
 # Grok Build / project-local
 mkdir -p .grok/skills
 ln -sfn "$(pwd)/skills/remove-ai-marks" .grok/skills/remove-ai-marks
@@ -42,6 +51,10 @@ ln -sfn "$(pwd)/skills/remove-ai-marks" .grok/skills/remove-ai-marks
 mkdir -p ~/.grok/skills
 ln -sfn "$(pwd)/skills/remove-ai-marks" ~/.grok/skills/remove-ai-marks
 ```
+
+The installer respects `CODEX_HOME`, `CLAUDE_HOME`, and `CURSOR_HOME`.
+Existing installations are preserved unless `--force` is passed; replacements
+are staged first and the previous installs are kept as uniquely named backups.
 
 Invoke with `/remove-ai-marks` or ask to “strip AI watermarks / C2PA / Claude marks / SynthID-class text.”
 
@@ -58,9 +71,7 @@ python3 install_skill.py
 ```
 
 On Windows, use `py install_skill.py`. The `install-skill.sh` wrapper is
-provided for macOS/Linux shells. Existing installations are preserved unless
-you pass `--force`; replacement is staged first and the previous install is
-kept as a uniquely named backup.
+provided for macOS/Linux shells.
 
 Skill invocation is model-selected. Projects that explicitly adopt this
 workflow can also copy the optional rule:
@@ -160,7 +171,7 @@ WM="http://127.0.0.1:8765"
 curl -s "$WM/health"                       # {"ok": true, "version": "..."}
 curl -s "$WM/openapi.json"                 # machine-readable OpenAPI 3.0.3 contract
 curl -s -X POST "$WM/clean" -H 'Content-Type: application/json' \
-  -d "{\"file\": \"$(base64 -w0 notes.md)\", \"name\": \"notes.md\"}"
+  -d "{\"file\": \"$(base64 < notes.md | tr -d '\r\n')\", \"name\": \"notes.md\"}"
 ```
 
 The service routes by filename extension then magic bytes, so text / image / container are auto-detected. Set `WATERMARKS_SERVER_API_KEY` to require `Authorization: Bearer <key>` on every request. Loopback-only bind by default (`--host` to override); intended for a trusted network.
@@ -213,7 +224,7 @@ Checks `wr-core` via `GET /health` and runs each harness/heavy service with `--h
 ```bash
 echo "Hello\u200bWorld\u00ad!" > /tmp/sample.txt
 curl -s -X POST http://127.0.0.1:8765/clean -H 'Content-Type: application/json' \
-  -d "{\"file\": \"$(base64 -w0 /tmp/sample.txt)\", \"name\": \"sample.txt\"}"
+  -d "{\"file\": \"$(base64 < /tmp/sample.txt | tr -d '\r\n')\", \"name\": \"sample.txt\"}"
 ```
 
 Everything else is optional and lives in a `.env` file at the repo root. `docker compose` **auto-loads `.env`** and interpolates the `${VAR}` references in `compose.yaml` from it (shell exports win over `.env` if both are set).

--- a/install_skill.py
+++ b/install_skill.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Install the lightweight text skill for Cursor."""
+"""Install a bundled skill for Codex, Claude, or Cursor."""
 
 from __future__ import annotations
 
@@ -11,9 +11,15 @@ import tempfile
 import uuid
 from pathlib import Path
 
-SKILL_NAME = "clean-user-facing-text"
 ROOT = Path(__file__).resolve().parent
-SOURCE = ROOT / "skills" / SKILL_NAME
+DEFAULT_SKILL_NAME = "clean-user-facing-text"
+SKILL_NAMES = (DEFAULT_SKILL_NAME, "remove-ai-marks")
+TARGETS = ("codex", "claude", "cursor")
+TARGET_SETTINGS = {
+    "codex": ("CODEX_HOME", ".codex"),
+    "claude": ("CLAUDE_HOME", ".claude"),
+    "cursor": ("CURSOR_HOME", ".cursor"),
+}
 
 
 def _present(path: Path) -> bool:
@@ -27,14 +33,14 @@ def _remove_path(path: Path) -> None:
         shutil.rmtree(path)
 
 
-def _stage(skills_dir: Path) -> tuple[Path, Path]:
+def _stage(skills_dir: Path, source: Path, skill_name: str) -> tuple[Path, Path]:
     skills_dir.mkdir(parents=True, exist_ok=True)
     staging_root = Path(
-        tempfile.mkdtemp(prefix=f".{SKILL_NAME}.staging.", dir=skills_dir)
+        tempfile.mkdtemp(prefix=f".{skill_name}.staging.", dir=skills_dir)
     )
-    staged_skill = staging_root / SKILL_NAME
+    staged_skill = staging_root / skill_name
     try:
-        shutil.copytree(SOURCE, staged_skill)
+        shutil.copytree(source, staged_skill)
         if not (staged_skill / "SKILL.md").is_file():
             raise RuntimeError("staged skill is missing SKILL.md")
     except BaseException:
@@ -43,7 +49,9 @@ def _stage(skills_dir: Path) -> tuple[Path, Path]:
     return staging_root, staged_skill
 
 
-def _install(destination: Path, force: bool) -> tuple[bool, Path | None]:
+def _install(
+    destination: Path, source: Path, force: bool
+) -> tuple[bool, Path | None]:
     if _present(destination) and not force:
         print(f"already exists: {destination}", file=sys.stderr)
         print(
@@ -52,7 +60,7 @@ def _install(destination: Path, force: bool) -> tuple[bool, Path | None]:
         )
         return False, None
 
-    staging_root, staged_skill = _stage(destination.parent)
+    staging_root, staged_skill = _stage(destination.parent, source, destination.name)
     backup: Path | None = None
     try:
         if _present(destination):
@@ -72,29 +80,69 @@ def _install(destination: Path, force: bool) -> tuple[bool, Path | None]:
     return True, backup
 
 
+def _agent_home(target: str, override: str | None) -> Path:
+    environment_name, default_directory = TARGET_SETTINGS[target]
+    configured = override or os.environ.get(environment_name)
+    return Path(configured or Path.home() / default_directory).expanduser()
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
+        "--target",
+        choices=(*TARGETS, "all"),
+        default="cursor",
+        help="Agent to install for (default: cursor)",
+    )
+    parser.add_argument(
+        "--skill",
+        choices=SKILL_NAMES,
+        default=DEFAULT_SKILL_NAME,
+        help=f"Bundled skill to install (default: {DEFAULT_SKILL_NAME})",
+    )
+    parser.add_argument(
         "--force",
         action="store_true",
-        help="Back up and replace an existing Cursor installation",
+        help="Back up and replace existing installations",
     )
     parser.add_argument("--cursor-home", help="Override Cursor home (default: ~/.cursor)")
+    parser.add_argument("--codex-home", help="Override Codex home (default: ~/.codex)")
+    parser.add_argument("--claude-home", help="Override Claude home (default: ~/.claude)")
     args = parser.parse_args()
 
-    cursor_home = Path(
-        args.cursor_home
-        or os.environ.get("CURSOR_HOME", Path.home() / ".cursor")
-    ).expanduser()
-    destination = cursor_home / "skills" / SKILL_NAME
+    selected_targets = TARGETS if args.target == "all" else (args.target,)
+    overrides = {
+        "codex": args.codex_home,
+        "claude": args.claude_home,
+        "cursor": args.cursor_home,
+    }
+    source = ROOT / "skills" / args.skill
+    destinations = {
+        target: _agent_home(target, overrides[target]) / "skills" / args.skill
+        for target in selected_targets
+    }
 
-    installed, backup = _install(destination, args.force)
-    if not installed:
-        return 1
-    if backup is not None:
-        print(f"Cursor: backed up existing skill to {backup}")
-    print(f"Cursor: installed {destination}")
-    print("Start a new Cursor session if the skill does not appear automatically.")
+    if not args.force:
+        existing = [path for path in destinations.values() if _present(path)]
+        if existing:
+            for path in existing:
+                print(f"already exists: {path}", file=sys.stderr)
+            print(
+                "No changes made. Re-run with --force to back up and replace.",
+                file=sys.stderr,
+            )
+            return 1
+
+    for target, destination in destinations.items():
+        installed, backup = _install(destination, source, args.force)
+        if not installed:
+            return 1
+        label = target.capitalize()
+        if backup is not None:
+            print(f"{label}: backed up existing skill to {backup}")
+        print(f"{label}: installed {destination}")
+
+    print("Start a new agent session if the skill does not appear automatically.")
     return 0
 
 

--- a/skills/remove-ai-marks/SKILL.md
+++ b/skills/remove-ai-marks/SKILL.md
@@ -86,14 +86,14 @@ clients.
 
 ```bash
 curl -s -X POST "$WM/inspect" -H 'Content-Type: application/json' \
-  -d "{\"file\": \"$(base64 -w0 notes.md)\", \"name\": \"notes.md\"}"
+  -d "{\"file\": \"$(base64 < notes.md | tr -d '\r\n')\", \"name\": \"notes.md\"}"
 ```
 
 **Clean** (text / image / container are auto-detected by name + bytes):
 
 ```bash
 curl -s -X POST "$WM/clean" -H 'Content-Type: application/json' \
-  -d "{\"file\": \"$(base64 -w0 notes.md)\", \"name\": \"notes.md\"}"
+  -d "{\"file\": \"$(base64 < notes.md | tr -d '\r\n')\", \"name\": \"notes.md\"}"
 ```
 
 Decode the returned `cleaned` base64 into the output file (`*.cleaned.*` by
@@ -126,7 +126,7 @@ mostly just send the file.
 
 ```bash
 curl -s -X POST "$WM/inspect" -H 'Content-Type: application/json' \
-  -d "{\"file\": \"$(base64 -w0 path)\", \"name\": \"$(basename path)\"}"
+  -d "{\"file\": \"$(base64 < path | tr -d '\r\n')\", \"name\": \"$(basename path)\"}"
 ```
 
 Show a short summary (suspicious codepoints; C2PA/AI flags; confidence labels
@@ -144,7 +144,7 @@ local detector is an official vendor detector.
 
 ```bash
 curl -s -X POST "$WM/clean" -H 'Content-Type: application/json' \
-  -d "{\"file\": \"$(base64 -w0 INPUT)\", \"name\": \"$(basename INPUT)\"}"
+  -d "{\"file\": \"$(base64 < INPUT | tr -d '\r\n')\", \"name\": \"$(basename INPUT)\"}"
 ```
 
 Decode `cleaned` → `OUTPUT` (`*.cleaned.*` unless the user asked in-place).
@@ -158,7 +158,7 @@ says the backend is present:
 
 ```bash
 curl -s -X POST "$WM/clean" -H 'Content-Type: application/json' \
-  -d "{\"file\": \"$(base64 -w0 shot.png)\", \"name\": \"shot.png\", \
+  -d "{\"file\": \"$(base64 < shot.png | tr -d '\r\n')\", \"name\": \"shot.png\", \
        \"options\": {\"remove_pixel\": \"ctrlregen\"}}"
 ```
 

--- a/skills/remove-ai-marks/agents/openai.yaml
+++ b/skills/remove-ai-marks/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Remove AI Marks"
+  short_description: "Inspect and clean authorized AI provenance marks"
+  default_prompt: "Use $remove-ai-marks to inspect and clean authorized AI provenance marks from this file."

--- a/tests/test_agent_skill_installer.py
+++ b/tests/test_agent_skill_installer.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL_NAME = "remove-ai-marks"
+
+
+def _run_installer(home: Path, *args: str, check: bool = True):
+    env = os.environ.copy()
+    for variable in ("CLAUDE_HOME", "CODEX_HOME", "CURSOR_HOME"):
+        env.pop(variable, None)
+    env.update({"HOME": str(home), "USERPROFILE": str(home)})
+    return subprocess.run(
+        [sys.executable, str(ROOT / "install_skill.py"), *args],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=check,
+    )
+
+
+def test_installs_remove_ai_marks_for_codex(tmp_path):
+    codex_home = tmp_path / "codex-home"
+
+    _run_installer(
+        tmp_path,
+        "--target",
+        "codex",
+        "--skill",
+        SKILL_NAME,
+        "--codex-home",
+        str(codex_home),
+    )
+
+    installed = codex_home / "skills" / SKILL_NAME
+    assert (installed / "SKILL.md").is_file()
+    assert (installed / "agents" / "openai.yaml").is_file()
+
+
+def test_installs_remove_ai_marks_for_claude(tmp_path):
+    claude_home = tmp_path / "claude-home"
+
+    _run_installer(
+        tmp_path,
+        "--target",
+        "claude",
+        "--skill",
+        SKILL_NAME,
+        "--claude-home",
+        str(claude_home),
+    )
+
+    installed = claude_home / "skills" / SKILL_NAME
+    assert (installed / "SKILL.md").is_file()
+    assert (installed / "references" / "ethics.md").is_file()
+
+
+def test_target_all_installs_every_agent_skill(tmp_path):
+    _run_installer(tmp_path, "--target", "all", "--skill", SKILL_NAME)
+
+    for agent_home in (".codex", ".claude", ".cursor"):
+        installed = tmp_path / agent_home / "skills" / SKILL_NAME
+        assert (installed / "SKILL.md").is_file()
+
+
+def test_codex_metadata_matches_remove_ai_marks_skill():
+    metadata = ROOT / "skills" / SKILL_NAME / "agents" / "openai.yaml"
+
+    assert metadata.is_file()
+    text = metadata.read_text(encoding="utf-8")
+    assert 'display_name: "Remove AI Marks"' in text
+    assert "$remove-ai-marks" in text
+
+
+def test_remove_ai_marks_skill_uses_portable_base64_commands():
+    skill_text = (ROOT / "skills" / SKILL_NAME / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "base64 -w0" not in skill_text
+    assert "tr -d '\\r\\n'" in skill_text


### PR DESCRIPTION
## What changed

- extend `install_skill.py` to install either bundled skill for Codex, Claude, Cursor, or every supported agent
- add Codex-facing `agents/openai.yaml` metadata for `remove-ai-marks`
- preserve the existing Cursor installer defaults and atomic backup behavior
- replace GNU-only `base64 -w0` examples with macOS/Linux-compatible commands
- document the new installation commands and add installer coverage

## Why

The full `remove-ai-marks` skill was documented only for Grok, while the installer handled only the lightweight Cursor skill. This makes the same agent-agnostic `SKILL.md` directly installable in Codex and Claude without duplicating the skill.

## User impact

Users can install the full skill with one command into `~/.codex/skills`, `~/.claude/skills`, or all supported agent homes. Existing installations remain untouched unless `--force` is passed.

## Validation

- `uv run --with-requirements requirements-dev.txt python -m pytest` — 285 passed, 1 skipped
- `quick_validate.py skills/remove-ai-marks` — valid
- focused installer tests cover Codex, Claude, all targets, backups, and metadata
