### PR TITLE
feat: strip Unicode noncharacters in Layer A

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,6 +671,7 @@ make smoke                          # quick CLI smoke on fixtures
 
 ### Unreleased
 
+- **Strip Unicode noncharacters in Layer A**: the 66 noncharacters (`U+FDD0`–`U+FDEF` plus `U+FFFE`/`U+FFFF` at the end of every plane) are permanently reserved for internal use and prohibited in interchange text, render as nothing or tofu, and survive normalisation, yet both `inspect_text` and `clean_text` passed them through untouched: a ready-made covert channel. Layer A now strips them and inspect reports them under the new `noncharacter` kind. Unlike other reserved ranges they can never be assigned, so stripping carries no future-Unicode risk. Applied to both the service engine and the vendored lightweight-skill copy
 - **Fix `inspect` missing Layer A carriers in markdown/HTML**: `inspect_container` never scanned the document body, so a `.md` or `.html` file holding invisible Unicode came back `suspicious: false` while `clean_container` went on to strip it — the same bytes saved as `.txt` were correctly flagged. The scan now runs for exactly the formats `clean_container` scrubs, so inspect predicts clean. Container reports gain `suspicious_total` (the same key `TextInspectReport` uses, so the HTTP `suspicious` flag and the `inspect_file` exit code pick it up) and `layer_a_hits`
 
 ### [v0.5.0](https://github.com/guillaumemeyer/watermarks-remover/releases/tag/v0.5.0) — service & Docker distribution, HTTP API, and verification harnesses

--- a/service/scripts/text_unicode.py
+++ b/service/scripts/text_unicode.py
@@ -168,6 +168,15 @@ LATIN_CONFUSABLES: dict[int, str] = {
 _VS_SUPPLEMENT = range(0xE0100, 0xE01F0)
 
 
+# The 66 Unicode noncharacters: U+FDD0..U+FDEF plus U+nFFFE/U+nFFFF at the
+# end of every plane. Permanently reserved for internal use and prohibited in
+# interchange text (TUS 23.7), so any occurrence in interchange is contraband.
+# Rendered as nothing or tofu, preserved by normalisation, and permanently
+# unassignable, so stripping them carries no future-Unicode risk.
+def _is_noncharacter(cp: int) -> bool:
+    return 0xFDD0 <= cp <= 0xFDEF or (cp & 0xFFFE) == 0xFFFE
+
+
 # Bidi / directional format controls (subset of strip set, finer inspect labels)
 _BIDI_CPS: frozenset[int] = frozenset(
     {
@@ -220,6 +229,8 @@ def _is_strip_cp(cp: int) -> bool:
     # Tag characters used in some stego schemes (U+E0001–U+E007F)
     if 0xE0001 <= cp <= 0xE007F:
         return True
+    if _is_noncharacter(cp):
+        return True
     if _is_private_use(cp):
         return True
     return False
@@ -229,6 +240,8 @@ def _strip_kind(cp: int) -> str:
     """Finer-grained inspect kind for strip-class codepoints."""
     if 0xE0001 <= cp <= 0xE007F:
         return "tag_chars"
+    if _is_noncharacter(cp):
+        return "noncharacter"
     if cp in _VS_SUPPLEMENT or 0xFE00 <= cp <= 0xFE0F or 0x180B <= cp <= 0x180D:
         return "variation_selector"
     if cp in _BIDI_CPS:
@@ -469,7 +482,7 @@ class CharHit:
     char: str
     label: str
     count: int
-    kind: str  # strip | bidi | tag_chars | variation_selector | zwj_family | private_use | space | confusable | other_cf
+    kind: str  # strip | bidi | tag_chars | variation_selector | zwj_family | private_use | noncharacter | space | confusable | other_cf
     samples: list[int] = field(default_factory=list)  # character offsets
 
 

--- a/skills/clean-user-facing-text/scripts/text_unicode.py
+++ b/skills/clean-user-facing-text/scripts/text_unicode.py
@@ -167,6 +167,15 @@ LATIN_CONFUSABLES: dict[int, str] = {
 _VS_SUPPLEMENT = range(0xE0100, 0xE01F0)
 
 
+# The 66 Unicode noncharacters: U+FDD0..U+FDEF plus U+nFFFE/U+nFFFF at the
+# end of every plane. Permanently reserved for internal use and prohibited in
+# interchange text (TUS 23.7), so any occurrence in interchange is contraband.
+# Rendered as nothing or tofu, preserved by normalisation, and permanently
+# unassignable, so stripping them carries no future-Unicode risk.
+def _is_noncharacter(cp: int) -> bool:
+    return 0xFDD0 <= cp <= 0xFDEF or (cp & 0xFFFE) == 0xFFFE
+
+
 # Bidi / directional format controls (subset of strip set, finer inspect labels)
 _BIDI_CPS: frozenset[int] = frozenset(
     {
@@ -204,6 +213,8 @@ def _is_strip_cp(cp: int) -> bool:
     # Tag characters used in some stego schemes (U+E0001–U+E007F)
     if 0xE0001 <= cp <= 0xE007F:
         return True
+    if _is_noncharacter(cp):
+        return True
     if _is_private_use(cp):
         return True
     return False
@@ -213,6 +224,8 @@ def _strip_kind(cp: int) -> str:
     """Finer-grained inspect kind for strip-class codepoints."""
     if 0xE0001 <= cp <= 0xE007F:
         return "tag_chars"
+    if _is_noncharacter(cp):
+        return "noncharacter"
     if cp in _VS_SUPPLEMENT or 0xFE00 <= cp <= 0xFE0F or 0x180B <= cp <= 0x180D:
         return "variation_selector"
     if cp in _BIDI_CPS:
@@ -360,7 +373,7 @@ class CharHit:
     char: str
     label: str
     count: int
-    kind: str  # strip | bidi | tag_chars | variation_selector | zwj_family | private_use | space | confusable | other_cf
+    kind: str  # strip | bidi | tag_chars | variation_selector | zwj_family | private_use | noncharacter | space | confusable | other_cf
     samples: list[int] = field(default_factory=list)  # character offsets
 
 

--- a/skills/remove-ai-marks/references/mark-classes.md
+++ b/skills/remove-ai-marks/references/mark-classes.md
@@ -11,6 +11,7 @@ Invisible or near-invisible characters, exotic spaces, bidi controls, tag charac
 | `tag_chars` | U+E0001–U+E007F |
 | `variation_selector` | VS1–VS256 |
 | `private_use` | U+E000–F8FF, U+F0000–FFFFD, U+100000–10FFFD |
+| `noncharacter` | U+FDD0–FDEF, U+FFFE/U+FFFF at the end of every plane |
 | `space` | NBSP, em space, ideographic space |
 | `confusable` | Cyrillic/fullwidth Latin (aggressive) |
 

--- a/tests/test_clean_text.py
+++ b/tests/test_clean_text.py
@@ -303,3 +303,46 @@ def test_inspect_floating_script_glue_is_suspicious():
 def test_inspect_private_use():
     report = inspect_text("a\ue000b")
     assert any(h.kind == "private_use" for h in report.hits)
+
+
+# The 66 Unicode noncharacters: U+FDD0..U+FDEF plus U+nFFFE/U+nFFFF at the
+# end of every plane. Permanently reserved for internal use and prohibited in
+# interchange (TUS 23.7), rendered as nothing or tofu, preserved by
+# normalisation: covert carriers with no future-assignment risk at all.
+# Transcribed independently of the implementation table.
+NONCHARACTER_CPS = list(range(0xFDD0, 0xFDF0)) + [
+    plane << 16 | low for plane in range(0x11) for low in (0xFFFE, 0xFFFF)
+]
+
+
+def test_noncharacter_list_is_complete():
+    assert len(NONCHARACTER_CPS) == 66
+
+
+def test_clean_strips_noncharacters():
+    for cp in NONCHARACTER_CPS:
+        raw = "word" + chr(cp) + "word"
+        cleaned, stats = clean_text(raw)
+        assert cleaned == "wordword", f"U+{cp:04X} not stripped"
+        assert stats["removed_count"] == 1
+
+
+def test_inspect_reports_noncharacter_kind():
+    for cp in NONCHARACTER_CPS:
+        report = inspect_text("word" + chr(cp) + "word")
+        assert any(h.kind == "noncharacter" for h in report.hits), (
+            f"U+{cp:04X} not reported as noncharacter"
+        )
+
+
+def test_noncharacter_does_not_claim_assigned_neighbours():
+    # U+FDF0 (Arabic ligature) and U+FFFD (replacement character) sit right
+    # next to noncharacter ranges and must stay untouched and unclaimed.
+    for cp in (0xFDF0, 0xFFFD):
+        raw = "word" + chr(cp) + "word"
+        cleaned, _ = clean_text(raw)
+        assert cleaned == raw, f"U+{cp:04X} wrongly altered"
+        report = inspect_text(raw)
+        assert not any(h.kind == "noncharacter" for h in report.hits), (
+            f"U+{cp:04X} wrongly reported as noncharacter"
+        )

--- a/tests/test_lightweight_skill.py
+++ b/tests/test_lightweight_skill.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
@@ -24,6 +25,39 @@ def test_lightweight_clean_text_cli():
     assert result.stdout.rstrip("\n") == "Hello world again"
     assert '"removed_count": 1' in result.stderr
     assert '"replaced_count": 1' in result.stderr
+
+
+def test_lightweight_clean_strips_noncharacters():
+    # The vendored engine must match the service engine on the 66 Unicode
+    # noncharacters (U+FDD0..U+FDEF plus U+nFFFE/U+nFFFF in every plane).
+    cps = list(range(0xFDD0, 0xFDF0)) + [
+        plane << 16 | low for plane in range(0x11) for low in (0xFFFE, 0xFFFF)
+    ]
+    payload = "a" + "".join(map(chr, cps)) + "b"
+
+    cleaned = subprocess.run(
+        [sys.executable, str(SKILL / "scripts" / "clean_text.py"), "-", "--stats"],
+        input=payload,
+        text=True,
+        encoding="utf-8",
+        capture_output=True,
+        check=True,
+    )
+    assert cleaned.stdout.rstrip("\n") == "ab"
+    assert f'"removed_count": {len(cps)}' in cleaned.stderr
+
+    inspected = subprocess.run(
+        [sys.executable, str(SKILL / "scripts" / "inspect_text.py"), "-", "--json"],
+        input=payload,
+        text=True,
+        encoding="utf-8",
+        capture_output=True,
+        check=False,
+    )
+    assert inspected.returncode == 1  # suspicious input exits 1 by design
+    report = json.loads(inspected.stdout)
+    kinds = {hit["kind"] for hit in report["hits"]}
+    assert kinds == {"noncharacter"}
 
 
 def test_lightweight_skill_has_no_template_placeholders():


### PR DESCRIPTION
## Summary

The 66 Unicode noncharacters (U+FDD0-U+FDEF plus U+nFFFE/U+nFFFF at the end of every plane) currently pass through both `inspect_text` and `clean_text` completely untouched, even between plain ASCII. They are permanently reserved for internal use and prohibited in interchange text (TUS 23.7), render as nothing or tofu, and survive normalisation and Python round-trips: a ready-made covert channel that category-based (`Cf`) scrubbing never sees, because they are category `Cn`.

This PR strips them in Layer A and reports them under a new `noncharacter` inspect kind. Unlike other reserved ranges, noncharacters can never be assigned, so stripping carries no future-Unicode risk at all.

## Changes

- `service/scripts/text_unicode.py` and the vendored copy in `skills/clean-user-facing-text/scripts/text_unicode.py`: new `_is_noncharacter` predicate (`U+FDD0-FDEF`, or `(cp & 0xFFFE) == 0xFFFE` covering `U+nFFFE`/`U+nFFFF` in all 17 planes), wired into the strip set and the inspect kind mapping.
- `tests/test_clean_text.py`: exhaustive sweep of all 66 code points through clean and inspect, a completeness check on the list itself, and a boundary test pinning the assigned neighbours U+FDF0 (Arabic ligature) and U+FFFD (replacement character) as untouched and unclaimed.
- `tests/test_lightweight_skill.py`: the vendored engine's CLIs are swept with all 66 code points end to end (clean output, removal count, inspect kind, and the suspicious exit code).
- Docs: `noncharacter` row in the Layer A kind table (`skills/remove-ai-marks/references/mark-classes.md`) and a README changelog entry under Unreleased.

## Test plan

- New tests were written first and verified to fail against the unpatched engines (both service and vendored), then pass with the change.
- Full suite: 283 passed, 3 skipped (pre-existing) on Windows; CI covers Ubuntu + Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)