### PR TITLE
fix(docs): use portable base64 encoding in curl examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ WM="http://127.0.0.1:8765"
 curl -s "$WM/health"                       # {"ok": true, "version": "..."}
 curl -s "$WM/openapi.json"                 # machine-readable OpenAPI 3.0.3 contract
 curl -s -X POST "$WM/clean" -H 'Content-Type: application/json' \
-  -d "{\"file\": \"$(base64 -w0 notes.md)\", \"name\": \"notes.md\"}"
+  -d "{\"file\": \"$(base64 < notes.md | tr -d '\n')\", \"name\": \"notes.md\"}"
 ```
 
 The service routes by filename extension then magic bytes, so text / image / container are auto-detected. Set `WATERMARKS_SERVER_API_KEY` to require `Authorization: Bearer <key>` on every request. Loopback-only bind by default (`--host` to override); intended for a trusted network.
@@ -213,7 +213,7 @@ Checks `wr-core` via `GET /health` and runs each harness/heavy service with `--h
 ```bash
 echo "Hello\u200bWorld\u00ad!" > /tmp/sample.txt
 curl -s -X POST http://127.0.0.1:8765/clean -H 'Content-Type: application/json' \
-  -d "{\"file\": \"$(base64 -w0 /tmp/sample.txt)\", \"name\": \"sample.txt\"}"
+  -d "{\"file\": \"$(base64 < /tmp/sample.txt | tr -d '\n')\", \"name\": \"sample.txt\"}"
 ```
 
 Everything else is optional and lives in a `.env` file at the repo root. `docker compose` **auto-loads `.env`** and interpolates the `${VAR}` references in `compose.yaml` from it (shell exports win over `.env` if both are set).

--- a/skills/remove-ai-marks/SKILL.md
+++ b/skills/remove-ai-marks/SKILL.md
@@ -86,14 +86,14 @@ clients.
 
 ```bash
 curl -s -X POST "$WM/inspect" -H 'Content-Type: application/json' \
-  -d "{\"file\": \"$(base64 -w0 notes.md)\", \"name\": \"notes.md\"}"
+  -d "{\"file\": \"$(base64 < notes.md | tr -d '\n')\", \"name\": \"notes.md\"}"
 ```
 
 **Clean** (text / image / container are auto-detected by name + bytes):
 
 ```bash
 curl -s -X POST "$WM/clean" -H 'Content-Type: application/json' \
-  -d "{\"file\": \"$(base64 -w0 notes.md)\", \"name\": \"notes.md\"}"
+  -d "{\"file\": \"$(base64 < notes.md | tr -d '\n')\", \"name\": \"notes.md\"}"
 ```
 
 Decode the returned `cleaned` base64 into the output file (`*.cleaned.*` by
@@ -126,7 +126,7 @@ mostly just send the file.
 
 ```bash
 curl -s -X POST "$WM/inspect" -H 'Content-Type: application/json' \
-  -d "{\"file\": \"$(base64 -w0 path)\", \"name\": \"$(basename path)\"}"
+  -d "{\"file\": \"$(base64 < path | tr -d '\n')\", \"name\": \"$(basename path)\"}"
 ```
 
 Show a short summary (suspicious codepoints; C2PA/AI flags; confidence labels
@@ -144,7 +144,7 @@ local detector is an official vendor detector.
 
 ```bash
 curl -s -X POST "$WM/clean" -H 'Content-Type: application/json' \
-  -d "{\"file\": \"$(base64 -w0 INPUT)\", \"name\": \"$(basename INPUT)\"}"
+  -d "{\"file\": \"$(base64 < INPUT | tr -d '\n')\", \"name\": \"$(basename INPUT)\"}"
 ```
 
 Decode `cleaned` → `OUTPUT` (`*.cleaned.*` unless the user asked in-place).
@@ -158,7 +158,7 @@ says the backend is present:
 
 ```bash
 curl -s -X POST "$WM/clean" -H 'Content-Type: application/json' \
-  -d "{\"file\": \"$(base64 -w0 shot.png)\", \"name\": \"shot.png\", \
+  -d "{\"file\": \"$(base64 < shot.png | tr -d '\n')\", \"name\": \"shot.png\", \
        \"options\": {\"remove_pixel\": \"ctrlregen\"}}"
 ```
 


### PR DESCRIPTION
## Problem

`base64 -w0 FILE` is a GNU coreutils form. On macOS/BSD there is no `-w` flag, so it fails and prints usage instead of encoding:

```
$ base64 -w0 notes.md
base64: invalid argument notes.md
Usage:	base64 [-Ddh] [-b num] [-i in_file] [-o out_file]
```

Every documented `/inspect` and `/clean` example is therefore unrunnable as written on a Mac host.

This is worse than a normal docs typo because of how the skill is designed. `SKILL.md` is a thin HTTP client that tells the agent to call the service with these exact commands, and it explicitly instructs the agent to **stop rather than fall back to local cleaning** if the service call fails:

> **Always check it first**, and stop with a clear message if it is unreachable — never fall back to local cleaning.

So on macOS the agent doesn't degrade gracefully — it constructs a request with an empty/invalid `file` field on its first call. The docs already carry a Windows-specific note for building base64, so the POSIX/BSD gap looks like an oversight rather than a deliberate GNU-only stance.

## Fix

Replace all 7 occurrences (2 in `README.md`, 5 in `skills/remove-ai-marks/SKILL.md`) with the POSIX form, which reads from stdin and unwraps any line breaks:

```bash
base64 < FILE | tr -d '\n'
```

This is portable rather than a swap of one platform's dialect for another's: GNU `base64` wraps at 76 columns and `tr -d '\n'` unwraps it, producing exactly what `-w0` produced. I avoided BSD's `base64 -i FILE` precisely because `-i` means `--ignore-garbage` in GNU coreutils.

## Verification

Byte-identical output on both implementations:

| Implementation | Command | Output |
| --- | --- | --- |
| BSD/macOS (Darwin 24.6.0) | `base64 < f \| tr -d '\n'` | `dGVzdOKAi2RhdGE=` |
| GNU coreutils (`gbase64`) | `gbase64 < f \| tr -d '\n'` | `dGVzdOKAi2RhdGE=` |

Base64 round-trip confirmed non-lossy for multibyte input (`U+200B` survives encode→decode).

I also ran the **rewritten commands verbatim** against a live `service/scripts/server.py` on `127.0.0.1:8765` rather than only eyeballing the diff, since the nested quoting inside `$( )` within a double-quoted `-d` string is exactly where this could break:

- `POST /inspect` → `ok: true`, `suspicious: true`
- `POST /clean` → `ok: true`, input `Hello​World­!` → `HelloWorld!`

Project gates, with `c2patool` / `exiftool` / `qpdf` all present:

- `python3 -m pytest -q` → **323 passed**
- `ruff check service tests` → clean
- `ruff format --check service tests` → 47 files already formatted
- OpenAPI spec validation → valid

## Notes

Docs-only; no code paths changed, so no unit tests were added. No drive-by refactors — the only change is the base64 invocation. Happy to also add a short "portable base64" line next to the existing Windows note if you'd like the rationale captured inline for future edits.