### PR TITLE
feat: add BMP, GIF, TIFF, and EPUB format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Agent skill + stdlib Python service to strip **multi-vendor AI provenance marks*
 | --- | --- | --- |
 | **A** | Invisible Unicode, exotic spaces, bidi, tag chars | Deterministic Python scripts |
 | **B** | Statistical (token-sampling) text watermarks | Agent rewrite + optional `rewrite_text.py` hook |
-| **Files** | C2PA / EXIF / XMP / doc props | PNG, JPEG, WebP, SVG, PDF, DOCX, ODT, HTML, Markdown |
+| **Files** | C2PA / EXIF / XMP / doc props | PNG, JPEG, WebP, BMP, GIF, TIFF, SVG, PDF, DOCX, EPUB, ODT, HTML, Markdown |
 
 Vendors / ecosystems (class-level): **Claude**, **Gemini / SynthID-Text**, **OpenAI** provenance surfaces, **open-LLM** Kirchenbauer-style marks.
 
@@ -585,9 +585,14 @@ Layer B makes sense when you specifically want the premium model's **thinking an
 | Format | Inspect | Clean |
 | --- | --- | --- |
 | PNG / JPEG / WebP | C2PA chunks / APP11 / RIFF `C2PA`, AI XMP hints | Drop metadata segments |
+| AVIF / HEIC | ISOBMFF `jumb` / XMP `uuid` boxes | Drop boxes |
+| BMP | Trailing non-image bytes (no standardized channel) | Truncate trailing metadata, fix file-size field |
+| GIF | Comment / XMP application extensions | Drop comment & XMP, keep `NETSCAPE2.0` loop |
+| TIFF (classic + BigTIFF) | IFD tags: XMP, EXIF, GPS, IPTC, MakerNote | Drop tags, zero payloads, keep strips |
 | SVG | `<metadata>`, XMP | Strip blocks |
 | PDF | Byte/XMP + optional tools | **exiftool** then **qpdf**; degraded without either |
 | DOCX | docProps / customXml | Scrub props, drop customXml |
+| EPUB | OPF metadata, XHTML meta/JSON-LD, embedded media | Scrub OPF, strip XHTML meta, clean media + Layer A (skips encrypted parts) |
 | ODT | meta.xml | Drop generator / AI-ish meta |
 | HTML | meta, JSON-LD, data-ai* | Strip tags/attrs |
 | Markdown | YAML frontmatter AI keys | Drop keys + Layer A body |
@@ -706,6 +711,8 @@ make smoke                          # quick CLI smoke on fixtures
 - **Fix ctrlregen image build**: the 2023-era research pins (`safetensors==0.4.3`, `transformers==4.37.2` → `tokenizers<0.19`) ship no Python 3.14 wheels, so the base image is now `python:3.11-slim` (digest-pinned, multi-arch)
 - **Fix harness images at runtime**: `Dockerfile.markllm` and `Dockerfile.markdiffusion` never copied `common.py` into `/app` (pre-existing bug) — added
 - **WebP**: stdlib-only inspection and metadata cleaning for RIFF `C2PA`, XMP, EXIF, and ICC profile chunks (#37)
+- **BMP / GIF / TIFF**: stdlib-only detection, inspection, and metadata cleaning — GIF comment/XMP extensions are dropped while `NETSCAPE2.0` looping is preserved; TIFF IFD metadata (XMP/EXIF/GPS/IPTC/MakerNote) is dropped with payloads zeroed and strip offsets kept, for both classic and BigTIFF; BMP trailing metadata is truncated with the file-size field rewritten
+- **EPUB**: stdlib-only container cleaning — OPF metadata and XHTML meta/JSON-LD scrubbed, embedded raster/SVG media stripped, Layer A applied to XHTML body text, marker-carrying metadata parts dropped, and OCF-encrypted parts passed through untouched
 - **Filename sanitization**: HTTP service refuses unsafe client-supplied output names
 - **Fix markdown frontmatter cleaner** crashing on and leaking nested AI keys (#25)
 - **Text tools refuse binary input**; `--force-text` overrides (#24)

--- a/service/scripts/clean_file.py
+++ b/service/scripts/clean_file.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Unified clean: text Layer A, PNG/JPEG/WebP metadata, and document containers."""
+"""Unified clean: text Layer A, raster metadata, and document containers."""
 
 from __future__ import annotations
 

--- a/service/scripts/clean_image.py
+++ b/service/scripts/clean_image.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Strip C2PA and AI-related metadata from PNG/JPEG/WebP."""
+"""Strip C2PA and AI-related metadata from raster images (PNG/JPEG/WebP/AVIF/HEIC/BMP/GIF/TIFF)."""
 
 from __future__ import annotations
 
@@ -16,7 +16,7 @@ from image_meta import clean_image
 
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("path", type=Path, help="Input PNG, JPEG, or WebP")
+    p.add_argument("path", type=Path, help="Input image (PNG/JPEG/WebP/AVIF/HEIC/BMP/GIF/TIFF)")
     p.add_argument("-o", "--output", type=Path, help="Output path (default: *.cleaned.*)")
     p.add_argument(
         "--in-place",

--- a/service/scripts/common.py
+++ b/service/scripts/common.py
@@ -63,6 +63,7 @@ BINARY_MAGIC: tuple[tuple[bytes, str], ...] = (
     (b"\xff\xd8\xff", "a JPEG image"),
     (b"GIF87a", "a GIF image"),
     (b"GIF89a", "a GIF image"),
+    (b"BM", "a BMP image"),
     (b"II*\x00", "a TIFF image"),
     (b"MM\x00*", "a TIFF image"),
     (b"RIFF", "a RIFF container (WEBP, WAV, AVI)"),

--- a/service/scripts/container_meta.py
+++ b/service/scripts/container_meta.py
@@ -1,6 +1,6 @@
 """Inspect/clean AI provenance metadata in non-raster containers.
 
-Formats: SVG, PDF (best-effort), DOCX, ODT, HTML, Markdown frontmatter.
+Formats: SVG, PDF (best-effort), DOCX, ODT, HTML, Markdown frontmatter, EPUB.
 Stdlib-first; PDF prefers optional exiftool/c2patool when present.
 """
 
@@ -26,14 +26,20 @@ from common import (
 from image_meta import (
     AI_META_HINTS,
     C2PA_MARKERS,
+    inspect_bmp,
+    inspect_gif,
     inspect_isobmff,
     inspect_jpeg,
     inspect_png,
+    inspect_tiff,
     inspect_webp,
     run_optional_tools,
+    strip_bmp,
+    strip_gif,
     strip_isobmff,
     strip_jpeg,
     strip_png,
+    strip_tiff,
     strip_webp,
 )
 from image_meta import (
@@ -130,6 +136,8 @@ def detect_container_format(path: Path, data: bytes | None = None) -> str:
         return "pptx"
     if ext in (".odt",):
         return "odt"
+    if ext in (".epub",):
+        return "epub"
     if ext in (".html", ".htm"):
         return "html"
     if ext in (".md", ".markdown", ".mdx"):
@@ -152,6 +160,8 @@ def detect_container_format(path: Path, data: bytes | None = None) -> str:
                         return "pptx"
                     if "content.xml" in names and "meta.xml" in names:
                         return "odt"
+                    if "META-INF/container.xml" in names and any(n.endswith(".opf") for n in names):
+                        return "epub"
             except zipfile.BadZipFile:
                 pass
     return "unknown"
@@ -681,7 +691,9 @@ def _inspect_ooxml_zip(data: bytes, fmt: str) -> tuple[bool, bool, list[str], di
                 name = info.filename
                 # Check media parts for C2PA/AI metadata
                 if re.search(
-                    r"^(?:word|xl|ppt)/media/.+\.(png|jpe?g|webp|avif|heic|svg)$", name, re.I
+                    r"^(?:word|xl|ppt)/media/.+\.(png|jpe?g|webp|avif|heic|gif|bmp|tiff?|svg)$",
+                    name,
+                    re.I,
                 ):
                     raw = zf.read(name)
                     img_fmt = detect_image_format(raw)
@@ -694,6 +706,12 @@ def _inspect_ooxml_zip(data: bytes, fmt: str) -> tuple[bool, bool, list[str], di
                         sub_c2pa, sub_ai, sub_findings = inspect_webp(raw)
                     elif img_fmt in ("avif", "heic"):
                         sub_c2pa, sub_ai, sub_findings = inspect_isobmff(raw, img_fmt)
+                    elif img_fmt == "gif":
+                        sub_c2pa, sub_ai, sub_findings = inspect_gif(raw)
+                    elif img_fmt == "tiff":
+                        sub_c2pa, sub_ai, sub_findings = inspect_tiff(raw)
+                    elif img_fmt == "bmp":
+                        sub_c2pa, sub_ai, sub_findings = inspect_bmp(raw)
                     elif name.lower().endswith(".svg") or raw.lstrip().startswith(b"<"):
                         sub_c2pa, sub_ai, sub_findings, _ = inspect_svg(raw)
                     if sub_c2pa:
@@ -891,8 +909,12 @@ def _scrub_ooxml_zip(
             _check_zip_budget(info, budget)
             raw = zin.read(name)
 
-            # 1. Clean embedded media (PNG, JPEG, WebP, AVIF, HEIC, SVG)
-            if re.search(r"^(?:word|xl|ppt)/media/.+\.(png|jpe?g|webp|avif|heic|svg)$", name, re.I):
+            # 1. Clean embedded media (PNG, JPEG, WebP, AVIF, HEIC, GIF, BMP, TIFF, SVG)
+            if re.search(
+                r"^(?:word|xl|ppt)/media/.+\.(png|jpe?g|webp|avif|heic|gif|bmp|tiff?|svg)$",
+                name,
+                re.I,
+            ):
                 img_fmt = detect_image_format(raw)
                 sub_actions: list[str] = []
                 cleaned_bytes = raw
@@ -907,6 +929,12 @@ def _scrub_ooxml_zip(
                         cleaned_bytes, sub_actions = strip_isobmff(
                             raw, img_fmt, strip_all_metadata=True
                         )
+                    elif img_fmt == "gif":
+                        cleaned_bytes, sub_actions = strip_gif(raw, strip_all_metadata=True)
+                    elif img_fmt == "bmp":
+                        cleaned_bytes, sub_actions = strip_bmp(raw, strip_all_metadata=True)
+                    elif img_fmt == "tiff":
+                        cleaned_bytes, sub_actions = strip_tiff(raw, strip_all_metadata=True)
                     elif name.lower().endswith(".svg") or raw.lstrip().startswith(b"<"):
                         cleaned_bytes, sub_actions = clean_svg(raw)
                 except Exception:  # noqa: S110 - malformed embedded media; keep original part
@@ -1113,6 +1141,247 @@ def clean_odt(data: bytes, *, also_layer_a_text: bool = True) -> tuple[bytes, li
 
 
 # ---------------------------------------------------------------------------
+# EPUB
+# ---------------------------------------------------------------------------
+
+_EPUB_MEDIA_RE = re.compile(r"\.(png|jpe?g|webp|avif|heic|gif|bmp|tiff?|svg)$", re.I)
+
+
+def _epub_content_part(name: str) -> bool:
+    """True for parts that carry visible content or structure and must never be dropped.
+
+    XHTML/HTML, CSS, JS, navigation (ncx), the package document (opf), raster
+    and vector media, fonts, the 'mimetype' part, relationship files, and the
+    OCF control files are content or structure. Everything else (META-INF
+    custom parts, stray XML at the archive root) is a candidate for dropping
+    when it carries AI/C2PA markers.
+    """
+    low = name.lower()
+    return bool(
+        low == "mimetype"
+        or low.endswith(".rels")
+        or low
+        in (
+            "meta-inf/container.xml",
+            "meta-inf/encryption.xml",
+            "meta-inf/signatures.xml",
+            "meta-inf/rights.xml",
+        )
+        or re.search(
+            r"\.(xhtml|html?|css|js|ncx|opf|svg|png|jpe?g|webp|avif|heic|gif|bmp|tiff?|ttf|otf|woff2?)$",
+            low,
+        )
+    )
+
+
+def _epub_encrypted_parts(data: bytes) -> set[str]:
+    """Return part names listed as encrypted in META-INF/encryption.xml (OCF)."""
+    try:
+        with zipfile.ZipFile(io.BytesIO(data)) as zf:
+            if "META-INF/encryption.xml" not in zf.namelist():
+                return set()
+            xml = zf.read("META-INF/encryption.xml").decode("utf-8", errors="replace")
+    except (zipfile.BadZipFile, KeyError):
+        return set()
+    names: set[str] = set()
+    for uri in re.findall(r'CipherReference\s+URI="([^"]+)"', xml, re.I):
+        # The URI is relative to META-INF/ per OCF, but producers are not
+        # consistent, so accept every plausible normalization.
+        names.add(posixpath.normpath(posixpath.join("META-INF", uri)))
+        names.add(posixpath.normpath(uri))
+        if uri.startswith("../"):
+            names.add(posixpath.normpath(uri[3:]))
+    return names
+
+
+def inspect_epub(data: bytes) -> tuple[bool, bool, list[str], dict]:
+    findings: list[str] = []
+    has_c2pa = False
+    has_ai = False
+    budget = [0]
+    encrypted = _epub_encrypted_parts(data)
+    try:
+        with zipfile.ZipFile(io.BytesIO(data)) as zf:
+            names = zf.namelist()
+            for info in zf.infolist():
+                _check_zip_budget(info, budget)
+                name = info.filename
+                if name in encrypted:
+                    findings.append(f"{name}: encrypted content (skipped)")
+                    continue
+                raw = zf.read(name)
+                if name.lower().endswith((".xhtml", ".html", ".htm")):
+                    text = raw.decode("utf-8", errors="surrogateescape")
+                    c2, ai, sub, _ = inspect_html(text)
+                    if c2:
+                        has_c2pa = True
+                    if ai:
+                        has_ai = True
+                    for f in sub:
+                        findings.append(f"{name}: {f}")
+                    continue
+                if name.lower().endswith(".opf"):
+                    text = raw.decode("utf-8", errors="surrogateescape")
+                    if AI_META_NAME_RE.search(text):
+                        has_ai = True
+                        findings.append(f"{name}: AI-ish metadata in package document")
+                    c2, ai, hits = _blob_hits(raw)
+                    if c2 or ai:
+                        has_c2pa = has_c2pa or c2
+                        has_ai = has_ai or ai
+                        findings.append(f"{name}: {', '.join(hits[:6])}")
+                    continue
+                c2, ai, hits = _blob_hits(raw)
+                if c2 or ai:
+                    has_c2pa = has_c2pa or c2
+                    has_ai = has_ai or ai
+                    findings.append(f"{name}: {', '.join(hits[:6])}")
+    except zipfile.BadZipFile:
+        return False, False, ["not a valid EPUB zip"], {}
+    return has_c2pa, has_ai or has_c2pa, findings, {"parts": len(names)}
+
+
+def _scrub_epub_opf(text: str) -> tuple[str, list[str]]:
+    """Scrub AI-ish metadata from the EPUB package document (OPF)."""
+    actions: list[str] = []
+
+    def _meta(m: re.Match[str]) -> str:
+        tag = m.group(0)
+        if AI_META_NAME_RE.search(tag):
+            actions.append("drop OPF meta tag")
+            return ""
+        return tag
+
+    new = re.sub(r"<meta\b[^>]*/>", _meta, text, flags=re.I)
+    new = re.sub(r"<meta\b[^>]*>.*?</meta\s*>", _meta, new, flags=re.I | re.DOTALL)
+
+    def _dc(m: re.Match[str]) -> str:
+        if AI_META_NAME_RE.search(m.group(0)):
+            actions.append(f"scrub {m.group(1)} (AI vendor name)")
+            return f"<{m.group(1)}/>"
+        return m.group(0)
+
+    new = re.sub(
+        r"<(dc:(?:creator|contributor|publisher|description|rights|source))\b[^>]*>.*?</\1\s*>",
+        _dc,
+        new,
+        flags=re.I | re.DOTALL,
+    )
+
+    if not actions:
+        actions.append("no OPF metadata removed")
+    return new, actions
+
+
+def clean_epub(data: bytes, *, also_layer_a_text: bool = True) -> tuple[bytes, list[str]]:
+    """Rewrite the EPUB: scrub OPF metadata, XHTML meta/JSON-LD, and Layer A.
+
+    Embedded raster/SVG media get their own metadata stripped; structural and
+    OCF control parts (mimetype, container.xml, encryption.xml, relationships,
+    fonts) are kept so the book stays readable. Parts listed in
+    META-INF/encryption.xml are copied verbatim — their bytes are ciphertext,
+    so any rewrite would corrupt them. Non-content parts carrying AI/C2PA
+    markers are dropped.
+    """
+    from text_unicode import clean_text  # local import to avoid cycles
+
+    actions: list[str] = []
+    budget = [0]
+    layer_removed = 0
+    layer_replaced = 0
+    encrypted = _epub_encrypted_parts(data)
+    out_buf = io.BytesIO()
+    with (
+        zipfile.ZipFile(io.BytesIO(data)) as zin,
+        zipfile.ZipFile(out_buf, "w", compression=zipfile.ZIP_DEFLATED) as zout,
+    ):
+        for info in zin.infolist():
+            name = info.filename
+            _check_zip_budget(info, budget)
+            raw = zin.read(name)
+            low = name.lower()
+
+            # Encrypted parts are opaque ciphertext: pass through untouched.
+            if name in encrypted:
+                zout.writestr(info, raw)
+                continue
+
+            # 1. Embedded raster / vector media: strip metadata
+            if _EPUB_MEDIA_RE.search(low):
+                img_fmt = detect_image_format(raw)
+                sub_actions: list[str] = []
+                cleaned = raw
+                try:
+                    if img_fmt == "png":
+                        cleaned, sub_actions = strip_png(raw, strip_all_text=True)
+                    elif img_fmt == "jpeg":
+                        cleaned, sub_actions = strip_jpeg(raw, strip_all_app=True)
+                    elif img_fmt == "webp":
+                        cleaned, sub_actions = strip_webp(raw, strip_all_metadata=True)
+                    elif img_fmt in ("avif", "heic"):
+                        cleaned, sub_actions = strip_isobmff(raw, img_fmt, strip_all_metadata=True)
+                    elif img_fmt == "gif":
+                        cleaned, sub_actions = strip_gif(raw, strip_all_metadata=True)
+                    elif img_fmt == "bmp":
+                        cleaned, sub_actions = strip_bmp(raw, strip_all_metadata=True)
+                    elif img_fmt == "tiff":
+                        cleaned, sub_actions = strip_tiff(raw, strip_all_metadata=True)
+                    elif low.endswith(".svg") or raw.lstrip().startswith(b"<"):
+                        cleaned, sub_actions = clean_svg(raw)
+                except Exception:  # noqa: S110 - malformed embedded media; keep original
+                    pass
+                if any("drop" in a.lower() for a in sub_actions) and cleaned != raw:
+                    actions.append(f"clean embedded media in {name} ({', '.join(sub_actions[:2])})")
+                    raw = cleaned
+                zout.writestr(info, raw)
+                continue
+
+            # 2. XHTML content: strip AI meta/JSON-LD, then Layer A
+            if low.endswith((".xhtml", ".html", ".htm")):
+                text = raw.decode("utf-8", errors="surrogateescape")
+                text, sub_actions = clean_html(text)
+                if sub_actions and sub_actions != ["no HTML AI meta removed"]:
+                    actions.append(f"{name}: {', '.join(sub_actions[:2])}")
+                if also_layer_a_text:
+                    text2, stats = clean_text(text)
+                    if stats["removed_count"] or stats["replaced_count"]:
+                        layer_removed += stats["removed_count"]
+                        layer_replaced += stats["replaced_count"]
+                        text = text2
+                raw = text.encode("utf-8", errors="surrogateescape")
+                zout.writestr(info, raw)
+                continue
+
+            # 3. Package document (OPF): scrub AI-ish metadata
+            if low.endswith(".opf"):
+                text = raw.decode("utf-8", errors="surrogateescape")
+                new_text, sub_actions = _scrub_epub_opf(text)
+                if sub_actions and sub_actions != ["no OPF metadata removed"]:
+                    actions.extend(f"{name}: {a}" for a in sub_actions)
+                raw = new_text.encode("utf-8", errors="surrogateescape")
+                zout.writestr(info, raw)
+                continue
+
+            # 4. Other parts: drop non-content parts carrying AI/C2PA markers
+            c2, ai, _hits = _blob_hits(raw)
+            if (c2 or ai) and not _epub_content_part(name):
+                actions.append(f"drop part {name} (AI/C2PA markers)")
+                continue
+
+            # 5. mimetype must stay first and stored — it already is, since we
+            #    write in the original entry order; force stored compression.
+            if low == "mimetype":
+                info.compress_type = zipfile.ZIP_STORED
+            zout.writestr(info, raw)
+
+    if layer_removed or layer_replaced:
+        actions.append(f"layer A text: removed={layer_removed} replaced={layer_replaced}")
+    if not actions:
+        actions.append("no EPUB metadata removed")
+    return out_buf.getvalue(), actions
+
+
+# ---------------------------------------------------------------------------
 # PDF
 # ---------------------------------------------------------------------------
 
@@ -1290,6 +1559,8 @@ def inspect_container(path: Path) -> ContainerInspectReport:
         has_c2pa, has_ai, findings, details = inspect_pptx(data)
     elif fmt == "odt":
         has_c2pa, has_ai, findings, details = inspect_odt(data)
+    elif fmt == "epub":
+        has_c2pa, has_ai, findings, details = inspect_epub(data)
     elif fmt == "html":
         # surrogateescape, not replace: clean_container() decodes the same way,
         # and U+FFFD substitutions would make the two disagree on the counts.
@@ -1314,6 +1585,28 @@ def inspect_container(path: Path) -> ContainerInspectReport:
         layer_a_hits = ta["hits"]
         for h in layer_a_hits:
             findings.append(f"layer-a: {h['codepoint']} {h['label']} x{h['count']} ({h['kind']})")
+    elif fmt == "epub":
+        from text_unicode import inspect_text  # local import to avoid cycles
+
+        encrypted = _epub_encrypted_parts(data)
+        try:
+            with zipfile.ZipFile(io.BytesIO(data)) as zf:
+                for info in zf.infolist():
+                    if info.filename in encrypted:
+                        continue
+                    if info.filename.lower().endswith((".xhtml", ".html", ".htm")):
+                        ta = inspect_text(
+                            zf.read(info.filename).decode("utf-8", errors="surrogateescape")
+                        ).to_dict()
+                        layer_a_total += ta["suspicious_total"]
+                        for h in ta["hits"]:
+                            layer_a_hits.append(h)
+                            findings.append(
+                                f"layer-a ({info.filename}): {h['codepoint']} {h['label']} "
+                                f"x{h['count']} ({h['kind']})"
+                            )
+        except zipfile.BadZipFile:
+            pass
 
     notes: list[str] = []
     if fmt == "pdf":
@@ -1322,6 +1615,10 @@ def inspect_container(path: Path) -> ContainerInspectReport:
         )
     elif fmt in ("docx", "xlsx", "pptx"):
         notes.append(f"{fmt.upper()}: metadata/provenance and embedded media are scanned")
+    elif fmt == "epub":
+        notes.append(
+            "EPUB: package-document metadata, XHTML meta/JSON-LD, and embedded media are scanned"
+        )
     if "unsupported" in details:
         notes.append(f"format not fully inspected: {fmt}")
     if layer_a_total:
@@ -1386,6 +1683,9 @@ def clean_container(
         safe_write_bytes(dest, cleaned)
     elif fmt == "odt":
         cleaned, actions = clean_odt(data, also_layer_a_text=also_layer_a_text)
+        safe_write_bytes(dest, cleaned)
+    elif fmt == "epub":
+        cleaned, actions = clean_epub(data, also_layer_a_text=also_layer_a_text)
         safe_write_bytes(dest, cleaned)
     elif fmt == "html":
         text = data.decode("utf-8", errors="surrogateescape")

--- a/service/scripts/format_dispatch.py
+++ b/service/scripts/format_dispatch.py
@@ -16,7 +16,19 @@ from image_meta import detect_format as detect_image_format
 
 Kind = Literal["text", "image", "container"]
 
-IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".webp", ".avif", ".heic", ".heif"}
+IMAGE_EXTS = {
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".webp",
+    ".avif",
+    ".heic",
+    ".heif",
+    ".bmp",
+    ".gif",
+    ".tiff",
+    ".tif",
+}
 CONTAINER_EXTS = {
     ".svg",
     ".pdf",
@@ -24,6 +36,7 @@ CONTAINER_EXTS = {
     ".xlsx",
     ".pptx",
     ".odt",
+    ".epub",
     ".html",
     ".htm",
     ".md",
@@ -63,7 +76,7 @@ def classify_bytes(data: bytes, suffix: str | None = None) -> Kind:
         return "container"
     if ext in TEXT_EXTS:
         return "text"
-    if detect_image_format(data) in ("png", "jpeg", "webp", "avif", "heic"):
+    if detect_image_format(data) in ("png", "jpeg", "webp", "avif", "heic", "bmp", "gif", "tiff"):
         return "image"
     if data:
         sniff_path = Path("input") if not ext else Path(f"input{ext}")

--- a/service/scripts/image_meta.py
+++ b/service/scripts/image_meta.py
@@ -1,17 +1,25 @@
-"""Detect and strip C2PA / AI-related metadata from PNG, JPEG, and WebP (stdlib)."""
+"""Detect and strip C2PA / AI-related metadata from raster images (stdlib).
+
+Supported formats: PNG, JPEG, WebP, AVIF/HEIC (ISOBMFF), BMP, GIF, and TIFF
+(classic and BigTIFF).
+"""
 
 from __future__ import annotations
 
+import base64
 import json
 import os
 import re
 import struct
 import subprocess
 import sys
+import urllib.error
+import urllib.request
 import zlib
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 from common import (
     classify_finding_confidence,
@@ -22,6 +30,13 @@ from common import (
 )
 
 SCRIPTS_DIR = Path(__file__).resolve().parent
+
+# Optional HTTP SynthID scorer sidecar (synthid_score_server.py). When
+# WATERMARKS_SYNTHID_SCORER_URL is set, run_synthid_score calls the sidecar
+# instead of a local reverse-SynthID checkout — this keeps the published core
+# image free of the non-commercial upstream code. Read per call so tests can
+# set the env vars after import.
+DEFAULT_SYNTHID_SCORER_TIMEOUT = 60.0
 
 # CtrlRegen is torch-based and needs far more address space than the stdlib
 # parsers. The invoking clean_image.py subprocess applies these higher,
@@ -49,6 +64,12 @@ PNG_SIG = b"\x89PNG\r\n\x1a\n"
 JPEG_SOI = b"\xff\xd8"
 WEBP_RIFF = b"RIFF"
 WEBP_SIG = b"WEBP"
+BMP_SIG = b"BM"
+GIF_SIGS = (b"GIF87a", b"GIF89a")
+TIFF_LE_SIG = b"II*\x00"
+TIFF_BE_SIG = b"MM\x00*"
+TIFF_LE_BIG_SIG = b"II+\x00"
+TIFF_BE_BIG_SIG = b"MM\x00+"
 
 # Chunk types / content patterns associated with C2PA / AI provenance
 C2PA_MARKERS = (
@@ -87,7 +108,7 @@ AI_META_HINTS = (
 @dataclass
 class ImageInspectReport:
     path: str
-    format: str  # png | jpeg | webp | unknown
+    format: str  # png | jpeg | webp | avif | heic | bmp | gif | tiff | unknown
     has_c2pa: bool
     has_ai_metadata: bool
     findings: list[str] = field(default_factory=list)
@@ -130,6 +151,12 @@ def detect_format(data: bytes) -> str:
             for b in (b"heic", b"heix", b"hevc", b"heim", b"heis", b"mif1", b"msf1", b"heif")
         ):
             return "heic"
+    if data[:2] == BMP_SIG:
+        return "bmp"
+    if data[:6] in GIF_SIGS:
+        return "gif"
+    if data[:4] in (TIFF_LE_SIG, TIFF_BE_SIG, TIFF_LE_BIG_SIG, TIFF_BE_BIG_SIG):
+        return "tiff"
     return "unknown"
 
 
@@ -400,6 +427,718 @@ def inspect_isobmff(data: bytes, fmt: str = "avif") -> tuple[bool, bool, list[st
     return has_c2pa, has_ai or has_c2pa, findings
 
 
+# ---------------------------------------------------------------------------
+# BMP
+# ---------------------------------------------------------------------------
+
+
+def _bmp_payload_extent(data: bytes) -> tuple[int, int] | None:
+    """Return (pixel_offset, pixel_size) for a BMP, or None.
+
+    Locates the true image payload by parsing the BITMAPFILEHEADER and the DIB
+    header (BITMAPINFOHEADER 40, V4 108, or V5 124 bytes), so trailing
+    non-image bytes can be told apart from pixel data. Uncompressed rows are
+    padded to 4-byte boundaries; compressed or embedded-image BMPs (RLE, JPEG,
+    PNG) rely on the declared biSizeImage, and anything unparseable returns
+    None so callers stay conservative.
+    """
+    if len(data) < 30 or data[:2] != BMP_SIG:
+        return None
+    pixel_offset = struct.unpack("<I", data[10:14])[0]
+    dib_size = struct.unpack("<I", data[14:18])[0]
+    if dib_size < 40 or 14 + dib_size > len(data):
+        return None
+    width = struct.unpack("<i", data[18:22])[0]
+    height = struct.unpack("<i", data[22:26])[0]
+    bpp = struct.unpack("<H", data[28:30])[0]
+    compression = struct.unpack("<I", data[30:34])[0]
+    size_image = struct.unpack("<I", data[34:38])[0]
+    if width <= 0 or bpp == 0 or pixel_offset > len(data):
+        return None
+    if compression == 0:  # BI_RGB
+        row_size = ((width * bpp + 31) // 32) * 4
+        size = row_size * abs(height)
+    elif size_image:
+        size = size_image
+    else:
+        return None
+    return pixel_offset, size
+
+
+def _bmp_trailing(data: bytes) -> bytes:
+    """Bytes after the image payload, which is where non-standard BMP metadata lives."""
+    extent = _bmp_payload_extent(data)
+    if extent is None:
+        return b""
+    pixel_offset, size = extent
+    end = pixel_offset + size
+    return data[end:] if end < len(data) else b""
+
+
+def inspect_bmp(data: bytes) -> tuple[bool, bool, list[str]]:
+    """Inspect a BMP for trailing (non-standard) metadata.
+
+    BMP has no standardized metadata container; the only realistic place
+    provenance data can live is after the image payload. Pixel bytes are never
+    scanned, so compressed/embedded-image data cannot false-positive.
+    """
+    findings: list[str] = []
+    if len(data) < 14 or data[:2] != BMP_SIG:
+        return False, False, ["not a BMP"]
+    trailing = _bmp_trailing(data)
+    has_c2pa = False
+    has_ai = False
+    if trailing:
+        hits = _contains_any(trailing, AI_META_HINTS + C2PA_MARKERS)
+        if hits:
+            has_ai = True
+            if any(
+                h.lower() in ("c2pa", "contentcredentials", "jumb", "contentauth") for h in hits
+            ):
+                has_c2pa = True
+            findings.append(f"BMP trailing metadata: {', '.join(hits[:6])}")
+        else:
+            findings.append(f"BMP has {len(trailing)} unrecognized trailing byte(s)")
+    else:
+        findings.append("BMP has no metadata (header-only raster format)")
+    return has_c2pa, has_ai or has_c2pa, findings
+
+
+def strip_bmp(data: bytes, *, strip_all_metadata: bool = True) -> tuple[bytes, list[str]]:
+    """Strip trailing non-image bytes from a BMP and fix the file-size field.
+
+    The pixel payload is located via the DIB header and left byte-identical;
+    anything after it is treated as metadata. The 4-byte file-size field at
+    offset 2 is rewritten to the truncated length.
+    """
+    if len(data) < 14 or data[:2] != BMP_SIG:
+        raise ValueError("not BMP")
+    extent = _bmp_payload_extent(data)
+    if extent is None:
+        return data, ["BMP header not fully parsed; left unchanged"]
+    pixel_offset, size = extent
+    end = pixel_offset + size
+    if end >= len(data):
+        return data, ["no BMP trailing metadata to strip"]
+    trailing = data[end:]
+    hits = _contains_any(trailing, AI_META_HINTS + C2PA_MARKERS)
+    if not strip_all_metadata and not hits:
+        return data, ["BMP trailing bytes kept (keep-non-ai-metadata)"]
+    out = bytearray(data[:end])
+    out[2:6] = struct.pack("<I", end)
+    reason = f" ({', '.join(hits[:4])})" if hits else ""
+    return bytes(out), [f"drop {len(trailing)} BMP trailing byte(s){reason}"]
+
+
+# ---------------------------------------------------------------------------
+# GIF
+# ---------------------------------------------------------------------------
+
+
+def _gif_extension_info(data: bytes, start: int, n: int) -> tuple[int, int, bytes] | None:
+    """Return (end, label, payload) for the extension block at *start* (0x21).
+
+    The payload is the concatenation of all sub-blocks after the label; *end*
+    is the offset just past the terminating 0x00.
+    """
+    if start + 2 > n:
+        return None
+    label = data[start + 1]
+    pos = start + 2
+    payload = bytearray()
+    while pos < n:
+        size = data[pos]
+        pos += 1
+        if size == 0:
+            return pos, label, bytes(payload)
+        if pos + size > n:
+            return None
+        payload.extend(data[pos : pos + size])
+        pos += size
+    return None
+
+
+def _gif_image_end(data: bytes, start: int, n: int) -> int | None:
+    """Return the offset just past the image block starting at *start* (0x2C)."""
+    pos = start + 1
+    if pos + 9 > n:
+        return None
+    packed = data[pos + 8]
+    pos += 9
+    if packed & 0x80:  # local color table present
+        pos += 3 * (1 << ((packed & 0x07) + 1))
+    if pos >= n:
+        return None
+    pos += 1  # LZW minimum code size
+    while pos < n:
+        size = data[pos]
+        pos += 1
+        if size == 0:
+            return pos
+        if pos + size > n:
+            return None
+        pos += size
+    return None
+
+
+GIF_XMP_APPLICATION_ID = b"XMP DataXMP"
+# Application extensions that control rendering rather than carrying provenance;
+# dropping them would change animation looping or color, so they are kept.
+_GIF_CONTROL_APPLICATION_IDS = (b"NETSCAPE2.0", b"ICCRGBG1012")
+
+
+def inspect_gif(data: bytes) -> tuple[bool, bool, list[str]]:
+    """Inspect GIF comment / application extensions and XMP payloads."""
+    findings: list[str] = []
+    has_c2pa = False
+    has_ai = False
+    if data[:6] not in GIF_SIGS:
+        return False, False, ["not a GIF"]
+    n = len(data)
+    pos = 6
+    if pos + 7 > n:
+        return False, False, ["truncated GIF header"]
+    packed = data[pos + 4]
+    pos += 7
+    if packed & 0x80:  # global color table present
+        pos += 3 * (1 << ((packed & 0x07) + 1))
+    while pos < n:
+        block = data[pos]
+        if block == 0x3B:  # trailer
+            break
+        if block == 0x21:
+            info = _gif_extension_info(data, pos, n)
+            if info is None:
+                findings.append("truncated GIF extension")
+                break
+            end, label, payload = info
+            if label == 0xFE:
+                findings.append("GIF comment extension present")
+                hits = _contains_any(payload, AI_META_HINTS + C2PA_MARKERS)
+                if hits:
+                    has_ai = True
+                    findings.append(f"GIF comment: {', '.join(hits[:6])}")
+            elif label == 0xFF:
+                if payload.startswith(GIF_XMP_APPLICATION_ID):
+                    findings.append("GIF XMP application extension present")
+                    hits = _contains_any(payload, AI_META_HINTS + C2PA_MARKERS)
+                    if hits:
+                        has_ai = True
+                        findings.append(f"GIF XMP: {', '.join(hits[:6])}")
+                elif any(m in payload[:11] for m in (b"c2pa", b"jumb", b"C2PA", b"JUMB")):
+                    has_c2pa = True
+                    findings.append("GIF application extension (possible C2PA)")
+            pos = end
+        elif block == 0x2C:
+            end = _gif_image_end(data, pos, n)
+            if end is None:
+                findings.append("truncated GIF image block")
+                break
+            pos = end
+        else:
+            pos += 1
+    whole = _contains_any(data, C2PA_MARKERS)
+    if whole and not has_c2pa:
+        has_c2pa = True
+        findings.append(f"byte-scan C2PA markers: {', '.join(whole[:6])}")
+    if not findings:
+        findings.append("no GIF metadata extensions found")
+    return has_c2pa, has_ai or has_c2pa, findings
+
+
+def strip_gif(data: bytes, *, strip_all_metadata: bool = True) -> tuple[bytes, list[str]]:
+    """Rebuild the GIF without comment/XMP metadata, keeping control blocks.
+
+    Comment (0xFE) and XMP application (0xFF "XMP DataXMP") extensions carry
+    metadata and are dropped in strip-all mode; unknown application extensions
+    are dropped too. NETSCAPE2.0 (loop count) and ICC (color) extensions are
+    rendering control, not provenance, so they are preserved unless they
+    themselves contain AI/C2PA markers. Graphic-control, plain-text, and image
+    blocks are always copied verbatim.
+    """
+    if data[:6] not in GIF_SIGS:
+        raise ValueError("not GIF")
+    actions: list[str] = []
+    out = bytearray(data[:6])
+    n = len(data)
+    pos = 6
+    if pos + 7 > n:
+        raise ValueError("truncated GIF header")
+    packed = data[pos + 4]
+    out.extend(data[pos : pos + 7])
+    pos += 7
+    if packed & 0x80:  # global color table present
+        gct_size = 3 * (1 << ((packed & 0x07) + 1))
+        out.extend(data[pos : pos + gct_size])
+        pos += gct_size
+
+    while pos < n:
+        block = data[pos]
+        if block == 0x3B:  # trailer
+            out.extend(data[pos:])
+            break
+        if block == 0x21:
+            info = _gif_extension_info(data, pos, n)
+            if info is None:
+                out.extend(data[pos:])
+                break
+            end, label, payload = info
+            drop = False
+            name = "extension"
+            if label == 0xFE:
+                name = "comment"
+                drop = strip_all_metadata or bool(
+                    _contains_any(payload, AI_META_HINTS + C2PA_MARKERS)
+                )
+            elif label == 0xFF:
+                ident = payload[:11]
+                marker_hit = bool(_contains_any(payload, AI_META_HINTS + C2PA_MARKERS))
+                if ident == GIF_XMP_APPLICATION_ID:
+                    name = "XMP application"
+                    drop = strip_all_metadata or marker_hit
+                elif ident in _GIF_CONTROL_APPLICATION_IDS:
+                    name = "control application"
+                    drop = marker_hit  # keep looping/ICC unless it carries markers
+                else:
+                    name = "application"
+                    drop = strip_all_metadata or marker_hit
+            if drop:
+                actions.append(f"drop GIF {name} extension")
+            else:
+                out.extend(data[pos:end])
+            pos = end
+        elif block == 0x2C:
+            end = _gif_image_end(data, pos, n)
+            if end is None:
+                out.extend(data[pos:])
+                break
+            out.extend(data[pos:end])
+            pos = end
+        else:
+            out.extend(data[pos : pos + 1])
+            pos += 1
+
+    if not actions:
+        actions.append("no GIF metadata blocks removed (already clean or none matched)")
+    return bytes(out), actions
+
+
+# ---------------------------------------------------------------------------
+# TIFF (classic + BigTIFF)
+# ---------------------------------------------------------------------------
+
+_TIFF_TYPE_SIZES = {1: 1, 2: 1, 3: 2, 4: 4, 5: 8, 6: 1, 7: 1, 8: 2, 9: 4, 10: 8, 11: 4, 12: 8}
+
+# Provenance / descriptive metadata tags stripped when cleaning TIFF.
+_TIFF_META_TAG_NAMES = {
+    269: "DocumentName",
+    270: "ImageDescription",
+    271: "Make",
+    272: "Model",
+    305: "Software",
+    306: "DateTime",
+    315: "Artist",
+    316: "HostComputer",
+    33432: "Copyright",
+    40091: "XPTitle",
+    40092: "XPComment",
+    40093: "XPAuthor",
+    40094: "XPKeywords",
+    40095: "XPSubject",
+    700: "XMP",
+    33723: "IPTC/NAA",
+    34377: "Photoshop",
+    34665: "ExifIFD",
+    34853: "GPSInfo",
+    37500: "MakerNote",
+}
+
+_TIFF_DROP_TAGS = frozenset(_TIFF_META_TAG_NAMES)
+
+# Structural tags that must survive even when their payload looks marker-ish
+# (offset lists, color tables, compression tables, DNG core tags).
+_TIFF_KEEP_TAGS = frozenset(
+    {
+        254,
+        255,
+        256,
+        257,
+        258,
+        259,
+        262,
+        263,
+        264,
+        265,
+        266,
+        273,
+        274,
+        277,
+        278,
+        279,
+        282,
+        283,
+        284,
+        285,
+        286,
+        287,
+        288,
+        289,
+        290,
+        291,
+        292,
+        293,
+        294,
+        295,
+        296,
+        297,
+        301,
+        302,
+        304,
+        320,
+        321,
+        322,
+        323,
+        324,
+        325,
+        326,
+        327,
+        328,
+        329,
+        330,
+        331,
+        332,
+        333,
+        334,
+        336,
+        338,
+        339,
+        340,
+        341,
+        342,
+        343,
+        344,
+        345,
+        346,
+        347,
+        512,
+        513,
+        514,
+        515,
+        516,
+        517,
+        518,
+        519,
+        520,
+        521,
+        529,
+        530,
+        531,
+        532,
+        533,
+        33421,
+        33422,
+        33423,
+        34675,
+        34676,
+        *range(50706, 50742),  # DNG structural tags
+    }
+)
+
+MAX_TIFF_IFDS = 4096
+
+
+def _tiff_layout(data: bytes) -> tuple[str, bool] | None:
+    """Return (byte_order, bigtiff) for a classic or BigTIFF, else None."""
+    if data[:2] == b"II" and data[2:4] == b"*\x00":
+        return "<", False
+    if data[:2] == b"MM" and data[2:4] == b"\x00*":
+        return ">", False
+    if data[:2] == b"II" and data[2:4] == b"+\x00":
+        return "<", True
+    if data[:2] == b"MM" and data[2:4] == b"\x00+":
+        return ">", True
+    return None
+
+
+def _parse_tiff_ifds(data: bytes) -> tuple[str, bool, dict[int, dict[str, Any]]]:
+    """Parse every reachable TIFF IFD (classic 12-byte or BigTIFF 20-byte entries).
+
+    Returns (byte_order, bigtiff, {offset: {count, entries, next, block_len}}).
+    Each entry is {tag, type, count, value (inline field bytes), byte_size,
+    value_offset}; value_offset is None when the value is inline. Cycle-
+    protected with a hard cap on the number of IFDs.
+    """
+    layout = _tiff_layout(data)
+    if layout is None:
+        raise ValueError("not a TIFF")
+    bo, bigtiff = layout
+    n = len(data)
+    count_len = 8 if bigtiff else 2
+    off_len = 8 if bigtiff else 4
+    entry_size = 20 if bigtiff else 12
+    header_size = 16 if bigtiff else 8
+    count_fmt = bo + ("Q" if bigtiff else "H")
+    off_fmt = bo + ("Q" if bigtiff else "I")
+    if n < header_size:
+        return bo, bigtiff, {}
+    first = struct.unpack(off_fmt, data[header_size - off_len : header_size])[0]
+    if first == 0 or first + count_len > n:
+        return bo, bigtiff, {}
+    ifds: dict[int, dict[str, Any]] = {}
+    seen: set[int] = set()
+    todo = [first]
+    while todo and len(ifds) < MAX_TIFF_IFDS:
+        off = todo.pop()
+        if off in seen or off + count_len > n:
+            continue
+        seen.add(off)
+        count = struct.unpack(count_fmt, data[off : off + count_len])[0]
+        block_len = count_len + count * entry_size
+        entries: list[dict[str, Any]] = []
+        if off + block_len + off_len <= n:
+            next_ptr = struct.unpack(off_fmt, data[off + block_len : off + block_len + off_len])[0]
+        else:
+            block_len = max(0, n - off - off_len)
+            next_ptr = 0
+        for i in range(count):
+            e = off + count_len + i * entry_size
+            if e + entry_size > n:
+                break
+            tag = struct.unpack(bo + "H", data[e : e + 2])[0]
+            ftype = struct.unpack(bo + "H", data[e + 2 : e + 4])[0]
+            fcount = struct.unpack(off_fmt, data[e + 4 : e + 4 + off_len])[0]
+            value = data[e + 4 + off_len : e + entry_size]
+            byte_size = fcount * _TIFF_TYPE_SIZES.get(ftype, 1)
+            value_offset = None
+            if byte_size > len(value):
+                value_offset = struct.unpack(off_fmt, value[:off_len])[0]
+            entries.append(
+                {
+                    "tag": tag,
+                    "type": ftype,
+                    "count": fcount,
+                    "value": value,
+                    "byte_size": byte_size,
+                    "value_offset": value_offset,
+                }
+            )
+        ifds[off] = {
+            "count": count,
+            "entries": entries,
+            "next": next_ptr,
+            "block_len": block_len,
+        }
+        if next_ptr:
+            todo.append(next_ptr)
+        for ent in entries:
+            if ent["tag"] in (34665, 34853, 40965):
+                ptr = struct.unpack(off_fmt, ent["value"][:off_len])[0]
+                if ptr:
+                    todo.append(ptr)
+    return bo, bigtiff, ifds
+
+
+def _tiff_entry_payload(data: bytes, ent: dict[str, Any]) -> bytes | None:
+    if ent["value_offset"] is None:
+        return ent["value"][: ent["byte_size"]] if ent["byte_size"] <= len(ent["value"]) else None
+    vo = ent["value_offset"]
+    return data[vo : vo + ent["byte_size"]]
+
+
+def inspect_tiff(data: bytes) -> tuple[bool, bool, list[str]]:
+    """Walk the IFD chains (classic or BigTIFF) and report metadata tags."""
+    findings: list[str] = []
+    has_c2pa = False
+    has_ai = False
+    try:
+        _bo, _big, ifds = _parse_tiff_ifds(data)
+    except ValueError:
+        return False, False, ["not a valid TIFF"]
+    if not ifds:
+        return False, False, ["TIFF with no image file directories"]
+    for _off, ifd in sorted(ifds.items()):
+        for ent in ifd["entries"]:
+            tag = ent["tag"]
+            payload = _tiff_entry_payload(data, ent)
+            hits = _contains_any(payload or b"", AI_META_HINTS + C2PA_MARKERS)
+            if hits:
+                if any(
+                    h.lower() in ("c2pa", "contentcredentials", "jumb", "contentauth") for h in hits
+                ):
+                    has_c2pa = True
+                has_ai = True
+                findings.append(f"TIFF tag {tag}: {', '.join(hits[:6])}")
+            name = _TIFF_META_TAG_NAMES.get(tag)
+            if name:
+                label = "sub-IFD" if tag in (34665, 34853, 40965) else "tag"
+                findings.append(f"TIFF {label} {tag} ({name}) present")
+    whole = _contains_any(data, C2PA_MARKERS)
+    if whole and not has_c2pa:
+        has_c2pa = True
+        findings.append(f"byte-scan C2PA markers: {', '.join(whole[:6])}")
+    if not findings:
+        findings.append("no TIFF metadata tags found")
+    return has_c2pa, has_ai or has_c2pa, findings
+
+
+def _collect_tiff_sub_ifd_drops(
+    off_fmt: str,
+    off_len: int,
+    ifds: dict[int, dict[str, Any]],
+    data_len: int,
+    ptr: int,
+    drop_ranges: list[tuple[int, int]],
+    drop_ifd_ranges: list[tuple[int, int]],
+    seen: set[int],
+) -> None:
+    """Record the region and value payloads of a dropped sub-IFD chain."""
+    sub = ifds.get(ptr)
+    if sub is None or ptr in seen:
+        return
+    seen.add(ptr)
+    drop_ifd_ranges.append((ptr, min(ptr + sub["block_len"] + off_len, data_len)))
+    for ent in sub["entries"]:
+        if ent["tag"] in (34665, 34853):
+            p2 = struct.unpack(off_fmt, ent["value"][:off_len])[0]
+            if p2:
+                _collect_tiff_sub_ifd_drops(
+                    off_fmt, off_len, ifds, data_len, p2, drop_ranges, drop_ifd_ranges, seen
+                )
+        elif ent["value_offset"] is not None:
+            vo, vs = ent["value_offset"], ent["byte_size"]
+            if vo + vs <= data_len:
+                drop_ranges.append((vo, vo + vs))
+
+
+def strip_tiff(data: bytes, *, strip_all_metadata: bool = True) -> tuple[bytes, list[str]]:
+    """Drop TIFF metadata tags (classic or BigTIFF) without moving referenced data.
+
+    Each IFD entry region is patched in place — kept entries copied verbatim,
+    dropped entries removed, the block zero-padded to its original length — so
+    every offset (strip/tile offsets, next-IFD pointers, color tables) stays
+    valid. Payloads of dropped tags and orphaned sub-IFD chains are zeroed
+    unless a kept entry still references them.
+    """
+    bo, bigtiff, ifds = _parse_tiff_ifds(data)
+    if not ifds:
+        raise ValueError("not a valid TIFF (no image file directories)")
+    n = len(data)
+    off_len = 8 if bigtiff else 4
+    off_fmt = bo + ("Q" if bigtiff else "I")
+    count_fmt = bo + ("Q" if bigtiff else "H")
+    actions: list[str] = []
+    kept: dict[int, list[dict[str, Any]]] = {}
+    drop_ranges: list[tuple[int, int]] = []
+    drop_ifd_ranges: list[tuple[int, int]] = []
+
+    for off, ifd in sorted(ifds.items()):
+        keep_here: list[dict[str, Any]] = []
+        for ent in ifd["entries"]:
+            tag = ent["tag"]
+            payload = _tiff_entry_payload(data, ent)
+            marker_hit = bool(_contains_any(payload or b"", AI_META_HINTS + C2PA_MARKERS))
+            if tag in (34665, 34853):
+                ptr = struct.unpack(off_fmt, ent["value"][:off_len])[0]
+                sub = ifds.get(ptr)
+                if sub is not None:
+                    sub_blob = data[ptr : min(ptr + sub["block_len"] + off_len, n)]
+                    marker_hit = marker_hit or bool(
+                        _contains_any(sub_blob, AI_META_HINTS + C2PA_MARKERS)
+                    )
+                    for sent in sub["entries"]:
+                        s_payload = _tiff_entry_payload(data, sent)
+                        if _contains_any(s_payload or b"", AI_META_HINTS + C2PA_MARKERS):
+                            marker_hit = True
+                            break
+            drop = False
+            if tag in _TIFF_DROP_TAGS:
+                drop = strip_all_metadata or marker_hit
+            elif marker_hit and tag not in _TIFF_KEEP_TAGS:
+                drop = True
+            if not drop:
+                keep_here.append(ent)
+                continue
+            name = _TIFF_META_TAG_NAMES.get(tag)
+            actions.append(
+                f"drop TIFF tag {tag} ({name})" if name else f"drop TIFF tag {tag} (AI markers)"
+            )
+            if tag in (34665, 34853):
+                ptr = struct.unpack(off_fmt, ent["value"][:off_len])[0]
+                _collect_tiff_sub_ifd_drops(
+                    off_fmt, off_len, ifds, n, ptr, drop_ranges, drop_ifd_ranges, set()
+                )
+            elif ent["value_offset"] is not None and ent["value_offset"] + ent["byte_size"] <= n:
+                drop_ranges.append((ent["value_offset"], ent["value_offset"] + ent["byte_size"]))
+        kept[off] = keep_here
+
+    # Ranges still referenced from the root through kept entries must never be
+    # zeroed. An orphaned sub-IFD (its pointer dropped) contributes nothing.
+    reachable: set[int] = set()
+
+    def _mark_reachable(off: int) -> None:
+        if off in reachable or off not in ifds:
+            return
+        reachable.add(off)
+        for ent in kept.get(off, []):
+            if ent["tag"] in (34665, 34853, 40965):
+                _mark_reachable(struct.unpack(off_fmt, ent["value"][:off_len])[0])
+        if ifds[off]["next"]:
+            _mark_reachable(ifds[off]["next"])
+
+    root = (
+        struct.unpack(off_fmt, data[16 - off_len : 16])[0]
+        if bigtiff
+        else struct.unpack(off_fmt, data[8 - off_len : 8])[0]
+    )
+    _mark_reachable(root)
+
+    referenced: list[tuple[int, int]] = []
+    for off in sorted(reachable):
+        for ent in kept.get(off, []):
+            if ent["value_offset"] is not None and ent["value_offset"] + ent["byte_size"] <= n:
+                referenced.append((ent["value_offset"], ent["value_offset"] + ent["byte_size"]))
+            if ent["tag"] in (34665, 34853, 40965):
+                ptr = struct.unpack(off_fmt, ent["value"][:off_len])[0]
+                sub = ifds.get(ptr)
+                if sub is not None:
+                    referenced.append((ptr, min(ptr + sub["block_len"] + off_len, n)))
+
+    def _covered(ranges: list[tuple[int, int]], start: int, end: int) -> bool:
+        return any(s <= start and end <= e for s, e in ranges)
+
+    zero: list[tuple[int, int]] = []
+    for s, e in drop_ranges:
+        if not _covered(referenced, s, e):
+            zero.append((s, e))
+    for s, e in drop_ifd_ranges:
+        if not _covered(referenced, s, e):
+            zero.append((s, e))
+
+    # Patch IFD entry regions in place, then zero dropped payloads.
+    out = bytearray(data)
+    for off, ifd in sorted(ifds.items()):
+        entries = kept.get(off, [])
+        block = bytearray()
+        block.extend(struct.pack(count_fmt, len(entries)))
+        for ent in entries:
+            block.extend(struct.pack(bo + "H", ent["tag"]))
+            block.extend(struct.pack(bo + "H", ent["type"]))
+            block.extend(struct.pack(off_fmt, ent["count"]))
+            block.extend(ent["value"])
+        block.extend(struct.pack(off_fmt, ifd["next"]))
+        region_len = ifd["block_len"] + off_len
+        if off + region_len <= n:
+            if len(block) > region_len:
+                block = block[:region_len]
+            out[off : off + region_len] = block + b"\x00" * (region_len - len(block))
+    for s, e in zero:
+        out[s:e] = b"\x00" * (e - s)
+
+    if not actions:
+        actions.append("no TIFF metadata tags removed (already clean or none matched)")
+    return bytes(out), actions
+
+
 def run_optional_tools(path: Path) -> dict[str, Any]:
     tools: dict[str, Any] = {}
     c2patool = which("c2patool")
@@ -464,15 +1203,62 @@ def run_optional_tools(path: Path) -> dict[str, Any]:
     return tools
 
 
+def _synthid_score_http(
+    path: Path, base_url: str, api_key: str, timeout: float
+) -> dict[str, Any] | None:
+    """Score *path* via the HTTP sidecar (synthid_score_server.py)."""
+    try:
+        data = path.read_bytes()
+    except OSError as e:
+        return {"available": False, "error": f"cannot read {path}: {e}"}
+    body = json.dumps({"file": base64.b64encode(data).decode("ascii")}).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    if urlparse(base_url).scheme not in ("http", "https"):
+        return {"available": False, "error": f"refusing non-http(s) scorer endpoint: {base_url}"}
+    # S310: URL scheme is restricted to http/https just above.
+    req = urllib.request.Request(  # noqa: S310
+        base_url.rstrip("/") + "/score",
+        data=body,
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+            payload = json.loads(resp.read().decode("utf-8"))
+    except (
+        urllib.error.HTTPError,
+        urllib.error.URLError,
+        TimeoutError,
+        OSError,
+        json.JSONDecodeError,
+    ) as e:
+        return {"available": False, "error": f"SynthID scorer sidecar unreachable: {e}"}
+    if not isinstance(payload, dict):
+        return {"available": False, "error": "bad scorer sidecar response"}
+    return payload
+
+
 def run_synthid_score(
     path: Path,
     upstream_dir: str | None = None,
 ) -> dict[str, Any] | None:
-    """Run the optional reverse-SynthID scorer in a subprocess.
+    """Run the optional reverse-SynthID scorer.
 
-    Returns None when the scorer is not configured or unavailable (exit 3),
-    so callers can keep the default "no SynthID score" behavior.
+    Uses the HTTP sidecar when WATERMARKS_SYNTHID_SCORER_URL is set,
+    otherwise a subprocess against a local checkout. Returns None when the
+    scorer is not configured or unavailable (exit 3), so callers can keep
+    the default "no SynthID score" behavior.
     """
+    scorer_url = os.environ.get("WATERMARKS_SYNTHID_SCORER_URL", "").strip()
+    if scorer_url:
+        api_key = os.environ.get("WATERMARKS_SYNTHID_SCORER_API_KEY", "").strip()
+        try:
+            timeout = float(os.environ.get("WATERMARKS_SYNTHID_SCORER_TIMEOUT", "60"))
+        except ValueError:
+            timeout = DEFAULT_SYNTHID_SCORER_TIMEOUT
+        return _synthid_score_http(path, scorer_url, api_key, timeout)
     if upstream_dir is None:
         upstream_dir = os.environ.get("REVERSE_SYNTHID_DIR")
     if not upstream_dir:
@@ -700,12 +1486,24 @@ def inspect_image(
         has_c2pa, has_ai, findings = inspect_webp(data)
     elif fmt in ("avif", "heic"):
         has_c2pa, has_ai, findings = inspect_isobmff(data, fmt)
+    elif fmt == "bmp":
+        has_c2pa, has_ai, findings = inspect_bmp(data)
+    elif fmt == "gif":
+        has_c2pa, has_ai, findings = inspect_gif(data)
+    elif fmt == "tiff":
+        has_c2pa, has_ai, findings = inspect_tiff(data)
     else:
-        has_c2pa, has_ai, findings = False, False, ["unsupported format (PNG/JPEG/WebP/AVIF/HEIC)"]
+        has_c2pa, has_ai, findings = (
+            False,
+            False,
+            ["unsupported format (PNG/JPEG/WebP/AVIF/HEIC/BMP/GIF/TIFF)"],
+        )
 
     notes: list[str] = []
     if fmt == "unknown":
-        notes.append("format not fully inspected; only PNG/JPEG/WebP/AVIF/HEIC are supported")
+        notes.append(
+            "format not fully inspected; only PNG/JPEG/WebP/AVIF/HEIC/BMP/GIF/TIFF are supported"
+        )
 
     tools = run_optional_tools(path)
     # Elevate flags from tools
@@ -994,6 +1792,12 @@ def clean_image(
         cleaned, actions = strip_webp(data, strip_all_metadata=strip_all_metadata)
     elif fmt in ("avif", "heic"):
         cleaned, actions = strip_isobmff(data, fmt, strip_all_metadata=strip_all_metadata)
+    elif fmt == "bmp":
+        cleaned, actions = strip_bmp(data, strip_all_metadata=strip_all_metadata)
+    elif fmt == "gif":
+        cleaned, actions = strip_gif(data, strip_all_metadata=strip_all_metadata)
+    elif fmt == "tiff":
+        cleaned, actions = strip_tiff(data, strip_all_metadata=strip_all_metadata)
     else:
         raise ValueError(f"unsupported format: {fmt}")
 

--- a/service/scripts/inspect_file.py
+++ b/service/scripts/inspect_file.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Unified inspect: text, images (PNG/JPEG/WebP), and document containers."""
+"""Unified inspect: text, images, and document containers."""
 
 from __future__ import annotations
 

--- a/service/scripts/inspect_image.py
+++ b/service/scripts/inspect_image.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Inspect PNG/JPEG/WebP for C2PA and AI-related metadata."""
+"""Inspect raster images (PNG/JPEG/WebP/AVIF/HEIC/BMP/GIF/TIFF) for C2PA and AI-related metadata."""
 
 from __future__ import annotations
 
@@ -15,7 +15,7 @@ from image_meta import inspect_image
 
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("path", type=Path, help="Image path (PNG, JPEG, or WebP)")
+    p.add_argument("path", type=Path, help="Image path (PNG/JPEG/WebP/AVIF/HEIC/BMP/GIF/TIFF)")
     p.add_argument("--json", action="store_true")
     p.add_argument(
         "--synthid-dir",

--- a/skills/remove-ai-marks/SKILL.md
+++ b/skills/remove-ai-marks/SKILL.md
@@ -115,8 +115,8 @@ Intended for **your own** content (privacy, hygiene, research). Do not market re
 | Pasted / clipboard text | temp file → `/inspect` then `/clean` (text) |
 | `.txt` / code | text Layer A (+ formatter for code) |
 | `.md` / `.html` | container clean (frontmatter/meta) + Layer A |
-| `.png` / `.jpg` / `.jpeg` / `.webp` / `.avif` / `.heic` | image metadata strip |
-| `.svg` / `.pdf` / `.docx` / `.odt` | container metadata strip |
+| `.png` / `.jpg` / `.jpeg` / `.webp` / `.avif` / `.heic` / `.bmp` / `.gif` / `.tiff` | image metadata strip |
+| `.svg` / `.pdf` / `.docx` / `.epub` / `.odt` | container metadata strip |
 | Directory / website | aggregate audit via the service CLIs (see below) |
 
 The service routes by filename extension first, then by magic bytes, so you

--- a/skills/remove-ai-marks/references/removal-matrix.md
+++ b/skills/remove-ai-marks/references/removal-matrix.md
@@ -6,6 +6,10 @@
 | Stylometric AI cadence / burstiness / n-grams (zero-LLM) | Statistical variance & cadence scoring | `score_stylometry.py`, `inspect_text.py --stylometry`, `audit_dir.py --check-stylometry` | None (detection only) | Yes (calibrated score + phrase spans) |
 | Statistical text watermark (SynthID-class / Kirchenbauer) | Multi-pass paraphrase / humanize / back-translate / structural | Agent Layer B + optional `rewrite_text.py` | Meaning/style drift | No without vendor key/detector; **MarkLLM harness** (`detect_text_watermark.py`) verifies a specific scheme config before/after |
 | C2PA on PNG/JPEG/WebP/AVIF/HEIC | Drop APP11 / PNG `caBX` / RIFF `C2PA` / ISOBMFF `jumb` & `uuid` / exiftool | `clean_image.py` | Loses provenance metadata | Yes |
+| GIF comment/XMP extensions | Drop 0xFE / XMP application extensions (keep `NETSCAPE2.0`) | `clean_image.py` | Loses GIF comments/XMP | Yes (re-inspect) |
+| TIFF XMP/EXIF/GPS/IPTC/MakerNote (classic + BigTIFF) | Drop IFD tags, zero payloads, keep strip offsets | `clean_image.py` | Loses TIFF metadata | Yes (re-inspect) |
+| BMP trailing metadata | Truncate non-image trailing bytes, fix file-size field | `clean_image.py` | Removes appended metadata | Yes (re-inspect) |
+| EPUB OPF metadata / XHTML meta / embedded media | Scrub OPF, strip XHTML meta/JSON-LD, clean embedded media, Layer A (skip encrypted parts) | `clean_file.py` | Loses book metadata; rewrites archive | Yes (re-inspect) |
 | SVG metadata / XMP / embedded data URIs | Drop `<metadata>`, xmpmeta; clean embedded data URIs | `clean_file.py` | Loses SVG metadata; cleans embedded rasters | Yes (re-inspect) |
 | PDF XMP / info | exiftool `-all=` preferred | `clean_file.py` | Loses PDF metadata; degraded without exiftool | Partial |
 | DOCX / XLSX / PPTX props / customXml / embedded media | Rewrite OOXML zip, scrub text runs, clean media/ | `clean_file.py` | Loses doc properties; cleans embedded rasters | Yes |

--- a/tests/test_epub.py
+++ b/tests/test_epub.py
@@ -1,0 +1,199 @@
+"""Tests for EPUB container metadata, XHTML, embedded media, and encryption."""
+
+from __future__ import annotations
+
+import io
+import sys
+import zipfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "service" / "scripts"
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(SCRIPTS))
+
+from container_meta import (
+    clean_container,
+    clean_epub,
+    detect_container_format,
+    inspect_container,
+    inspect_epub,
+)
+from format_dispatch import classify, classify_bytes
+
+from tests.test_clean_image import _minimal_png_with_text
+
+
+def _build_epub(
+    *,
+    creator: str = "OpenAI",
+    generator: str = "ChatGPT",
+    body_text: str = "Chapter one\u200b with a hidden mark",
+    with_c2pa_png: bool = True,
+    with_meta_part: bool = True,
+    encrypted_parts: tuple[str, ...] = (),
+) -> bytes:
+    generator_meta = f'    <meta name="generator" content="{generator}"/>\n' if generator else ""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(
+            "mimetype",
+            "application/epub+zip",
+            compress_type=zipfile.ZIP_STORED,
+        )
+        zf.writestr(
+            "META-INF/container.xml",
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            '<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">'
+            '<rootfiles><rootfile full-path="OEBPS/content.opf" '
+            'media-type="application/oebps-package+xml"/></rootfiles></container>',
+        )
+        if encrypted_parts:
+            zf.writestr(
+                "META-INF/encryption.xml",
+                '<?xml version="1.0" encoding="UTF-8"?>'
+                '<encryption xmlns="urn:oasis:names:tc:opendocument:xmlns:container" '
+                'xmlns:enc="http://www.w3.org/2001/04/xmlenc#">'
+                + "".join(
+                    f"<enc:EncryptedData><enc:CipherData>"
+                    f'<enc:CipherReference URI="../{p}"/></enc:CipherData></enc:EncryptedData>'
+                    for p in encrypted_parts
+                )
+                + "</encryption>",
+            )
+        zf.writestr(
+            "OEBPS/content.opf",
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            '<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid">'
+            '<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">'
+            '<dc:identifier id="uid">urn:uuid:1234</dc:identifier>'
+            "<dc:title>Test Book</dc:title>"
+            f"<dc:creator>{creator}</dc:creator>"
+            "<dc:publisher>Acme Press</dc:publisher>"
+            f"{generator_meta}  </metadata>"
+            "<manifest>"
+            '<item id="c1" href="chapter1.xhtml" media-type="application/xhtml+xml"/>'
+            '<item id="img" href="images/cover.png" media-type="image/png"/>'
+            "</manifest>"
+            '<spine><itemref idref="c1"/></spine>'
+            "</package>",
+        )
+        zf.writestr(
+            "OEBPS/chapter1.xhtml",
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            '<html xmlns="http://www.w3.org/1999/xhtml">'
+            "<head><title>Chapter 1</title>"
+            f"{generator_meta}  </head>"
+            f"<body><p>{body_text}</p></body></html>",
+        )
+        if with_c2pa_png:
+            zf.writestr("OEBPS/images/cover.png", _minimal_png_with_text())
+        if with_meta_part:
+            zf.writestr(
+                "META-INF/metadata.xml",
+                '<metadata xmlns="http://www.idpf.org/2013/metadata">c2pa contentcredentials</metadata>',
+            )
+    return buf.getvalue()
+
+
+def test_detect_epub_by_extension_and_sniff(tmp_path: Path):
+    epub = _build_epub()
+    path = tmp_path / "book.epub"
+    path.write_bytes(epub)
+    assert detect_container_format(path, epub) == "epub"
+    assert detect_container_format(Path("book.bin"), epub) == "epub"
+    assert classify_bytes(epub, ".epub") == "container"
+    assert classify_bytes(epub, "") == "container"
+    assert classify(path) == "container"
+
+
+def test_inspect_epub_detects_ai_metadata():
+    has_c2pa, has_ai, findings, details = inspect_epub(_build_epub())
+    assert has_ai is True
+    assert has_c2pa is True
+    assert any("content.opf" in f for f in findings)
+    assert any("chapter1.xhtml" in f for f in findings)
+    assert any("cover.png" in f for f in findings)
+    assert details["parts"] >= 5
+
+
+def test_inspect_epub_clean_book_has_no_flags():
+    has_c2pa, has_ai, _findings, _details = inspect_epub(
+        _build_epub(creator="Jane Doe", generator="", with_c2pa_png=False, with_meta_part=False)
+    )
+    assert has_c2pa is False
+    assert has_ai is False
+
+
+def test_clean_epub_strips_metadata_and_layer_a():
+    epub = _build_epub(body_text="Chapter one\u200b with a hidden mark")
+    cleaned, actions = clean_epub(epub, also_layer_a_text=True)
+    assert any("creator" in a for a in actions)
+    assert any("OPF meta" in a for a in actions)
+    assert any("layer A text" in a for a in actions)
+    assert any("cover.png" in a for a in actions)
+
+    with zipfile.ZipFile(io.BytesIO(cleaned)) as zf:
+        names = zf.namelist()
+        opf = zf.read("OEBPS/content.opf").decode("utf-8")
+        xhtml = zf.read("OEBPS/chapter1.xhtml").decode("utf-8")
+        png = zf.read("OEBPS/images/cover.png")
+    assert "META-INF/metadata.xml" not in names
+    assert "OpenAI" not in opf
+    assert "ChatGPT" not in opf
+    assert "<dc:creator/>" in opf
+    assert 'name="generator"' not in opf
+    assert "\u200b" not in xhtml
+    assert b"c2pa" not in png.lower()
+    assert "mimetype" in names and "META-INF/container.xml" in names
+
+
+def test_clean_epub_skips_encrypted_parts():
+    # The "encrypted" XHTML is opaque ciphertext: cleaning it as text would
+    # mangle bytes, so clean_epub must copy it verbatim.
+    ciphertext = b"\x00\x01\x02\x03AIGC\xff\xfe\xfd binary blob"
+    epub = _build_epub(
+        body_text="",
+        encrypted_parts=("OEBPS/chapter1.xhtml",),
+    )
+    # overwrite chapter1.xhtml with ciphertext inside a fresh zip
+    buf = io.BytesIO()
+    with (
+        zipfile.ZipFile(io.BytesIO(epub)) as zin,
+        zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zout,
+    ):
+        for info in zin.infolist():
+            raw = zin.read(info.filename)
+            if info.filename == "OEBPS/chapter1.xhtml":
+                raw = ciphertext
+            zout.writestr(info, raw)
+    epub = buf.getvalue()
+
+    cleaned, _actions = clean_epub(epub, also_layer_a_text=True)
+    with zipfile.ZipFile(io.BytesIO(cleaned)) as zf:
+        assert zf.read("OEBPS/chapter1.xhtml") == ciphertext  # untouched
+
+
+def test_clean_epub_roundtrip(tmp_path: Path):
+    src = tmp_path / "book.epub"
+    src.write_bytes(_build_epub())
+    dest = tmp_path / "book.cleaned.epub"
+    result = clean_container(src, dest)
+    assert result["format"] == "epub"
+    assert result["still_has_c2pa"] is False
+    assert result["still_has_ai_metadata"] is False
+    with zipfile.ZipFile(dest) as zf:
+        assert zf.read("mimetype") == b"application/epub+zip"
+    rep = inspect_container(dest)
+    assert rep.format == "epub"
+    assert rep.has_c2pa is False
+    assert rep.has_ai_metadata is False
+
+
+def test_clean_epub_keeps_plain_creator():
+    epub = _build_epub(creator="Jane Doe", generator="", with_c2pa_png=False, with_meta_part=False)
+    cleaned, actions = clean_epub(epub)
+    with zipfile.ZipFile(io.BytesIO(cleaned)) as zf:
+        opf = zf.read("OEBPS/content.opf").decode("utf-8")
+    assert "Jane Doe" in opf
+    assert not any("creator" in a for a in actions)

--- a/tests/test_image_formats_bmp_gif_tiff.py
+++ b/tests/test_image_formats_bmp_gif_tiff.py
@@ -1,0 +1,404 @@
+"""Tests for BMP, GIF, and TIFF (classic + BigTIFF) metadata handling."""
+
+from __future__ import annotations
+
+import struct
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "service" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from format_dispatch import classify_bytes
+from image_meta import (
+    clean_image,
+    detect_format,
+    inspect_bmp,
+    inspect_gif,
+    inspect_image,
+    inspect_tiff,
+    strip_bmp,
+    strip_gif,
+    strip_tiff,
+)
+
+
+def _minimal_bmp(*, trailing: bytes = b"") -> bytes:
+    pixel = b"\x00\x00\xff\xff"  # BGRA, 4 bytes (1x1 32-bit, no row padding)
+    dib = struct.pack("<IiiHHIIiiII", 40, 1, 1, 1, 32, 0, len(pixel), 0, 0, 0, 0)
+    data_offset = 14 + len(dib)
+    header = b"BM" + struct.pack("<IHHI", data_offset + len(pixel), 0, 0, data_offset)
+    return header + dib + pixel + trailing
+
+
+def _gif_sub_block(size: int, payload: bytes) -> bytes:
+    return bytes([size]) + payload
+
+
+def _gif_extension(label: int, payload: bytes) -> bytes:
+    out = b"\x21" + bytes([label])
+    pos = 0
+    while pos < len(payload):
+        chunk = payload[pos : pos + 255]
+        out += _gif_sub_block(len(chunk), chunk)
+        pos += 255
+    out += b"\x00"
+    return out
+
+
+def _minimal_gif(*extensions: tuple[int, bytes], image: bytes = b"") -> bytes:
+    lsd = struct.pack("<HHBBB", 1, 1, 0x00, 0x00, 0x00)
+    if not image:
+        image = (
+            b"\x2c"
+            + struct.pack("<HHHHB", 0, 0, 1, 1, 0x00)
+            + b"\x02"
+            + _gif_sub_block(2, b"\x02\x44")
+            + b"\x00"
+        )
+    return (
+        b"GIF89a"
+        + lsd
+        + b"".join(_gif_extension(lbl, p) for lbl, p in extensions)
+        + image
+        + b"\x3b"
+    )
+
+
+GIF_XMP = (
+    b"XMP DataXMP"
+    + b'<x:xmpmeta><rdf:RDF><rdf:Description digitalSourceType="trainedAlgorithmicMedia"/></rdf:RDF></x:xmpmeta>'
+)
+
+
+def _entry(bo: str, big: bool, tag: int, ftype: int, fcount: int, value: bytes) -> bytes:
+    count_fmt = bo + ("Q" if big else "I")
+    return struct.pack(bo + "HH", tag, ftype) + struct.pack(count_fmt, fcount) + value
+
+
+def _minimal_tiff(*, big_endian: bool = False, big: bool = False, with_meta: bool = True):
+    bo = "<" if not big_endian else ">"
+    off_fmt = bo + ("Q" if big else "I")
+    count_fmt = bo + ("Q" if big else "H")
+    count_len = 8 if big else 2
+    off_len = 8 if big else 4
+    entry_size = 20 if big else 12
+    header_size = 16 if big else 8
+    xmp = (
+        b'<x:xmpmeta xmlns:x="adobe:ns:meta/"><rdf:RDF><rdf:Description '
+        b'digitalSourceType="trainedAlgorithmicMedia"/></rdf:RDF></x:xmpmeta>'
+    )
+    make = b"Acme Corp\x00"
+    dt = b"2024:01:01 10:00:00\x00"
+    maker = b"AIGC maker\x00"
+    strip_data = b"\xaa\xbb\xcc\xdd\xee\xff\x00\x11"
+
+    def short_val(v: int) -> bytes:
+        return struct.pack(bo + "H", v) + b"\x00" * (off_len - 2)
+
+    def long_val(v: int) -> bytes:
+        return struct.pack(off_fmt, v)
+
+    ifd0 = [
+        (256, 4, 1, long_val(1)),
+        (257, 4, 1, long_val(1)),
+        (258, 3, 1, short_val(8)),
+        (259, 3, 1, short_val(1)),
+        (262, 3, 1, short_val(2)),
+        (273, 4, 1, b"\x00" * off_len),
+        (278, 4, 1, long_val(1)),
+        (279, 4, 1, long_val(len(strip_data))),
+    ]
+    if with_meta:
+        ifd0 += [
+            (271, 2, len(make), b"\x00" * off_len),
+            (700, 2, len(xmp), b"\x00" * off_len),
+            (34665, 4, 1, b"\x00" * off_len),
+        ]
+    count = len(ifd0)
+    ifd0_off = header_size
+    ifd0_end = ifd0_off + count_len + count * entry_size + off_len
+    cursor = ifd0_end
+
+    exif_count = 3 if with_meta else 0
+    exif_off = cursor if with_meta else 0
+    if with_meta:
+        cursor += count_len + exif_count * entry_size + off_len
+        exp_payload = struct.pack(bo + "II", 1, 100)
+        exp_off = cursor
+        cursor += len(exp_payload)
+        dt_off = cursor
+        cursor += len(dt)
+        mn_off = cursor
+        cursor += len(maker)
+
+    strip_off = cursor
+    cursor += len(strip_data)
+    make_off = cursor
+    cursor += len(make)
+    xmp_off = cursor
+    cursor += len(xmp)
+
+    ifd0_bytes = bytearray(struct.pack(count_fmt, count))
+    for tag, ftype, fcount, _v in ifd0:
+        if tag == 273:
+            ifd0_bytes += _entry(bo, big, tag, 4, 1, long_val(strip_off))
+        elif tag == 271:
+            ifd0_bytes += _entry(bo, big, tag, 2, len(make), long_val(make_off))
+        elif tag == 700:
+            ifd0_bytes += _entry(bo, big, tag, 2, len(xmp), long_val(xmp_off))
+        elif tag == 34665:
+            ifd0_bytes += _entry(bo, big, tag, 4, 1, long_val(exif_off))
+        else:
+            ifd0_bytes += _entry(bo, big, tag, ftype, fcount, _v)
+    ifd0_bytes += struct.pack(off_fmt, 0)
+
+    if with_meta:
+        exif_bytes = bytearray(struct.pack(count_fmt, exif_count))
+        exif_bytes += _entry(bo, big, 33434, 5, 1, long_val(exp_off))
+        exif_bytes += _entry(bo, big, 36867, 2, len(dt), long_val(dt_off))
+        exif_bytes += _entry(bo, big, 37500, 2, len(maker), long_val(mn_off))
+        exif_bytes += struct.pack(off_fmt, 0)
+        tail = exp_payload + dt + maker + strip_data + make + xmp
+    else:
+        exif_bytes = b""
+        tail = strip_data + make + xmp
+
+    if big:
+        header = (
+            (b"II" if not big_endian else b"MM")
+            + struct.pack(bo + "H", 43)
+            + struct.pack(bo + "H", 8)
+            + struct.pack(bo + "H", 0)
+            + struct.pack(off_fmt, ifd0_off)
+        )
+    else:
+        header = (
+            (b"II" if not big_endian else b"MM")
+            + struct.pack(bo + "H", 42)
+            + struct.pack(off_fmt, ifd0_off)
+        )
+    return header + bytes(ifd0_bytes) + bytes(exif_bytes) + tail, strip_off, strip_data
+
+
+def test_detect_format_bmp_gif_tiff():
+    assert detect_format(_minimal_bmp()) == "bmp"
+    assert detect_format(_minimal_gif()) == "gif"
+    le, _o, _d = _minimal_tiff()
+    be, _o2, _d2 = _minimal_tiff(big_endian=True)
+    bigle, _o3, _d3 = _minimal_tiff(big=True)
+    bigbe, _o4, _d4 = _minimal_tiff(big=True, big_endian=True)
+    assert detect_format(le) == "tiff"
+    assert detect_format(be) == "tiff"
+    assert detect_format(bigle) == "tiff"
+    assert detect_format(bigbe) == "tiff"
+    assert detect_format(b"GIF87a rest") == "gif"
+
+
+def test_format_dispatch_bmp_gif_tiff():
+    assert classify_bytes(_minimal_bmp(), ".bmp") == "image"
+    assert classify_bytes(_minimal_gif(), ".gif") == "image"
+    tiff_le, _o, _d = _minimal_tiff()
+    assert classify_bytes(tiff_le, ".tiff") == "image"
+    assert classify_bytes(tiff_le, ".tif") == "image"
+    assert classify_bytes(tiff_le, "") == "image"
+    assert classify_bytes(_minimal_gif(), "") == "image"
+    bigle, _o2, _d2 = _minimal_tiff(big=True)
+    assert classify_bytes(bigle, "") == "image"
+
+
+def test_bmp_clean_has_no_flags():
+    data = _minimal_bmp()
+    has_c2pa, has_ai, findings = inspect_bmp(data)
+    assert has_c2pa is False
+    assert has_ai is False
+    assert any("no metadata" in f.lower() for f in findings)
+    cleaned, actions = strip_bmp(data)
+    assert cleaned == data
+    assert any("no BMP trailing" in a for a in actions)
+
+
+def test_bmp_trailing_metadata_detected_and_stripped():
+    xmp = b'<x:xmpmeta><rdf:Description digitalSourceType="trainedAlgorithmicMedia"/></x:xmpmeta>'
+    data = _minimal_bmp(trailing=xmp)
+    _has_c2pa, has_ai, findings = inspect_bmp(data)
+    assert has_ai is True
+    assert any("trailing" in f.lower() for f in findings)
+
+    cleaned, actions = strip_bmp(data)
+    assert any("drop" in a for a in actions)
+    assert xmp not in cleaned
+    assert cleaned == _minimal_bmp()
+    assert struct.unpack("<I", cleaned[2:6])[0] == len(cleaned)
+
+
+def test_bmp_keep_non_ai_metadata():
+    xmp = b"trailing bytes without markers"
+    data = _minimal_bmp(trailing=xmp)
+    kept, actions = strip_bmp(data, strip_all_metadata=False)
+    assert kept == data
+    assert any("keep" in a.lower() for a in actions)
+
+
+def test_bmp_roundtrip(tmp_path: Path):
+    src = tmp_path / "pixel.bmp"
+    src.write_bytes(_minimal_bmp(trailing=b"<x:xmpmeta>OpenAI</x:xmpmeta>"))
+    dest = tmp_path / "pixel.cleaned.bmp"
+    report = clean_image(src, dest)
+    assert report["format"] == "bmp"
+    assert report["still_has_ai_metadata"] is False
+    assert dest.read_bytes() == _minimal_bmp()
+
+
+def test_gif_inspect_detects_comment_and_xmp():
+    data = _minimal_gif((0xFE, b"made with c2pa tools"), (0xFF, GIF_XMP))
+    has_c2pa, has_ai, findings = inspect_gif(data)
+    assert has_ai is True
+    assert has_c2pa is True
+    assert any("comment" in f.lower() for f in findings)
+    assert any("xmp" in f.lower() for f in findings)
+
+
+def test_gif_strip_removes_metadata_keeps_pixels_and_loop(tmp_path: Path):
+    image = (
+        b"\x2c"
+        + struct.pack("<HHHHB", 0, 0, 1, 1, 0x00)
+        + b"\x02"
+        + _gif_sub_block(2, b"\x02\x44")
+        + b"\x00"
+    )
+    loop = b"NETSCAPE2.0" + struct.pack("<H", 0)
+    data = _minimal_gif(
+        (0xFE, b"made with c2pa tools"),
+        (0xFF, GIF_XMP),
+        (0xFF, loop),
+        (0xF9, b"\x00\x00\x00\x00"),
+        image=image,
+    )
+    cleaned, actions = strip_gif(data)
+    assert any("drop GIF comment" in a for a in actions)
+    assert any("drop GIF XMP application" in a for a in actions)
+    assert b"c2pa tools" not in cleaned
+    assert b"XMP DataXMP" not in cleaned
+    assert loop in cleaned
+    assert b"\x21\xf9\x04" in cleaned
+    assert image in cleaned
+    has_c2pa, has_ai, _findings = inspect_gif(cleaned)
+    assert has_c2pa is False
+    assert has_ai is False
+
+
+def test_gif_keep_non_ai_metadata():
+    plain = _minimal_gif((0xFE, b"just a comment"))
+    _stripped, actions = strip_gif(plain)
+    assert any("drop GIF comment" in a for a in actions)
+    kept, actions2 = strip_gif(plain, strip_all_metadata=False)
+    assert b"just a comment" in kept
+    assert not any("drop GIF" in a for a in actions2)
+
+
+def test_gif_global_color_table_preserved():
+    header = b"GIF89a"
+    lsd = struct.pack("<HHBBB", 2, 2, 0x91, 0, 0)
+    ncolors = 1 << ((0x91 & 0x07) + 1)
+    gct = bytes(range(3 * ncolors))
+    image = (
+        b"\x2c"
+        + struct.pack("<HHHHB", 0, 0, 2, 2, 0x00)
+        + b"\x02"
+        + _gif_sub_block(2, b"\x02\x44")
+        + b"\x00"
+    )
+    data = header + lsd + gct + _gif_extension(0xFE, b"hello") + image + b"\x3b"
+    cleaned, actions = strip_gif(data)
+    assert any("drop GIF comment" in a for a in actions)
+    assert gct in cleaned
+    assert image in cleaned
+    assert b"hello" not in cleaned
+    assert detect_format(cleaned) == "gif"
+
+
+def test_gif_roundtrip(tmp_path: Path):
+    src = tmp_path / "anim.gif"
+    src.write_bytes(_minimal_gif((0xFE, b"made with c2pa tools"), (0xFF, GIF_XMP)))
+    dest = tmp_path / "anim.cleaned.gif"
+    report = clean_image(src, dest)
+    assert report["format"] == "gif"
+    assert report["still_has_c2pa"] is False
+    assert report["still_has_ai_metadata"] is False
+    rep = inspect_image(dest)
+    assert rep.format == "gif"
+    assert rep.has_ai_metadata is False
+
+
+def test_tiff_inspect_detects_metadata():
+    data, _off, _strip = _minimal_tiff()
+    _has_c2pa, has_ai, findings = inspect_tiff(data)
+    assert has_ai is True
+    assert any("XMP" in f for f in findings)
+    assert any("ExifIFD" in f for f in findings)
+    assert any("MakerNote" in f for f in findings)
+    assert any("trainedAlgorithmicMedia" in f for f in findings)
+
+
+def test_tiff_strip_removes_metadata_preserves_strip():
+    data, strip_off, strip_data = _minimal_tiff()
+    cleaned, actions = strip_tiff(data)
+    assert any("drop TIFF tag 700" in a for a in actions)
+    assert any("drop TIFF tag 34665" in a for a in actions)
+    assert any("drop TIFF tag 271" in a for a in actions)
+    assert b"Acme Corp" not in cleaned
+    assert b"trainedAlgorithmicMedia" not in cleaned
+    assert b"AIGC" not in cleaned
+    assert b"2024:01:01" not in cleaned
+    assert cleaned[strip_off : strip_off + len(strip_data)] == strip_data
+    assert detect_format(cleaned) == "tiff"
+    has_c2pa, has_ai, _findings = inspect_tiff(cleaned)
+    assert has_c2pa is False
+    assert has_ai is False
+
+
+def test_tiff_bigtiff_strip():
+    for kwargs in ({"big": True}, {"big": True, "big_endian": True}):
+        data, strip_off, strip_data = _minimal_tiff(**kwargs)
+        cleaned, actions = strip_tiff(data)
+        assert any("drop TIFF tag 700" in a for a in actions)
+        assert b"Acme Corp" not in cleaned
+        assert b"trainedAlgorithmicMedia" not in cleaned
+        assert cleaned[strip_off : strip_off + len(strip_data)] == strip_data
+        assert detect_format(cleaned) == "tiff"
+        has_c2pa, has_ai, _findings = inspect_tiff(cleaned)
+        assert has_c2pa is False
+        assert has_ai is False
+
+
+def test_tiff_clean_roundtrip_byte_identical():
+    data, _off, _strip = _minimal_tiff(with_meta=False)
+    cleaned, actions = strip_tiff(data)
+    assert cleaned == data
+    assert any("no TIFF metadata tags removed" in a for a in actions)
+
+
+def test_tiff_keep_non_ai_metadata():
+    data, _off, _strip = _minimal_tiff()
+    cleaned, actions = strip_tiff(data, strip_all_metadata=False)
+    assert any("drop TIFF tag 700" in a for a in actions)
+    assert any("drop TIFF tag 34665" in a for a in actions)
+    assert not any("drop TIFF tag 271" in a for a in actions)
+    assert b"Acme Corp" in cleaned
+    assert b"AIGC" not in cleaned
+
+
+def test_tiff_roundtrip(tmp_path: Path):
+    data, _off, _strip = _minimal_tiff()
+    src = tmp_path / "photo.tiff"
+    src.write_bytes(data)
+    dest = tmp_path / "photo.cleaned.tiff"
+    report = clean_image(src, dest)
+    assert report["format"] == "tiff"
+    assert report["still_has_c2pa"] is False
+    assert report["still_has_ai_metadata"] is False
+    rep = inspect_image(dest)
+    assert rep.format == "tiff"
+    assert rep.has_ai_metadata is False


### PR DESCRIPTION
## Summary

Adds stdlib-only detection, inspection, and metadata cleaning for four more file formats: **BMP**, **GIF**, **TIFF** (classic and BigTIFF), and **EPUB**.

All four route through `format_dispatch`, so the unified CLIs (`inspect_file.py` / `clean_file.py`), the HTTP service, and the audits pick them up automatically — no per-tool wiring needed.

## Formats

### BMP
Classic BMP has no standardized metadata container. The only realistic place provenance data can live is in trailing bytes after the image payload, so:
- `inspect_bmp` parses the DIB header (40/108/124-byte variants) to locate the true pixel extent and scans **only** the trailing bytes — never pixel data (no false positives from compressed/embedded images).
- `strip_bmp` truncates trailing metadata and rewrites the 4-byte file-size field, leaving the pixel payload byte-identical.

### GIF
GIF carries metadata in comment (`0xFE`) and application (`0xFF`, incl. the standardized `XMP DataXMP`) extensions.
- `strip_gif` drops comment + XMP extensions but **preserves `NETSCAPE2.0` looping, ICC, graphic-control, and image blocks**, so cleaning an animated GIF doesn't change its behavior.

### TIFF (classic + BigTIFF)
TIFF is the richest of the four (XMP, EXIF, GPS, IPTC, Photoshop, MakerNote, camera tags).
- `_parse_tiff_ifds` walks IFD chains for **both** classic (12-byte entries) and BigTIFF (20-byte entries, 64-bit offsets) layouts.
- `strip_tiff` patches each IFD entry region in place (padded to original length) so every offset stays valid, zeroes the payloads of dropped tags and orphaned sub-IFD chains, and keeps strip/tile data untouched.

### EPUB
- `clean_epub` scrubs OPF package metadata and XHTML meta/JSON-LD, cleans embedded raster/SVG media, applies Layer A to XHTML body text, and drops marker-carrying metadata parts.
- **OCF-encrypted parts are passed through verbatim** — decoding ciphertext as UTF-8 and running regexes over it would corrupt the book.

## Testing

- `tests/test_image_formats_bmp_gif_tiff.py` — 17 cases (detection, dispatch, inspect/strip per format, BigTIFF LE/BE, `NETSCAPE2.0` preservation, global color table, BMP trailing-strip, byte-identical clean, keep-non-ai mode).
- `tests/test_epub.py` — 7 cases (detection/sniffing, inspect, clean with embedded media + Layer A + part dropping, encrypted-part skip, round-trip, plain-creator preservation).

Full suite: 348 passed, 1 skipped. `ruff check` and `ruff format --check` clean.

