### PR TITLE
fix: validate /clean option types

### DIFF
--- a/service/scripts/server.py
+++ b/service/scripts/server.py
@@ -462,9 +462,13 @@ class Handler(BaseHTTPRequestHandler):
             options = {}
         if not isinstance(options, dict):
             raise ValueError("'options' must be an object")
-        for key in options:
+        for key, value in options.items():
             if key not in ALLOWED_CLEAN_OPTIONS:
                 raise ValueError(f"unknown option: {key}")
+            expected_type = ALLOWED_CLEAN_OPTIONS[key]
+            if not isinstance(value, expected_type):
+                type_name = "boolean" if expected_type is bool else "string"
+                raise ValueError(f"option {key!r} must be a {type_name}")
 
         with tempfile.TemporaryDirectory(prefix="wm-clean-") as tmp:
             tmpdir = Path(tmp)

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -182,6 +182,25 @@ def test_unknown_option_rejected(conn):
     assert "unknown option" in body["error"]
 
 
+@pytest.mark.parametrize(
+    ("key", "value", "type_name"),
+    [
+        ("nfkc", "false", "boolean"),
+        ("aggressive_homoglyphs", 1, "boolean"),
+        ("keep_non_ai_metadata", None, "boolean"),
+        ("also_layer_a_text", {}, "boolean"),
+        ("strip_all_metadata", [], "boolean"),
+        ("remove_pixel", False, "string"),
+    ],
+)
+def test_option_wrong_type_rejected(conn, key, value, type_name):
+    status, body = _post(
+        conn, "/clean", {"file": _b64(b"x"), "name": "x.txt", "options": {key: value}}
+    )
+    assert status == 400
+    assert body["error"] == f"option '{key}' must be a {type_name}"
+
+
 def test_bad_base64_rejected(conn):
     status, _body = _post(conn, "/inspect", {"file": "!!!not-base64!!!"})
     assert status == 400


### PR DESCRIPTION
## Summary

- validate `/clean` option values against the types declared in `ALLOWED_CLEAN_OPTIONS`
- return HTTP 400 when boolean or string options have the wrong JSON type
- add parameterized regression coverage for every supported clean option

## Problem

The OpenAPI schema declares options such as `nfkc` as booleans, but the
server only validates option names. A request containing `"nfkc": "false"`
is accepted and interpreted as true because `bool("false")` is `True`,
unexpectedly enabling NFKC normalization.

## Testing

- `python -m pytest -q`
- `python -m ruff check service tests`
- `python -m ruff format --check service tests`
- OpenAPI specification validation
