### PR TITLE
docs: discourage watermarks-remover look-alike names in Ecosystem entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,7 +666,7 @@ Third-party projects that wrap or complement this repository, listed for discove
 
 ### Adding a project
 
-To register a project here, open a PR adding a short entry — project name, what it wraps or adds, and a link to its own repository. Keep entries brief and factual; do not claim compatibility with, or endorsement by, this project.
+To register a project here, open a PR adding a short entry — project name, what it wraps or adds, and a link to its own repository. Keep entries brief and factual; do not claim compatibility with, or endorsement by, this project. Please avoid names that start with or closely resemble `watermarks-remover` — look-alike names make it hard to tell which project is which.
 
 ## Tests
 


### PR DESCRIPTION
## Summary

Sets the naming expectation up front in the Ecosystem section: entries should avoid names that start with or closely resemble `watermarks-remover`, so future submissions are guided by the README instead of being flagged case by case.

## Changes

- **README.md** - under `### Adding a project`: added one sentence asking contributors to avoid look-alike names.

## Testing

Docs-only change; no tests required.
