### PR TITLE
docs: remove Unreleased section from README changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,11 +669,6 @@ make smoke                          # quick CLI smoke on fixtures
 
 ## Changelog
 
-### Unreleased
-
-- **Fix vendored Cursor-skill engine drift and pin it byte-for-byte**: the text engine vendored into `skills/clean-user-facing-text/` had silently fallen behind the service copy, so the Cursor skill still blanket-stripped legitimate RTL directional marks and isolates (corrupting mixed RTL/LTR prose that isolates an LTR run with `U+2066`…`U+2069` and `U+200F`) and stripped emoji variation selectors after arrow and symbol bases (visibly changing sequences like `U+2194 U+FE0F`, ↔️ as one glyph). The vendored `text_unicode.py` is now an exact copy of the service engine and a new test pins the two files byte-for-byte, so future engine changes cannot land in one copy only. The CLI wrappers still deliberately differ (text-only skill: no stylometry, no `--strip-bidi`)
-- **Fix `inspect` missing Layer A carriers in markdown/HTML**: `inspect_container` never scanned the document body, so a `.md` or `.html` file holding invisible Unicode came back `suspicious: false` while `clean_container` went on to strip it — the same bytes saved as `.txt` were correctly flagged. The scan now runs for exactly the formats `clean_container` scrubs, so inspect predicts clean. Container reports gain `suspicious_total` (the same key `TextInspectReport` uses, so the HTTP `suspicious` flag and the `inspect_file` exit code pick it up) and `layer_a_hits`
-
 ### [v0.5.0](https://github.com/guillaumemeyer/watermarks-remover/releases/tag/v0.5.0) — service & Docker distribution, HTTP API, and verification harnesses
 
 **Service / Docker distribution**


### PR DESCRIPTION
Removes the  section from the README changelog. The two entries it contained are already covered by released versions (v0.5.0 and PR #96's fix).