### PR TITLE
fix: mark only one rewrite candidate as selected

### DIFF
--- a/service/scripts/rewrite_text.py
+++ b/service/scripts/rewrite_text.py
@@ -378,6 +378,7 @@ def rewrite(
     else:
         info["candidates"] = n
         out, scores = _select_candidate(text, outs)
+        selected_idx = max(range(len(outs)), key=lambda i: scores[i])
         trigger = markllm_scheme is not None or bool(
             os.environ.get("WATERMARKS_GEMINI_API_KEY", "").strip()
         )
@@ -388,7 +389,7 @@ def rewrite(
                 {
                     "lexical_divergence": _lexical_divergence(text, cand),
                     "selection_score": scores[i],
-                    "selected": cand == out,
+                    "selected": i == selected_idx,
                     "detections": detections[i] if trigger else [],
                 }
             )

--- a/tests/test_rewrite_text.py
+++ b/tests/test_rewrite_text.py
@@ -163,6 +163,32 @@ def _two_candidates(monkeypatch):
     monkeypatch.setattr(rewrite_text, "call_ollama", lambda *a, **k: next(texts))
 
 
+def test_duplicate_candidates_mark_only_one_selected(monkeypatch):
+    monkeypatch.delenv("WATERMARKS_GEMINI_API_KEY", raising=False)
+
+    texts = iter(
+        [
+            "alpha beta gamma delta",
+            "alpha beta gamma delta",
+        ]
+    )
+    monkeypatch.setattr(
+        rewrite_text,
+        "call_ollama",
+        lambda *a, **k: next(texts),
+    )
+
+    out, info = rewrite(
+        "the cat sat on the mat",
+        **_rewrite_candidates_kwargs(),
+    )
+
+    assert out == "alpha beta gamma delta"
+
+    selected = [entry["selected"] for entry in info["candidate_scores"]]
+    assert selected == [True, False]
+
+
 def test_candidate_scores_restructured_with_detections(monkeypatch):
     monkeypatch.setattr(rewrite_text, "MarkLLMTextDetector", _FakeMarkLLM)
     calls: list = []


### PR DESCRIPTION
## Why

Per-candidate stats currently use `cand == out` to mark the selected rewrite candidate.

`_select_candidate()` selects a single candidate index, but if the rewrite backend returns duplicate candidate strings, multiple entries can compare equal to `out` and therefore be reported as `"selected": true`.

## What

- Track the selected candidate by index rather than string equality.
- Add a regression test covering duplicate rewrite candidates.
- Keep the existing lexical candidate-selection behavior unchanged.

## Verification

- `python3 -m pytest -q tests/test_rewrite_text.py`
- `python3 -m pytest -q`

Both test commands pass locally with Python 3.12. The full suite has one existing skip.

Related to #106 and #109.