### PR TITLE
docs: fix grammar - parallel structure inconsistency in reporting list

### DIFF
--- a/skills/clean-user-facing-text/SKILL.md
+++ b/skills/clean-user-facing-text/SKILL.md
@@ -58,7 +58,7 @@ When prose and code are mixed, rewrite prose only. Never rename variables, alter
 When the user asks for an audit, distinguish:
 
 - **Verifiable:** Unicode characters removed or replaced, with script counts.
-- **Best-effort:** prose was rewritten to alter token and syntax patterns.
+- **Best-effort:** prose rewritten to alter token and syntax patterns.
 - **Not established:** official detector evasion, human authorship, or removal of a vendor's secret-key watermark.
 
 For technical background, read `references/watermark-notes.md`. For misuse or disclosure questions, read `references/responsible-use.md`.


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `skills/clean-user-facing-text/SKILL.md` (line 61).

## Problem

Parallel structure inconsistency: the bullet 'Best-effort: prose was rewritten...' uses a full sentence with passive verb 'was rewritten' while adjacent bullets use noun phrases ('Unicode characters removed or replaced' and 'official detector evasion, human authorship, or removal of a vendor\'s secret-key watermark'). The list should use parallel grammatical structure across all items.

The problematic text:
```markdown
- **Best-effort:** prose was rewritten to alter token and syntax patterns.
```

## Fix

Replaced with:
```markdown
- **Best-effort:** prose rewritten to alter token and syntax patterns.
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text

## Audit Metadata

| Field | Value |
|-------|-------|
| **Fingerprint** | `a9c80f5f5afbfbe7` |
| **Severity** | minor |
| **Category** | grammar |
| **Audit Date** | 2026-08-17 |