### PR TITLE
docs: add Windows auto-start guide via Task Scheduler 

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ make serve                 # http://127.0.0.1:8765
 python3 service/scripts/server.py --host 127.0.0.1 --port 8765
 ```
 
+### Windows (no Docker)
+
+See [docs/windows-autostart.md](docs/windows-autostart.md) for auto-starting the service at Windows login without Docker.
+
 For the whole infra (core + optional harness/heavy backends), see [Docker / compose](#docker--compose) below.
 
 Optional system tools (auto-used when present — preinstalled in the core Docker image):

--- a/docs/windows-autostart.md
+++ b/docs/windows-autostart.md
@@ -1,94 +1,51 @@
-\# Windows: Auto-start the service at login
-
-
+# Windows: Auto-start the service at login
 
 Run the service silently in the background on every login, without a terminal window or manual start.
 
+## 1. Clone the repo somewhere permanent
 
+Replace `<path-to-clone>` below with wherever you want the repo to live (e.g. `C:\watermarks-remover` or `C:\Users\<you>\watermarks-remover`). Use the same path consistently in every step below.
 
-\## 1. Clone the repo somewhere permanent
+```powershell
+git clone https://github.com/guillaumemeyer/watermarks-remover.git <path-to-clone>
+```
 
+## 2. Create a silent launcher script
 
+Save as `<path-to-clone>\start-service.vbs`:
 
-\\`\\`\\`powershell
-
-git clone https://github.com/guillaumemeyer/watermarks-remover.git C:\\watermarks-remover
-
-\\`\\`\\`
-
-
-
-\## 2. Create a silent launcher script
-
-
-
-Save as `C:\\watermarks-remover\\start-service.vbs`:
-
-
-
-\\`\\`\\`vbscript
-
+```vbscript
 Set WshShell = CreateObject("WScript.Shell")
+WshShell.Run "python service\scripts\server.py --host 127.0.0.1 --port 8765", 0, False
+```
 
-WshShell.Run "python service\\scripts\\server.py --host 127.0.0.1 --port 8765", 0, False
+## 3. Register a scheduled task
 
-\\`\\`\\`
+This does **not** require Administrator privileges — `-AtLogOn` with a user-level trigger runs under your own account, so a regular PowerShell window is enough.
 
-
-
-\## 3. Register a scheduled task (run PowerShell as Administrator)
-
-
-
-\\`\\`\\`powershell
-
-$action = New-ScheduledTaskAction -Execute "wscript.exe" -Argument '"C:\\watermarks-remover\\start-service.vbs"' -WorkingDirectory "C:\\watermarks-remover"
-
+```powershell
+$action = New-ScheduledTaskAction -Execute "wscript.exe" -Argument '"<path-to-clone>\start-service.vbs"' -WorkingDirectory "<path-to-clone>"
 $trigger = New-ScheduledTaskTrigger -AtLogOn
-
 $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable
-
 Register-ScheduledTask -TaskName "WatermarksRemoverService" -Action $action -Trigger $trigger -Settings $settings -Description "Auto-starts the watermarks-remover HTTP service at login"
+```
 
-\\`\\`\\`
+## 4. Start it immediately (no reboot needed)
 
-
-
-\## 4. Start it immediately (no reboot needed)
-
-
-
-\\`\\`\\`powershell
-
+```powershell
 Start-ScheduledTask -TaskName "WatermarksRemoverService"
+```
 
-\\`\\`\\`
+## 5. Verify
 
-
-
-\## 5. Verify
-
-
-
-\\`\\`\\`powershell
-
+```powershell
 Invoke-RestMethod http://127.0.0.1:8765/health
-
-\\`\\`\\`
-
-
+```
 
 Should return `{"ok": true, "version": "..."}`.
 
+## Notes
 
-
-\## Notes
-
-
-
-\- Requires Python 3.10+ on PATH.
-
-\- The scheduled task runs at every login going forward — no manual start needed.
-
-\- To stop auto-starting: `Unregister-ScheduledTask -TaskName "WatermarksRemoverService"`
-
+- Requires Python 3.10+ on PATH.
+- The scheduled task runs at every login going forward — no manual start needed.
+- To stop auto-starting: `Unregister-ScheduledTask -TaskName "WatermarksRemoverService"`

--- a/docs/windows-autostart.md
+++ b/docs/windows-autostart.md
@@ -1,0 +1,94 @@
+\# Windows: Auto-start the service at login
+
+
+
+Run the service silently in the background on every login, without a terminal window or manual start.
+
+
+
+\## 1. Clone the repo somewhere permanent
+
+
+
+\\`\\`\\`powershell
+
+git clone https://github.com/guillaumemeyer/watermarks-remover.git C:\\watermarks-remover
+
+\\`\\`\\`
+
+
+
+\## 2. Create a silent launcher script
+
+
+
+Save as `C:\\watermarks-remover\\start-service.vbs`:
+
+
+
+\\`\\`\\`vbscript
+
+Set WshShell = CreateObject("WScript.Shell")
+
+WshShell.Run "python service\\scripts\\server.py --host 127.0.0.1 --port 8765", 0, False
+
+\\`\\`\\`
+
+
+
+\## 3. Register a scheduled task (run PowerShell as Administrator)
+
+
+
+\\`\\`\\`powershell
+
+$action = New-ScheduledTaskAction -Execute "wscript.exe" -Argument '"C:\\watermarks-remover\\start-service.vbs"' -WorkingDirectory "C:\\watermarks-remover"
+
+$trigger = New-ScheduledTaskTrigger -AtLogOn
+
+$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable
+
+Register-ScheduledTask -TaskName "WatermarksRemoverService" -Action $action -Trigger $trigger -Settings $settings -Description "Auto-starts the watermarks-remover HTTP service at login"
+
+\\`\\`\\`
+
+
+
+\## 4. Start it immediately (no reboot needed)
+
+
+
+\\`\\`\\`powershell
+
+Start-ScheduledTask -TaskName "WatermarksRemoverService"
+
+\\`\\`\\`
+
+
+
+\## 5. Verify
+
+
+
+\\`\\`\\`powershell
+
+Invoke-RestMethod http://127.0.0.1:8765/health
+
+\\`\\`\\`
+
+
+
+Should return `{"ok": true, "version": "..."}`.
+
+
+
+\## Notes
+
+
+
+\- Requires Python 3.10+ on PATH.
+
+\- The scheduled task runs at every login going forward — no manual start needed.
+
+\- To stop auto-starting: `Unregister-ScheduledTask -TaskName "WatermarksRemoverService"`
+


### PR DESCRIPTION
## What

Adds `docs/windows-autostart.md`: a guide for auto-starting `service/scripts/server.py` on Windows at login, using a silent `.vbs` launcher registered via Task Scheduler. No Docker required.

## Why

The README covers starting the service via Docker/compose or `make serve`, but neither persists across reboots/logins on Windows, and there's no documented path for Windows users without Docker. As a result, the `/remove-ai-marks` skill's health check (`WATERMARKS_SERVICE_URL`, default `http://127.0.0.1:8765`) fails until the service is started manually each session. This doc fixes that.

## Checklist

- Behaviour matches `SKILL.md` / `references/removal-matrix.md` when relevant—docs-only, no runtime behaviour changed
- Docs updated (README and/or skill references) if user-facing behavior changes
- No drive-by refactors unrelated to the fix or feature

## Notes for reviewer

Docs-only, no code touched. Scoped to local auto-start (`127.0.0.1` only)—deliberately does not cover exposing the service
over a public tunnel (e.g., ngrok), which is a different security posture and out of scope here. Manually verified on Windows 11: the service starts automatically at login with no visible console window, and `/health` responds correctly with zero manual steps. No sample files or secrets included.