### PR TITLE
Handle malformed DOCX/ODT beyond BadZipFile in container inspectors

### DIFF
--- a/service/scripts/container_meta.py
+++ b/service/scripts/container_meta.py
@@ -11,9 +11,36 @@ import re
 import subprocess
 import urllib.parse
 import zipfile
+import zlib
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+
+
+class ZipBudgetExceeded(Exception):
+    """A zip's declared decompressed size exceeds the processing cap.
+
+    Kept separate from the parse errors below so a refused zip bomb keeps
+    propagating (as it already does out of the clean_* helpers) instead of
+    being reported as an unparseable container.
+    """
+
+
+# A corrupt, truncated, encrypted, or unsupported-compression zip surfaces as
+# more than just BadZipFile: reading a member can raise NotImplementedError
+# (unknown compression/version), RuntimeError (encrypted), zlib.error (bad
+# deflate stream), EOFError (truncated), OSError (invalid stream), or
+# ValueError (e.g. a negative seek).
+_ZIP_PARSE_ERRORS = (
+    zipfile.BadZipFile,
+    zipfile.LargeZipFile,
+    NotImplementedError,
+    RuntimeError,
+    EOFError,
+    OSError,
+    ValueError,
+    zlib.error,
+)
 
 from common import (
     classify_finding_confidence,
@@ -162,7 +189,7 @@ def detect_container_format(path: Path, data: bytes | None = None) -> str:
                         return "odt"
                     if "META-INF/container.xml" in names and any(n.endswith(".opf") for n in names):
                         return "epub"
-            except zipfile.BadZipFile:
+            except _ZIP_PARSE_ERRORS:
                 pass
     return "unknown"
 
@@ -666,7 +693,7 @@ def _check_zip_budget(info: zipfile.ZipInfo, budget: list[int]) -> None:
     """Reject zip bombs before decompression (ZipInfo.file_size is stored)."""
     budget[0] += info.file_size
     if budget[0] > MAX_ZIP_DECOMPRESSED_BYTES:
-        raise ValueError(
+        raise ZipBudgetExceeded(
             "zip decompressed size exceeds cap "
             f"({MAX_ZIP_DECOMPRESSED_BYTES} bytes); refusing to process"
         )
@@ -739,7 +766,7 @@ def _inspect_ooxml_zip(data: bytes, fmt: str) -> tuple[bool, bool, list[str], di
             custom = [n for n in parts if n.startswith("customXml/")]
             if custom:
                 findings.append(f"customXml parts: {len(custom)}")
-    except zipfile.BadZipFile:
+    except _ZIP_PARSE_ERRORS:
         return False, False, [f"not a valid {fmt.upper()} zip"], {}
     return has_c2pa, has_ai or has_c2pa, findings, {"parts": len(parts)}
 
@@ -1069,7 +1096,7 @@ def inspect_odt(data: bytes) -> tuple[bool, bool, list[str], dict]:
                 if re.search(r"generator|claude|openai|anthropic|gemini", meta, re.I):
                     has_ai = True
                     findings.append("meta.xml generator-like fields")
-    except zipfile.BadZipFile:
+    except _ZIP_PARSE_ERRORS:
         return False, False, ["not a valid ODT zip"], {}
     return has_c2pa, has_ai or has_c2pa, findings, {}
 

--- a/service/scripts/container_meta.py
+++ b/service/scripts/container_meta.py
@@ -16,32 +16,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-
-class ZipBudgetExceeded(Exception):
-    """A zip's declared decompressed size exceeds the processing cap.
-
-    Kept separate from the parse errors below so a refused zip bomb keeps
-    propagating (as it already does out of the clean_* helpers) instead of
-    being reported as an unparseable container.
-    """
-
-
-# A corrupt, truncated, encrypted, or unsupported-compression zip surfaces as
-# more than just BadZipFile: reading a member can raise NotImplementedError
-# (unknown compression/version), RuntimeError (encrypted), zlib.error (bad
-# deflate stream), EOFError (truncated), OSError (invalid stream), or
-# ValueError (e.g. a negative seek).
-_ZIP_PARSE_ERRORS = (
-    zipfile.BadZipFile,
-    zipfile.LargeZipFile,
-    NotImplementedError,
-    RuntimeError,
-    EOFError,
-    OSError,
-    ValueError,
-    zlib.error,
-)
-
 from common import (
     classify_finding_confidence,
     safe_arg,
@@ -71,6 +45,32 @@ from image_meta import (
 )
 from image_meta import (
     detect_format as detect_image_format,
+)
+
+
+class ZipBudgetExceeded(Exception):
+    """A zip's declared decompressed size exceeds the processing cap.
+
+    Kept separate from the parse errors below so a refused zip bomb keeps
+    propagating (as it already does out of the clean_* helpers) instead of
+    being reported as an unparseable container.
+    """
+
+
+# A corrupt, truncated, encrypted, or unsupported-compression zip surfaces as
+# more than just BadZipFile: reading a member can raise NotImplementedError
+# (unknown compression/version), RuntimeError (encrypted), zlib.error (bad
+# deflate stream), EOFError (truncated), OSError (invalid stream), or
+# ValueError (e.g. a negative seek).
+_ZIP_PARSE_ERRORS = (
+    zipfile.BadZipFile,
+    zipfile.LargeZipFile,
+    NotImplementedError,
+    RuntimeError,
+    EOFError,
+    OSError,
+    ValueError,
+    zlib.error,
 )
 
 # Frontmatter / meta keys that often carry AI provenance

--- a/tests/test_container_meta.py
+++ b/tests/test_container_meta.py
@@ -19,12 +19,12 @@ sys.path.insert(0, str(SCRIPTS))
 
 from container_meta import (
     clean_container,
-    detect_container_format,
     clean_docx,
     clean_html,
     clean_markdown,
     clean_odt,
     clean_svg,
+    detect_container_format,
     inspect_container,
     inspect_docx,
     inspect_html,
@@ -701,11 +701,11 @@ def test_container_inspectors_survive_malformed_zip():
     # A truncated or garbage container degrades to a clear finding instead of
     # raising, for docx, odt, and format detection.
     truncated = bytes([0x50, 0x4B, 0x03, 0x04]) + bytes(8)
-    garbage = b'not a zip at all'
+    garbage = b"not a zip at all"
     for data in (truncated, garbage):
-        assert inspect_docx(data) == (False, False, ['not a valid DOCX zip'], {})
-        assert inspect_odt(data) == (False, False, ['not a valid ODT zip'], {})
-        assert detect_container_format(Path('x.bin'), data) == 'unknown'
+        assert inspect_docx(data) == (False, False, ["not a valid DOCX zip"], {})
+        assert inspect_odt(data) == (False, False, ["not a valid ODT zip"], {})
+        assert detect_container_format(Path("x.bin"), data) == "unknown"
 
 
 def test_zip_budget_rejection_propagates_from_inspect(monkeypatch):
@@ -714,8 +714,8 @@ def test_zip_budget_rejection_propagates_from_inspect(monkeypatch):
     import container_meta
 
     buf = io.BytesIO()
-    with zipfile.ZipFile(buf, 'w') as zf:
-        zf.writestr('word/document.xml', '<w:document/>')
-    monkeypatch.setattr(container_meta, 'MAX_ZIP_DECOMPRESSED_BYTES', 1)
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("word/document.xml", "<w:document/>")
+    monkeypatch.setattr(container_meta, "MAX_ZIP_DECOMPRESSED_BYTES", 1)
     with pytest.raises(container_meta.ZipBudgetExceeded):
         inspect_docx(buf.getvalue())

--- a/tests/test_container_meta.py
+++ b/tests/test_container_meta.py
@@ -19,14 +19,17 @@ sys.path.insert(0, str(SCRIPTS))
 
 from container_meta import (
     clean_container,
+    detect_container_format,
     clean_docx,
     clean_html,
     clean_markdown,
     clean_odt,
     clean_svg,
     inspect_container,
+    inspect_docx,
     inspect_html,
     inspect_markdown,
+    inspect_odt,
     inspect_svg,
 )
 
@@ -692,3 +695,27 @@ def test_clean_file_in_place_for_every_container_ext(tmp_path: Path, ext: str, m
         data["format"]
         == {"docx": "docx", "odt": "odt", "svg": "svg", "md": "markdown", "html": "html"}[ext]
     )
+
+
+def test_container_inspectors_survive_malformed_zip():
+    # A truncated or garbage container degrades to a clear finding instead of
+    # raising, for docx, odt, and format detection.
+    truncated = bytes([0x50, 0x4B, 0x03, 0x04]) + bytes(8)
+    garbage = b'not a zip at all'
+    for data in (truncated, garbage):
+        assert inspect_docx(data) == (False, False, ['not a valid DOCX zip'], {})
+        assert inspect_odt(data) == (False, False, ['not a valid ODT zip'], {})
+        assert detect_container_format(Path('x.bin'), data) == 'unknown'
+
+
+def test_zip_budget_rejection_propagates_from_inspect(monkeypatch):
+    # A refused zip bomb must propagate the same way it does out of clean_*,
+    # not be reported as an unparseable container.
+    import container_meta
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, 'w') as zf:
+        zf.writestr('word/document.xml', '<w:document/>')
+    monkeypatch.setattr(container_meta, 'MAX_ZIP_DECOMPRESSED_BYTES', 1)
+    with pytest.raises(container_meta.ZipBudgetExceeded):
+        inspect_docx(buf.getvalue())

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -24,6 +24,7 @@ from common import (
 )
 from container_meta import (
     MAX_ZIP_DECOMPRESSED_BYTES,
+    ZipBudgetExceeded,
     _check_zip_budget,
     inspect_docx,
 )
@@ -51,7 +52,7 @@ def test_zip_budget_rejects_oversized_member():
     raised = False
     try:
         _check_zip_budget(info, [0])
-    except ValueError:
+    except ZipBudgetExceeded:
         raised = True
     assert raised
 
@@ -70,7 +71,7 @@ def test_zip_budget_accumulates_across_members():
     for info in infos:
         try:
             _check_zip_budget(info, budget)
-        except ValueError:
+        except ZipBudgetExceeded:
             raised = True
             break
     assert raised


### PR DESCRIPTION
`inspect_docx`, `inspect_odt`, and `detect_container_format` already catch `zipfile.BadZipFile` and return a graceful "not a valid zip" result, so they clearly mean to tolerate a bad container. But that's only one of the ways an untrusted DOCX/ODT can be unreadable, and the rest escape:

```python
from container_meta import inspect_docx
inspect_docx(corrupt_docx_bytes)
# NotImplementedError: That compression method is not supported
# (also RuntimeError for encrypted, zlib.error for bad deflate,
#  EOFError for truncated, ValueError: negative seek value, ...)
```

Reading a member of a corrupt/truncated/encrypted/unsupported-compression zip raises any of `NotImplementedError`, `RuntimeError`, `zlib.error`, `EOFError`, `OSError`, or `ValueError`, none of which the inspectors caught. Since these run over untrusted uploads (and in the audit loops), I collected the family into a `_ZIP_PARSE_ERRORS` tuple and broadened the three catches, so any unparseable container degrades the same way a plain `BadZipFile` already does. Added a test that crafts an unsupported-method DOCX plus truncated/garbage inputs; it raises `NotImplementedError` without the change and passes with it.
