### PR TITLE
feat: self-contained skill bundle for Claude Desktop (sandboxed, serverless)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,17 @@
 !/docs/**
 !/service/
 !/service/**
+# git never descends into an excluded directory, so /skills/ itself must be
+# re-included before per-skill rules can match anything beneath it.
+!/skills/
+/skills/*
+!/skills/clean-user-facing-text/
+!/skills/clean-user-facing-text/**
 !/skills/remove-ai-marks/
 !/skills/remove-ai-marks/**
+!/skills/remove-ai-marks-desktop/
+!/skills/remove-ai-marks-desktop/**
+!/package_desktop_skill.py
 !/tests/
 !/tests/**
 !/.dockerignore

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 	smoke-markllm bootstrap-markllm docker-markllm-build docker-markllm-help \
 	smoke-markdiffusion bootstrap-markdiffusion docker-markdiffusion-build docker-markdiffusion-help \
 	docker-core-build docker-core-help serve compose-up compose-up-heavy compose-check \
-	install-skill install-cursor-text-skill clean
+	install-skill install-cursor-text-skill desktop-skill clean
 
 SCRIPTS := service/scripts
 PYTHON ?= $(shell if [ -x .venv/bin/python ]; then echo .venv/bin/python; else echo python3; fi)
@@ -112,6 +112,10 @@ install-skill:
 
 install-cursor-text-skill:
 	$(PYTHON) install_skill.py
+
+# Self-contained skill zip for Claude Desktop (sandboxed, no host network).
+desktop-skill:
+	$(PYTHON) package_desktop_skill.py
 
 clean:
 	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -45,6 +45,27 @@ ln -sfn "$(pwd)/skills/remove-ai-marks" ~/.grok/skills/remove-ai-marks
 
 Invoke with `/remove-ai-marks` or ask to “strip AI watermarks / C2PA / Claude marks / SynthID-class text.”
 
+### Claude Desktop (sandboxed) skill
+
+Claude Desktop runs skills inside a sandboxed VM that cannot reach servers on
+the host, so the HTTP-client skill above does not work there. Package the
+self-contained variant instead:
+
+```bash
+make desktop-skill        # or: python3 package_desktop_skill.py
+```
+
+This writes `dist/remove-ai-marks-desktop.zip` with the full stdlib cleaning
+engine copied fresh from `service/scripts/` (single source of truth, nothing
+vendored) plus a Desktop-specific `SKILL.md`
+([`skills/remove-ai-marks-desktop/`](skills/remove-ai-marks-desktop/)) that
+drives the CLIs directly. Import the zip in Claude Desktop under Settings >
+Capabilities > Skills.
+
+In-sandbox degradations are documented in the skill itself: PDF strips are
+best-effort without `exiftool`/`qpdf`, and the heavy pixel/scoring backends are
+unavailable.
+
 ### Optional Cursor text-only skill
 
 [`skills/clean-user-facing-text/`](skills/clean-user-facing-text/) is a
@@ -671,6 +692,7 @@ make smoke                          # quick CLI smoke on fixtures
 
 ### Unreleased
 
+- **Self-contained skill bundle for Claude Desktop**: Desktop runs skills in a sandboxed VM with no route to a host-side service, so the HTTP-client skill could never reach `127.0.0.1:8765` there. New `package_desktop_skill.py` (and `make desktop-skill`) assembles `dist/remove-ai-marks-desktop.zip`: a Desktop-specific `SKILL.md` (`skills/remove-ai-marks-desktop/`) that drives the unified CLIs directly, the shared references, and the stdlib engine scripts copied fresh from `service/scripts/` at build time, so there are no vendored duplicates to drift. Bundled scope: text Layer A, image/container metadata, directory audits, and Layer B via the offline `print-prompt` backend; the skill states the sandbox degradations (best-effort PDF without `exiftool`/`qpdf`, no pixel/scoring backends) up front
 - **Fix `inspect` missing Layer A carriers in markdown/HTML**: `inspect_container` never scanned the document body, so a `.md` or `.html` file holding invisible Unicode came back `suspicious: false` while `clean_container` went on to strip it — the same bytes saved as `.txt` were correctly flagged. The scan now runs for exactly the formats `clean_container` scrubs, so inspect predicts clean. Container reports gain `suspicious_total` (the same key `TextInspectReport` uses, so the HTTP `suspicious` flag and the `inspect_file` exit code pick it up) and `layer_a_hits`
 
 ### [v0.5.0](https://github.com/guillaumemeyer/watermarks-remover/releases/tag/v0.5.0) — service & Docker distribution, HTTP API, and verification harnesses

--- a/package_desktop_skill.py
+++ b/package_desktop_skill.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Package the self-contained remove-ai-marks skill for Claude Desktop.
+
+Claude Desktop runs skills inside a sandboxed VM that cannot reach servers on
+the host, so the HTTP-client skill (skills/remove-ai-marks) does not work
+there. This script assembles a zip whose scripts are copied fresh from
+service/scripts at build time: one source of truth, no vendored duplicates.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import zipfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+SKILL_SOURCE = ROOT / "skills" / "remove-ai-marks-desktop"
+REFERENCES_SOURCE = ROOT / "skills" / "remove-ai-marks" / "references"
+SCRIPTS_SOURCE = ROOT / "service" / "scripts"
+
+# Folder name inside the zip; matches the frontmatter name so Desktop imports
+# it as a drop-in replacement for the HTTP-client skill.
+SKILL_DIR_IN_ZIP = "remove-ai-marks"
+DEFAULT_OUT = ROOT / "dist" / "remove-ai-marks-desktop.zip"
+
+# Stdlib-only modules reachable from the unified CLIs, plus the offline-capable
+# extras (audit_dir for folders, rewrite_text's print-prompt backend for
+# Layer B). server.py, audit_website.py and every optional heavy backend stay
+# out: they need the host network or external checkouts the sandbox lacks.
+BUNDLED_SCRIPTS = [
+    "audit_dir.py",
+    "audit_lib.py",
+    "clean_file.py",
+    "clean_text.py",
+    "common.py",
+    "container_meta.py",
+    "format_dispatch.py",
+    "image_meta.py",
+    "inspect_file.py",
+    "inspect_text.py",
+    "rewrite_text.py",
+    "score_stylometry.py",
+    "text_unicode.py",
+]
+
+
+def build_zip(out: Path) -> Path:
+    skill_md = SKILL_SOURCE / "SKILL.md"
+    if not skill_md.is_file():
+        raise FileNotFoundError(f"missing {skill_md}")
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.write(skill_md, f"{SKILL_DIR_IN_ZIP}/SKILL.md")
+        for ref in sorted(REFERENCES_SOURCE.glob("*.md")):
+            zf.write(ref, f"{SKILL_DIR_IN_ZIP}/references/{ref.name}")
+        for name in BUNDLED_SCRIPTS:
+            src = SCRIPTS_SOURCE / name
+            if not src.is_file():
+                raise FileNotFoundError(f"missing bundled script: {src}")
+            zf.write(src, f"{SKILL_DIR_IN_ZIP}/scripts/{name}")
+    return out
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--out",
+        type=Path,
+        default=DEFAULT_OUT,
+        help=f"Output zip path (default: {DEFAULT_OUT.relative_to(ROOT)})",
+    )
+    args = p.parse_args()
+    path = build_zip(args.out)
+    print(f"wrote {path}")
+    print("Import it in Claude Desktop: Settings > Capabilities > Skills > Upload skill.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/remove-ai-marks-desktop/SKILL.md
+++ b/skills/remove-ai-marks-desktop/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: remove-ai-marks
+description: >
+  Remove multi-vendor AI provenance marks: invisible Unicode (Layer A), statistical
+  text watermarks via rewrite (Layer B, always offer), and C2PA/EXIF/XMP/container
+  metadata on PNG/JPEG/WebP/SVG/PDF/DOCX/ODT/HTML/MD. Covers Claude, Gemini/SynthID-class,
+  OpenAI provenance, and open-LLM sampling marks. Use when the user asks to strip
+  watermarks, remove C2PA/Content Credentials, clean AI metadata, remove invisible
+  Unicode, anti-detect clean AI output, or runs /remove-ai-marks (aliases:
+  /remove-claude-marks).
+---
+
+# Remove AI marks (self-contained)
+
+Multi-vendor anti-detection hygiene for **text** (Unicode + statistical rewrite) and **files** (C2PA / AI metadata across common containers).
+
+Read if needed:
+
+- `references/mark-classes.md`: Unicode / sampling / C2PA / containers
+- `references/vendor-notes.md`: Claude, Gemini/SynthID, OpenAI, open-LLM
+- `references/removal-matrix.md`: which layer when
+- `references/ethics.md`: intended use
+- `references/how-claude-marks.md`: Anthropic-specific detail
+
+This is the **self-contained** variant of the skill for sandboxed environments
+(Claude Desktop and similar) that cannot reach a host HTTP service. All
+cleaning machinery is bundled in `scripts/` (pure Python 3.10+ standard
+library, no pip installs). Run the scripts directly with `python`; never try to
+call an HTTP service.
+
+## Known degradations in the sandbox
+
+State these honestly when relevant; never silently pretend full capability:
+
+- **PDF**: a real strip needs `exiftool` and then `qpdf`. Without them the
+  clean still runs but is best-effort, and the report says so ("degraded").
+  Offer the user the option to run the full clean on a host with those tools.
+- **Layer B**: no model backends are reachable; use the agent-as-rewriter
+  prompts below (this is the normal path anyway).
+- **Pixel-domain image watermark removal** (CtrlRegen / DiffusionPurification)
+  and **SynthID scoring** are unavailable: they need external heavy backends.
+  Do not offer them.
+
+## Workflow
+
+### 1. Classify input
+
+| Input | Route |
+| --- | --- |
+| Pasted / clipboard text | write to a temp file, then inspect + clean |
+| `.txt` / code | text Layer A (+ formatter for code) |
+| `.md` / `.html` | container clean (frontmatter/meta) + Layer A |
+| `.png` / `.jpg` / `.jpeg` / `.webp` / `.avif` / `.heic` | image metadata strip |
+| `.svg` / `.pdf` / `.docx` / `.odt` | container metadata strip |
+| Directory | aggregate audit via `scripts/audit_dir.py` |
+
+The scripts route by filename extension first, then by magic bytes, so you
+mostly just pass the file to the unified CLIs.
+
+### 2. Inspect first (decide, don't guess)
+
+```bash
+python scripts/inspect_file.py INPUT --json
+```
+
+Exit code 0 means nothing suspicious; 1 means findings. Show a short summary
+(suspicious codepoints; C2PA/AI flags; confidence labels `confirmed` /
+`probable` / `informational` / `likely_false_positive`).
+
+For plain text there is also `python scripts/inspect_text.py INPUT`, which adds
+a stylometry score (statistical hints only, never proof).
+
+### 3. Deterministic clean (always for matching inputs)
+
+```bash
+python scripts/clean_file.py INPUT --json
+```
+
+This writes `INPUT.cleaned.EXT` next to the input (use `-o OUTPUT` or
+`--in-place` if the user asks). Re-inspect the result when residual risk
+matters:
+
+```bash
+python scripts/inspect_file.py INPUT.cleaned.EXT --json
+```
+
+Useful options: `--nfkc` and `--aggressive-homoglyphs` (text),
+`--keep-non-ai-metadata` (images), `--force-text` (override the binary guard).
+
+**Directories:**
+
+```bash
+python scripts/audit_dir.py DIR --json
+```
+
+### 4. Layer B: always offer rewrite (prose)
+
+After Layer A, **always propose** a statistical-mark reduction pass for
+natural-language content. Do not skip this step silently.
+
+There is no rewrite model bundled: **you** are the rewrite model. Run the
+prompts below on the cleaned text with a model **≠ suspected origin** (Claude
+text → not Claude; Gemini → not Gemini; etc.). When you cannot switch models,
+say so and note the reduced effectiveness.
+
+Multi-pass recipe:
+
+1. Layer A clean (`clean_file.py`)
+2. Paraphrase (default): explicit word-choice + syntax churn: change clause order, connectors, transition words, and sentence boundaries; replace content and function words where meaning allows; preserve facts, numbers, names, code IDs
+3. Optional strong pass: `humanize` (natural-human prose), back-translate, or structural outline→regen
+4. Layer A again on the result (`clean_file.py`)
+5. Report residual risk honestly (short/highly predictable text = lower; long, high-entropy prose = higher)
+
+**Code files:** Prefer formatter (`prettier`, `black`, `gofmt`, …) + Layer A. Offer a code-rewrite pass (comments/docstrings/string-literal wording + local identifier renames) with explicit user OK, since renaming identifiers is behavior-adjacent.
+
+#### Rewrite prompts (use as-is)
+
+**Paraphrase preserve meaning (word choice + syntax):**
+
+```
+Rewrite the following text so that it uses substantially different wording at
+the token level. Change clause order, connectors, and transition words; vary
+sentence boundaries and length; and replace both content words and function
+words where meaning allows. Preserve all facts, numbers, names, and technical
+identifiers. Do not add or remove claims. Output only the rewritten text.
+
+---
+{TEXT}
+```
+
+**Humanize (write like a human):**
+
+```
+Rewrite the following text so it reads as if a human wrote it from scratch.
+Vary sentence rhythm and length, replace formulaic AI-style transitions and
+filler with concrete natural phrasing, and use plain, varied wording. Preserve
+all facts, numbers, names, and technical identifiers. Do not add or remove
+claims. Output only the rewritten text.
+
+---
+{TEXT}
+```
+
+**Code (comments / docstrings / identifiers):**
+
+```
+Rewrite the natural-language parts of this code — comments, docstrings, and
+string literals — using different wording. Rename local variables, function
+parameters, and private helper names to semantically equivalent names. Preserve
+program behavior, public API names, and all values that affect output. Output
+only the rewritten code.
+
+---
+{TEXT}
+```
+
+**Back-translate (two steps):**
+
+```
+Translate the following text to {LANG}. Output only the translation.
+```
+
+```
+Translate the following text to {ORIGINAL_LANG}. Preserve meaning; use natural
+phrasing. Output only the translation.
+```
+
+**Structural:**
+
+```
+Extract a bullet outline of all claims and structure from the text (no full sentences).
+```
+
+Then:
+
+```
+Write a complete document from this outline in natural, varied human prose.
+Avoid formulaic transitions. Do not omit any bullet. Output only the document.
+```
+
+### 5. Report
+
+Always state:
+
+- What Layer A / container clean **verifiably** removed (counts, actions), taken from the JSON report.
+- What Layer B did (best-effort statistical; **cannot claim official "undetectable"**). Residual risk is lower for short/highly predictable text and higher for long, high-entropy prose.
+- Out of scope: pixel/audio/video SynthID, **C2PA soft binding**, secret-key detectors, training backdoors.
+- Soft binding / media watermarks may still be detectable by vendor tools after our strip.
+- Prefer writing `*.cleaned.*` unless the user asked in-place.
+- Ethics one-liner: own content / no compliance theatre.
+
+## Ethics
+
+Intended for **your own** content (privacy, hygiene, research). Do not market results as "proves human-written." If the user clearly wants academic fraud or illegal non-disclosure, warn using `references/ethics.md` and still only perform technical cleaning they own.
+
+## Limitations
+
+- Layer A does **not** remove token-sampling watermarks.
+- Layer B cannot be gold-verified without vendor detectors / keys.
+- PDF strip is best-effort without `exiftool`, and incomplete without `qpdf` (see degradations above).
+- Pixel-domain image watermarks, audio/video watermarks, and reverse-SynthID scoring are out of scope in this bundle.
+- **C2PA soft binding** (content watermark that re-links to a remote manifest after metadata strip) is out of scope: stripping hard-bound C2PA does not clear it.
+- Data-driven / backdoor model marks (trigger phrases) are out of scope.

--- a/tests/test_desktop_skill.py
+++ b/tests/test_desktop_skill.py
@@ -1,0 +1,117 @@
+"""Tests for the bundled Claude Desktop skill package.
+
+The Desktop variant is assembled at build time by package_desktop_skill.py:
+the engine scripts are copied fresh from service/scripts, so there are no
+vendored duplicates to keep in sync (unlike the Cursor skill).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from package_desktop_skill import BUNDLED_SCRIPTS, SKILL_DIR_IN_ZIP, build_zip  # noqa: E402
+
+REFERENCES = sorted(
+    p.name for p in (ROOT / "skills" / "remove-ai-marks" / "references").glob("*.md")
+)
+
+
+@pytest.fixture(scope="module")
+def built_zip(tmp_path_factory) -> Path:
+    out = tmp_path_factory.mktemp("desktop-skill") / "remove-ai-marks-desktop.zip"
+    return build_zip(out)
+
+
+def test_zip_member_list_is_exact(built_zip):
+    with zipfile.ZipFile(built_zip) as zf:
+        members = sorted(n for n in zf.namelist() if not n.endswith("/"))
+    expected = sorted(
+        [f"{SKILL_DIR_IN_ZIP}/SKILL.md"]
+        + [f"{SKILL_DIR_IN_ZIP}/references/{name}" for name in REFERENCES]
+        + [f"{SKILL_DIR_IN_ZIP}/scripts/{name}" for name in BUNDLED_SCRIPTS]
+    )
+    assert members == expected
+
+
+def test_zip_excludes_server_and_backend_files(built_zip):
+    with zipfile.ZipFile(built_zip) as zf:
+        names = zf.namelist()
+    for banned in ("server.py", "audit_website.py", "setup_", "requirements-"):
+        assert not any(banned in n for n in names), f"{banned} leaked into the bundle"
+
+
+def test_skill_md_frontmatter(built_zip):
+    with zipfile.ZipFile(built_zip) as zf:
+        raw = zf.read(f"{SKILL_DIR_IN_ZIP}/SKILL.md").decode("utf-8")
+    # Checkout may materialise the file with either line ending.
+    text = raw.replace("\r\n", "\n")
+    assert text.startswith("---\n")
+    frontmatter = text.split("---", 2)[1]
+    assert "name: remove-ai-marks" in frontmatter
+    assert "description:" in frontmatter
+    # The Desktop variant must not instruct HTTP use.
+    body = text.split("---", 2)[2]
+    assert "curl" not in body
+    assert "scripts/inspect_file.py" in body
+    assert "scripts/clean_file.py" in body
+
+
+def test_bundled_scripts_match_service_copies(built_zip):
+    with zipfile.ZipFile(built_zip) as zf:
+        for name in BUNDLED_SCRIPTS:
+            bundled = zf.read(f"{SKILL_DIR_IN_ZIP}/scripts/{name}")
+            service = (ROOT / "service" / "scripts" / name).read_bytes()
+            assert bundled == service, f"{name} differs from service copy"
+
+
+def test_extracted_bundle_is_self_contained(built_zip, tmp_path):
+    with zipfile.ZipFile(built_zip) as zf:
+        zf.extractall(tmp_path)
+    scripts = tmp_path / SKILL_DIR_IN_ZIP / "scripts"
+
+    sample = tmp_path / "sample.md"
+    sample.write_text("# Title\n\nbody​here\n", encoding="utf-8")
+
+    inspect = subprocess.run(
+        [sys.executable, str(scripts / "inspect_file.py"), str(sample), "--json"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    assert inspect.returncode == 1  # ZWSP present -> suspicious
+    report = json.loads(inspect.stdout)
+    assert report["kind"] == "container"
+
+    clean = subprocess.run(
+        [sys.executable, str(scripts / "clean_file.py"), str(sample), "--json"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    assert clean.returncode == 0, clean.stderr
+    cleaned = tmp_path / "sample.cleaned.md"
+    assert cleaned.is_file()
+    assert "​" not in cleaned.read_text(encoding="utf-8")
+
+
+def test_cli_writes_zip(tmp_path):
+    out = tmp_path / "bundle.zip"
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "package_desktop_skill.py"), "--out", str(out)],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    assert result.returncode == 0, result.stderr
+    assert out.is_file()
+    with zipfile.ZipFile(out) as zf:
+        assert f"{SKILL_DIR_IN_ZIP}/SKILL.md" in zf.namelist()


### PR DESCRIPTION
## Why

Claude Desktop runs skills inside a sandboxed VM whose network policy blocks all routes to the host, so the thin-client skill can never reach a local service on `127.0.0.1:8765` (nor a LAN address). The existing HTTP skill is therefore unusable in Desktop.

## What

- **`package_desktop_skill.py`** (+ `make desktop-skill`) assembles `dist/remove-ai-marks-desktop.zip` at build time: a Desktop-specific `SKILL.md` (`skills/remove-ai-marks-desktop/`), the shared `references/`, and the stdlib engine scripts copied fresh from `service/scripts/`. Nothing is vendored, so there are no duplicate engine copies to drift (unlike the Cursor skill, this variant wants byte-identical service behaviour, and a test enforces it).
- **`skills/remove-ai-marks-desktop/SKILL.md`**: same workflow as the HTTP skill (inspect first, deterministic clean, always offer Layer B, honest reporting) but drives `scripts/inspect_file.py` / `scripts/clean_file.py` directly. Sandbox degradations are stated up front: best-effort PDF without `exiftool`/`qpdf`, Layer B via the agent-as-rewriter prompts only, no pixel/scoring backends.
- **Bundled scope**: text Layer A, image metadata (PNG/JPEG/WebP/AVIF/HEIC), containers (SVG/DOCX/ODT/HTML/MD, PDF best-effort), stylometry, directory audits, `rewrite_text.py` print-prompt backend. Excluded: `server.py`, `audit_website.py`, every optional heavy backend and setup script.
- **Tests** (`tests/test_desktop_skill.py`): exact zip member list (backend/server files can never leak in), frontmatter validity, byte-equality of bundled scripts against the service copies, an extract-and-run smoke proving the bundle is self-contained, and the CLI entry point. Line-ending agnostic for the Windows runner.
- **`.gitignore` fix**: git never descends into an excluded directory, so the deny-by-default `/*` rule silently swallowed any *new* file under `skills/` despite the per-skill negations. `/skills/` is now re-included first, its children re-excluded, then each skill negated, and `skills/clean-user-facing-text/` gains the explicit allow it was missing.

## Testing

`python -m pytest`: 284 passed, 3 skipped (the usual optional-tool skips) on Windows; the new tests avoid platform-specific assumptions.

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)
