### PR TITLE
fix: correctness and security hardening of the cleaning scripts (#122)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,17 @@ python3 "$SCRIPTS/inspect_text.py" report.docx
 Detection is by magic number plus a control-byte ratio, so text in encodings
 other than UTF-8 keeps working. `--force-text` overrides it everywhere.
 
+### Unrecognized formats are never auto-cleaned
+
+`classify()` labels bytes that match no supported text, image or container
+format as **`unknown`** — it no longer falls back to "text". In auto mode
+`clean_file.py` refuses such files (exit 2, no output written) instead of
+decoding them as UTF-8 and writing back mangled bytes; `--as text` or
+`--force-text` are the explicit opt-ins. `inspect_file.py` reports the file
+as `unknown` (exit 0), and the HTTP service answers `/inspect` with
+`kind: "unknown"` but rejects `/clean` of unknown formats (400 — send a
+filename with a known extension, e.g. `notes.txt`).
+
 ## HTTP service
 
 The same machinery runs as a stdlib HTTP service (`service/scripts/server.py`) — the interface the skill uses and the way any web app can integrate without vendoring:
@@ -314,6 +325,12 @@ maintained reimplementation of the ICLR 2025
 
 The backend is **not bundled** and ships no LICENSE file, so it is treated as
 all-rights-reserved: it is cloned at a pinned commit and loaded at runtime.
+Its research-era dependency pins (`requirements-ctrlregen.txt` — e.g.
+`transformers==4.37.2`, `diffusers==0.27.2`) carry published advisories and
+are intentionally not current, so they are only ever installed inside the
+dedicated venv this script creates and never into the main service image;
+`setup_ctrlregen.sh` also re-verifies the pinned commit on existing
+checkouts, not just fresh clones.
 
 ### Bootstrap
 

--- a/service/scripts/audit_dir.py
+++ b/service/scripts/audit_dir.py
@@ -16,7 +16,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from audit_lib import aggregate, format_sarif, print_human_report, scan_file
-from common import MAX_INPUT_BYTES, emit_json, eprint
+from common import EXIT_PARTIAL, MAX_INPUT_BYTES, emit_json, eprint
 
 DEFAULT_SKIP_DIRS = {
     ".git",
@@ -156,7 +156,10 @@ def main() -> int:
             },
         )
 
-    return 1 if summary["actionable_files"] else 0
+    # A partial scan (one or more files could not be scanned) is reported
+    # with a distinct code in every output format: incomplete audits are
+    # the more important CI signal and take precedence over actionable.
+    return EXIT_PARTIAL if skipped else (1 if summary["actionable_files"] else 0)
 
 
 if __name__ == "__main__":

--- a/service/scripts/audit_lib.py
+++ b/service/scripts/audit_lib.py
@@ -84,6 +84,18 @@ def scan_file(
             "notes": report.notes,
         }
 
+    if kind == "unknown":
+        return {
+            "path": name,
+            "kind": "unknown",
+            "has_c2pa": False,
+            "has_ai_metadata": False,
+            "suspicious_total": 0,
+            "findings": [],
+            "confidence": [],
+            "notes": ["unrecognized format; not scanned"],
+        }
+
     report = inspect_container(path)
     findings = list(report.findings)
     confidences = [classify_finding_confidence(f) for f in report.findings]

--- a/service/scripts/audit_website.py
+++ b/service/scripts/audit_website.py
@@ -67,8 +67,11 @@ def parse_sitemap(data: bytes) -> tuple[str, list[str]]:
     elif len(data) > MAX_SITEMAP_DECOMPRESSED_BYTES:
         raise ValueError(f"sitemap size exceeds cap ({MAX_SITEMAP_DECOMPRESSED_BYTES} bytes)")
 
-    # stdlib ElementTree does not expand external entities, but internal entity
-    # expansion (billion-laughs) is still possible; reject DTDs outright.
+    # This repo is stdlib-only by policy, so sitemaps use ElementTree. stdlib
+    # ET does not expand external entities (no XXE), but internal entity
+    # expansion (billion-laughs) is still possible, so DTDs/entities are
+    # rejected outright before parsing. If the policy ever changes, swap in
+    # defusedxml.ElementTree with the same DTD rejection as defense in depth.
     if b"<!DOCTYPE" in data or b"<!ENTITY" in data:
         raise ValueError("sitemap declares a DTD / entities; refusing to parse")
 

--- a/service/scripts/audit_website.py
+++ b/service/scripts/audit_website.py
@@ -29,7 +29,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import contextlib
 
 from audit_lib import aggregate, print_human_report, scan_file
-from common import emit_json, eprint
+from common import EXIT_PARTIAL, emit_json, eprint
 
 DEFAULT_MAX_BYTES = 4 << 20
 DEFAULT_TIMEOUT = 15
@@ -547,7 +547,9 @@ def main() -> int:
         for failure in failures:
             print(f"  [error] {failure['url']}: {failure['error']}")
 
-    return 1 if summary["actionable_files"] else 0
+    # A partial scan (one or more URLs failed to fetch/inspect) gets a
+    # distinct code: an incomplete audit outranks actionable findings.
+    return EXIT_PARTIAL if failures else (1 if summary["actionable_files"] else 0)
 
 
 if __name__ == "__main__":

--- a/service/scripts/clean_file.py
+++ b/service/scripts/clean_file.py
@@ -61,6 +61,19 @@ def main() -> int:
 
     kind = args.force_type if args.force_type != "auto" else classify(args.path)
 
+    # classify() reports "unknown" for bytes that match no supported format.
+    # Never mutate those in auto mode: a binary with valid UTF-8 runs would
+    # be decoded and written back mangled. --as text / --force-text are the
+    # explicit opt-ins and both route through the text pipeline below.
+    if kind == "unknown":
+        if args.force_type == "text" or args.force_text:
+            kind = "text"
+        else:
+            eprint(f"refusing to classify {args.path}: unrecognized format")
+            for line in ROUTER_ADVICE:
+                eprint(line)
+            return 2
+
     # In-place cleaning reads from a .bak copy whose suffix would make
     # markdown/HTML (detected by extension, not magic bytes) classify as
     # "unknown". Pin the format from the original path so --in-place and -o

--- a/service/scripts/common.py
+++ b/service/scripts/common.py
@@ -16,6 +16,12 @@ from typing import Any
 MAX_INPUT_BYTES = int(os.environ.get("WATERMARKS_MAX_INPUT_BYTES", str(256 << 20)))
 MAX_STDIN_BYTES = int(os.environ.get("WATERMARKS_MAX_STDIN_BYTES", str(64 << 20)))
 
+# Exit codes shared by the audit CLIs. 0 = clean, 1 = actionable findings,
+# 2 = usage/refusal error, 3 = partial scan (some files/URLs failed to
+# scan). A partial scan takes precedence over actionable findings: an
+# incomplete audit is the more important CI signal.
+EXIT_PARTIAL = 3
+
 # Child-process resource limits (address space / output file size). Applied
 # via preexec_fn so a crafted file cannot make exiftool/c2patool/OpenCV
 # exhaust host memory or fill the disk.

--- a/service/scripts/container_meta.py
+++ b/service/scripts/container_meta.py
@@ -690,13 +690,46 @@ MAX_ZIP_DECOMPRESSED_BYTES = 128 * 1024 * 1024
 
 
 def _check_zip_budget(info: zipfile.ZipInfo, budget: list[int]) -> None:
-    """Reject zip bombs before decompression (ZipInfo.file_size is stored)."""
-    budget[0] += info.file_size
-    if budget[0] > MAX_ZIP_DECOMPRESSED_BYTES:
+    """Fast-path zip-bomb guard on the declared member size.
+
+    A single member whose *declared* size already exceeds the cap is
+    rejected before any decompression. The authoritative accounting lives in
+    _read_zip_member, which charges **actual** decompressed bytes to the
+    shared budget: ZipInfo.file_size comes from the archive central
+    directory and is attacker-controlled, so trusting it for the cumulative
+    limit would let a crafted archive declare a tiny size and still expand
+    to gigabytes.
+    """
+    if info.file_size > MAX_ZIP_DECOMPRESSED_BYTES:
         raise ZipBudgetExceeded(
             "zip decompressed size exceeds cap "
             f"({MAX_ZIP_DECOMPRESSED_BYTES} bytes); refusing to process"
         )
+
+
+def _read_zip_member(zf: zipfile.ZipFile, info: zipfile.ZipInfo, budget: list[int]) -> bytes:
+    """Read one zip member, charging real decompressed bytes to the budget.
+
+    Streams the member in chunks so the cumulative cap is enforced on bytes
+    actually produced, not on the declared ``file_size``; raises
+    ``ZipBudgetExceeded`` the moment the cap is crossed, before the whole
+    member is buffered.
+    """
+    _check_zip_budget(info, budget)
+    with zf.open(info) as stream:
+        chunks: list[bytes] = []
+        while True:
+            chunk = stream.read(1 << 16)
+            if not chunk:
+                break
+            budget[0] += len(chunk)
+            if budget[0] > MAX_ZIP_DECOMPRESSED_BYTES:
+                raise ZipBudgetExceeded(
+                    "zip decompressed size exceeds cap "
+                    f"({MAX_ZIP_DECOMPRESSED_BYTES} bytes); refusing to process"
+                )
+            chunks.append(chunk)
+    return b"".join(chunks)
 
 
 def _is_docx_meta_part(name: str) -> bool:
@@ -722,7 +755,7 @@ def _inspect_ooxml_zip(data: bytes, fmt: str) -> tuple[bool, bool, list[str], di
                     name,
                     re.I,
                 ):
-                    raw = zf.read(name)
+                    raw = _read_zip_member(zf, info, budget)
                     img_fmt = detect_image_format(raw)
                     sub_c2pa, sub_ai, sub_findings = False, False, []
                     if img_fmt == "png":
@@ -754,7 +787,7 @@ def _inspect_ooxml_zip(data: bytes, fmt: str) -> tuple[bool, bool, list[str], di
                 # vendor names such as "Claude" without being AI-generated metadata.
                 if not _is_docx_meta_part(name):
                     continue
-                raw = zf.read(name)
+                raw = _read_zip_member(zf, info, budget)
                 c2, ai, hits = _blob_hits(raw)
                 if c2 or ai:
                     if c2:
@@ -922,6 +955,83 @@ def _prune_dangling_relationships(
     return new.encode("utf-8"), dropped[0]
 
 
+def _prune_odt_manifest_entries(raw: bytes, dropped: set[str]) -> tuple[bytes, int]:
+    """Remove manifest file-entry elements pointing at dropped parts.
+
+    ODF packages list every member in META-INF/manifest.xml; dropping a part
+    (e.g. one carrying AI/C2PA markers) without removing its entry makes
+    readers flag the package as damaged. full-path is matched
+    attribute-order-independently, mirroring _prune_dangling_relationships.
+    The package-root entry (full-path="/") and entries for surviving parts
+    are left untouched.
+    """
+    text = raw.decode("utf-8", errors="replace")
+    removed = [0]
+
+    def _full_path(tag: str) -> str:
+        m = re.search(r'\bfull-path\s*=\s*"([^"]*)"', tag, re.I)
+        return m.group(1) if m else ""
+
+    def _drop(m: re.Match[str]) -> str:
+        tag = m.group(0)
+        path = posixpath.normpath(_full_path(tag).lstrip("/"))
+        if path in ("", "."):
+            return tag  # package root — never pruned
+        if path in dropped:
+            removed[0] += 1
+            return ""
+        return tag
+
+    new = re.sub(r"<manifest:file-entry\b[^>]*/>", _drop, text, flags=re.I)
+    return new.encode("utf-8"), removed[0]
+
+
+def _prune_opf_manifest(raw: bytes, opf_name: str, dropped: set[str]) -> tuple[bytes, int]:
+    """Remove OPF <item> entries pointing at dropped parts (and spine refs).
+
+    The package document lists every content part; a dropped part that is
+    still referenced makes EPUB readers reject the book. href values are
+    relative to the package document directory, and <itemref> spine entries
+    for removed items are pruned too so no idref dangles.
+    """
+    base = posixpath.dirname(opf_name)
+    text = raw.decode("utf-8", errors="replace")
+    removed = [0]
+    removed_ids: set[str] = set()
+
+    def _attr(tag: str, name: str) -> str:
+        m = re.search(rf'\b{name}\s*=\s*"([^"]*)"', tag, re.I)
+        return m.group(1) if m else ""
+
+    def _drop_item(m: re.Match[str]) -> str:
+        tag = m.group(0)
+        href = _attr(tag, "href")
+        if not href:
+            return tag
+        resolved = posixpath.normpath(posixpath.join(base, href))
+        if resolved in dropped:
+            removed[0] += 1
+            item_id = _attr(tag, "id")
+            if item_id:
+                removed_ids.add(item_id)
+            return ""
+        return tag
+
+    new = re.sub(r"<item\b[^>]*/>", _drop_item, text, flags=re.I)
+
+    if removed_ids:
+
+        def _drop_itemref(m: re.Match[str]) -> str:
+            tag = m.group(0)
+            if _attr(tag, "idref") in removed_ids:
+                removed[0] += 1
+                return ""
+            return tag
+
+        new = re.sub(r"<itemref\b[^>]*/>", _drop_itemref, new, flags=re.I)
+    return new.encode("utf-8"), removed[0]
+
+
 def _scrub_ooxml_zip(
     data: bytes, fmt: str, *, also_layer_a_text: bool = True
 ) -> tuple[bytes, list[str]]:
@@ -932,9 +1042,9 @@ def _scrub_ooxml_zip(
     kept: list[tuple[zipfile.ZipInfo, bytes]] = []
     with zipfile.ZipFile(io.BytesIO(data)) as zin:
         for info in zin.infolist():
-            name = info.filename
             _check_zip_budget(info, budget)
-            raw = zin.read(name)
+            name = info.filename
+            raw = _read_zip_member(zin, info, budget)
 
             # 1. Clean embedded media (PNG, JPEG, WebP, AVIF, HEIC, GIF, BMP, TIFF, SVG)
             if re.search(
@@ -1083,7 +1193,7 @@ def inspect_odt(data: bytes) -> tuple[bool, bool, list[str], dict]:
         with zipfile.ZipFile(io.BytesIO(data)) as zf:
             for info in zf.infolist():
                 _check_zip_budget(info, budget)
-                raw = zf.read(info.filename)
+                raw = _read_zip_member(zf, info, budget)
                 c2, ai, hits = _blob_hits(raw)
                 if c2 or ai:
                     if c2:
@@ -1092,7 +1202,9 @@ def inspect_odt(data: bytes) -> tuple[bool, bool, list[str], dict]:
                         has_ai = True
                     findings.append(f"{info.filename}: {', '.join(hits[:6])}")
             if "meta.xml" in zf.namelist():
-                meta = zf.read("meta.xml").decode("utf-8", errors="replace")
+                meta = _read_zip_member(zf, zf.getinfo("meta.xml"), budget).decode(
+                    "utf-8", errors="replace"
+                )
                 if re.search(r"generator|claude|openai|anthropic|gemini", meta, re.I):
                     has_ai = True
                     findings.append("meta.xml generator-like fields")
@@ -1103,18 +1215,16 @@ def inspect_odt(data: bytes) -> tuple[bool, bool, list[str], dict]:
 
 def clean_odt(data: bytes, *, also_layer_a_text: bool = True) -> tuple[bytes, list[str]]:
     actions: list[str] = []
-    out_buf = io.BytesIO()
     budget = [0]
     layer_removed = 0
     layer_replaced = 0
-    with (
-        zipfile.ZipFile(io.BytesIO(data)) as zin,
-        zipfile.ZipFile(out_buf, "w", compression=zipfile.ZIP_DEFLATED) as zout,
-    ):
+    kept: list[tuple[zipfile.ZipInfo, bytes]] = []
+    dropped: set[str] = set()
+    with zipfile.ZipFile(io.BytesIO(data)) as zin:
         for info in zin.infolist():
-            name = info.filename
             _check_zip_budget(info, budget)
-            raw = zin.read(name)
+            name = info.filename
+            raw = _read_zip_member(zin, info, budget)
             if name == "meta.xml":
                 text = raw.decode("utf-8", errors="replace")
                 new, n = re.subn(
@@ -1150,6 +1260,7 @@ def clean_odt(data: bytes, *, also_layer_a_text: bool = True) -> tuple[bytes, li
                     "META-INF/manifest.xml",
                 ):
                     actions.append(f"drop part {name} (AI/C2PA markers)")
+                    dropped.add(name)
                     continue
             # Layer A over the visible paragraph text of the body part.
             if also_layer_a_text and name == "content.xml":
@@ -1159,6 +1270,26 @@ def clean_odt(data: bytes, *, also_layer_a_text: bool = True) -> tuple[bytes, li
                     layer_removed += r
                     layer_replaced += rp
                     raw = new.encode("utf-8")
+            kept.append((info, raw))
+
+    # Two-pass: rewrite META-INF/manifest.xml now that the dropped set is
+    # known. The manifest precedes the dropped parts in the archive, so a
+    # single pass cannot remove entries for parts dropped later in the loop.
+    if dropped:
+        rewritten: list[tuple[zipfile.ZipInfo, bytes]] = []
+        for info, part_raw in kept:
+            out_raw = part_raw
+            if info.filename == "META-INF/manifest.xml":
+                pruned, n = _prune_odt_manifest_entries(part_raw, dropped)
+                if n:
+                    actions.append(f"drop manifest entries x{n}")
+                    out_raw = pruned
+            rewritten.append((info, out_raw))
+        kept = rewritten
+
+    out_buf = io.BytesIO()
+    with zipfile.ZipFile(out_buf, "w", compression=zipfile.ZIP_DEFLATED) as zout:
+        for info, raw in kept:
             zout.writestr(info, raw)
     if layer_removed or layer_replaced:
         actions.append(f"layer A text: removed={layer_removed} replaced={layer_replaced}")
@@ -1207,7 +1338,10 @@ def _epub_encrypted_parts(data: bytes) -> set[str]:
         with zipfile.ZipFile(io.BytesIO(data)) as zf:
             if "META-INF/encryption.xml" not in zf.namelist():
                 return set()
-            xml = zf.read("META-INF/encryption.xml").decode("utf-8", errors="replace")
+            budget: list[int] = [0]
+            xml = _read_zip_member(zf, zf.getinfo("META-INF/encryption.xml"), budget).decode(
+                "utf-8", errors="replace"
+            )
     except (zipfile.BadZipFile, KeyError):
         return set()
     names: set[str] = set()
@@ -1236,7 +1370,7 @@ def inspect_epub(data: bytes) -> tuple[bool, bool, list[str], dict]:
                 if name in encrypted:
                     findings.append(f"{name}: encrypted content (skipped)")
                     continue
-                raw = zf.read(name)
+                raw = _read_zip_member(zf, info, budget)
                 if name.lower().endswith((".xhtml", ".html", ".htm")):
                     text = raw.decode("utf-8", errors="surrogateescape")
                     c2, ai, sub, _ = inspect_html(text)
@@ -1308,7 +1442,8 @@ def clean_epub(data: bytes, *, also_layer_a_text: bool = True) -> tuple[bytes, l
     fonts) are kept so the book stays readable. Parts listed in
     META-INF/encryption.xml are copied verbatim — their bytes are ciphertext,
     so any rewrite would corrupt them. Non-content parts carrying AI/C2PA
-    markers are dropped.
+    markers are dropped, and the OPF manifest is pruned afterwards so no
+    dropped part stays referenced.
     """
     from text_unicode import clean_text  # local import to avoid cycles
 
@@ -1317,20 +1452,18 @@ def clean_epub(data: bytes, *, also_layer_a_text: bool = True) -> tuple[bytes, l
     layer_removed = 0
     layer_replaced = 0
     encrypted = _epub_encrypted_parts(data)
-    out_buf = io.BytesIO()
-    with (
-        zipfile.ZipFile(io.BytesIO(data)) as zin,
-        zipfile.ZipFile(out_buf, "w", compression=zipfile.ZIP_DEFLATED) as zout,
-    ):
+    kept: list[tuple[zipfile.ZipInfo, bytes]] = []
+    dropped: set[str] = set()
+    with zipfile.ZipFile(io.BytesIO(data)) as zin:
         for info in zin.infolist():
-            name = info.filename
             _check_zip_budget(info, budget)
-            raw = zin.read(name)
+            name = info.filename
+            raw = _read_zip_member(zin, info, budget)
             low = name.lower()
 
             # Encrypted parts are opaque ciphertext: pass through untouched.
             if name in encrypted:
-                zout.writestr(info, raw)
+                kept.append((info, raw))
                 continue
 
             # 1. Embedded raster / vector media: strip metadata
@@ -1360,7 +1493,7 @@ def clean_epub(data: bytes, *, also_layer_a_text: bool = True) -> tuple[bytes, l
                 if any("drop" in a.lower() for a in sub_actions) and cleaned != raw:
                     actions.append(f"clean embedded media in {name} ({', '.join(sub_actions[:2])})")
                     raw = cleaned
-                zout.writestr(info, raw)
+                kept.append((info, raw))
                 continue
 
             # 2. XHTML content: strip AI meta/JSON-LD, then Layer A
@@ -1376,7 +1509,7 @@ def clean_epub(data: bytes, *, also_layer_a_text: bool = True) -> tuple[bytes, l
                         layer_replaced += stats["replaced_count"]
                         text = text2
                 raw = text.encode("utf-8", errors="surrogateescape")
-                zout.writestr(info, raw)
+                kept.append((info, raw))
                 continue
 
             # 3. Package document (OPF): scrub AI-ish metadata
@@ -1386,19 +1519,38 @@ def clean_epub(data: bytes, *, also_layer_a_text: bool = True) -> tuple[bytes, l
                 if sub_actions and sub_actions != ["no OPF metadata removed"]:
                     actions.extend(f"{name}: {a}" for a in sub_actions)
                 raw = new_text.encode("utf-8", errors="surrogateescape")
-                zout.writestr(info, raw)
+                kept.append((info, raw))
                 continue
 
             # 4. Other parts: drop non-content parts carrying AI/C2PA markers
             c2, ai, _hits = _blob_hits(raw)
             if (c2 or ai) and not _epub_content_part(name):
                 actions.append(f"drop part {name} (AI/C2PA markers)")
+                dropped.add(name)
                 continue
 
             # 5. mimetype must stay first and stored — it already is, since we
             #    write in the original entry order; force stored compression.
             if low == "mimetype":
                 info.compress_type = zipfile.ZIP_STORED
+            kept.append((info, raw))
+
+    # Two-pass: prune the OPF manifest now that the dropped set is known.
+    if dropped:
+        rewritten: list[tuple[zipfile.ZipInfo, bytes]] = []
+        for info, part_raw in kept:
+            out_raw = part_raw
+            if info.filename.lower().endswith(".opf"):
+                pruned, n = _prune_opf_manifest(part_raw, info.filename, dropped)
+                if n:
+                    actions.append(f"prune OPF manifest entries x{n}")
+                    out_raw = pruned
+            rewritten.append((info, out_raw))
+        kept = rewritten
+
+    out_buf = io.BytesIO()
+    with zipfile.ZipFile(out_buf, "w", compression=zipfile.ZIP_DEFLATED) as zout:
+        for info, raw in kept:
             zout.writestr(info, raw)
 
     if layer_removed or layer_replaced:
@@ -1616,6 +1768,7 @@ def inspect_container(path: Path) -> ContainerInspectReport:
         from text_unicode import inspect_text  # local import to avoid cycles
 
         encrypted = _epub_encrypted_parts(data)
+        budget: list[int] = [0]
         try:
             with zipfile.ZipFile(io.BytesIO(data)) as zf:
                 for info in zf.infolist():
@@ -1623,7 +1776,9 @@ def inspect_container(path: Path) -> ContainerInspectReport:
                         continue
                     if info.filename.lower().endswith((".xhtml", ".html", ".htm")):
                         ta = inspect_text(
-                            zf.read(info.filename).decode("utf-8", errors="surrogateescape")
+                            _read_zip_member(zf, info, budget).decode(
+                                "utf-8", errors="surrogateescape"
+                            )
                         ).to_dict()
                         layer_a_total += ta["suspicious_total"]
                         for h in ta["hits"]:

--- a/service/scripts/format_dispatch.py
+++ b/service/scripts/format_dispatch.py
@@ -14,7 +14,13 @@ from typing import Literal
 from container_meta import detect_container_format
 from image_meta import detect_format as detect_image_format
 
-Kind = Literal["text", "image", "container"]
+Kind = Literal["text", "image", "container", "unknown"]
+
+#: Bytes read for header-only sniffing. Every supported image/container
+#: magic lives in the prefix; zip-based containers (docx/odt/...) need the
+#: full central directory, which sits at the end of the archive, so only a
+#: PK header triggers a whole-file read.
+CLASSIFY_HEADER_BYTES = 4096
 
 IMAGE_EXTS = {
     ".png",
@@ -63,8 +69,9 @@ def classify_bytes(data: bytes, suffix: str | None = None) -> Kind:
     """Classify *data* by extension first, then by magic bytes.
 
     The extension wins when it names a known format; otherwise the bytes are
-    sniffed for image/container signatures. Unrecognized bytes fall back to
-    "text" — callers that must not mangle unknown binaries guard themselves.
+    sniffed for image/container signatures. Unrecognized bytes classify as
+    "unknown" — callers that must not mangle unknown binaries refuse unless
+    the user explicitly forces a kind (--as / --force-text).
 
     *data* must cover the whole file: zip-based containers (docx/odt) are
     detected from their central directory, which sits at the end of the bytes.
@@ -82,10 +89,32 @@ def classify_bytes(data: bytes, suffix: str | None = None) -> Kind:
         sniff_path = Path("input") if not ext else Path(f"input{ext}")
         if detect_container_format(sniff_path, data) != "unknown":
             return "container"
-    return "text"
+    return "unknown"
 
 
 def classify(path: Path) -> Kind:
-    """Classify a file on disk by extension, then by its bytes."""
-    data = path.read_bytes()
-    return classify_bytes(data, path.suffix)
+    """Classify a file on disk by extension, then by its bytes.
+
+    Known extensions are routed without reading the file. For unknown
+    extensions a 4096-byte header is sniffed once; only when the header is a
+    zip local header (PK) is the whole file read, because the container
+    signature (docx/xlsx/pptx/odt/epub) lives in the central directory at
+    the end of the archive.
+    """
+    ext = path.suffix.lower()
+    if ext in IMAGE_EXTS:
+        return "image"
+    if ext in CONTAINER_EXTS:
+        return "container"
+    if ext in TEXT_EXTS:
+        return "text"
+    with path.open("rb") as fh:
+        head = fh.read(CLASSIFY_HEADER_BYTES)
+    if detect_image_format(head) in ("png", "jpeg", "webp", "avif", "heic", "bmp", "gif", "tiff"):
+        return "image"
+    if head:
+        data = path.read_bytes() if head[:4] == b"PK\x03\x04" else head
+        sniff_path = Path("input") if not ext else Path(f"input{ext}")
+        if detect_container_format(sniff_path, data) != "unknown":
+            return "container"
+    return "unknown"

--- a/service/scripts/inspect_file.py
+++ b/service/scripts/inspect_file.py
@@ -52,6 +52,21 @@ def main() -> int:
     kind = args.force_type if args.force_type != "auto" else classify(args.path)
     file_label = str(args.path.resolve())
 
+    # "unknown" means the bytes match no supported format. Inspect does not
+    # mutate, so report it as-is; --as / --force-text override to text.
+    if kind == "unknown":
+        if args.force_type == "text" or args.force_text:
+            kind = "text"
+        else:
+            note = "unrecognized format; pass --as text|image|container or --force-text to override"
+            if args.json:
+                emit_json({"kind": "unknown", "path": file_label, "note": note})
+            else:
+                print(f"File: {file_label}")
+                print("Kind: unknown")
+                print(note)
+            return 0
+
     if kind == "text":
         text = read_text_input(
             str(args.path),

--- a/service/scripts/requirements-ctrlregen.txt
+++ b/service/scripts/requirements-ctrlregen.txt
@@ -8,6 +8,16 @@
 # ML libs are pinned to versions the upstream CtrlRegen research code
 # (yepengliu/CtrlRegen) was built against. Validate against the pinned
 # noai-watermark commit before bumping.
+#
+# Security expectation: several of these research pins (transformers 4.37.2,
+# diffusers 0.27.2, Pillow 12.3.0) carry published advisories. They are
+# deliberately NOT updated to current versions because the upstream code
+# does not run on them. This file is therefore only ever installed inside
+# the dedicated venv created by setup_ctrlregen.sh (service profile
+# "ctrlregen"), never into the main service image, and the backend is not
+# exposed to untrusted input on the network path. Keep it that way: do not
+# merge these pins into the core requirements or the Docker images, and
+# run a scoped pip-audit against this file if you need a report.
 diffusers==0.27.2
 transformers==4.37.2
 accelerate==1.14.0

--- a/service/scripts/server.py
+++ b/service/scripts/server.py
@@ -430,6 +430,19 @@ class Handler(BaseHTTPRequestHandler):
 
     def _handle_inspect(self, data: bytes, name: str) -> None:
         kind = classify_bytes(data, Path(name).suffix)
+        if kind == "unknown":
+            self._respond(
+                HTTPStatus.OK,
+                {
+                    "ok": True,
+                    "kind": "unknown",
+                    "report": {
+                        "note": "unrecognized format; use a filename with a known extension",
+                    },
+                    "suspicious": False,
+                },
+            )
+            return
         with tempfile.TemporaryDirectory(prefix="wm-inspect-") as tmp:
             path = _tmp_path(Path(tmp), name or "input")
             path.write_bytes(data)
@@ -457,6 +470,11 @@ class Handler(BaseHTTPRequestHandler):
 
     def _handle_clean(self, data: bytes, name: str, body: dict[str, Any]) -> None:
         kind = classify_bytes(data, Path(name).suffix)
+        if kind == "unknown":
+            raise ValueError(
+                "unrecognized file format; use a filename with a known extension "
+                "(e.g. notes.txt) or a supported image/container name"
+            )
         options = body.get("options")
         if options is None:
             options = {}

--- a/service/scripts/setup_ctrlregen.ps1
+++ b/service/scripts/setup_ctrlregen.ps1
@@ -83,6 +83,16 @@ if (-not (Test-Path (Join-Path $Dir '.git'))) {
     if ($head -ne $Ref) { throw "error: expected pinned ref $Ref, got $head" }
 } else {
     Write-Host "Using existing checkout: $Dir"
+    $head = ''
+    try { $head = "$(git -C $Dir rev-parse HEAD)".Trim() } catch { $head = '' }
+    if ($head -ne $Ref) {
+        Write-Host "existing checkout not at pinned ref $Ref (HEAD: $head); re-pinning"
+        Invoke-Checked 'git fetch' { git -C $Dir fetch --depth 1 origin $Ref }
+        Invoke-Checked 'git checkout' { git -C $Dir checkout --detach $Ref }
+        Invoke-Checked 'sparse-checkout' { git -C $Dir sparse-checkout set --no-cone '/src/' }
+        $head = (git -C $Dir rev-parse HEAD).Trim()
+        if ($head -ne $Ref) { throw "error: expected pinned ref $Ref, got $head" }
+    }
 }
 
 $venvPython = Join-Path $Dir '.venv\Scripts\python.exe'

--- a/service/scripts/setup_ctrlregen.sh
+++ b/service/scripts/setup_ctrlregen.sh
@@ -78,6 +78,21 @@ if [[ ! -d "$DIR/.git" ]]; then
   fi
 else
   echo "Using existing checkout: $DIR"
+  HEAD_SHA="$(git -C "$DIR" rev-parse HEAD 2>/dev/null || true)"
+  if [[ "$HEAD_SHA" != "$REF" ]]; then
+    echo "existing checkout not at pinned ref $REF (HEAD: ${HEAD_SHA:-missing}); re-pinning"
+    git -C "$DIR" fetch --depth 1 origin "$REF" || {
+      echo "error: could not fetch pinned ref $REF" >&2
+      exit 1
+    }
+    git -C "$DIR" checkout --detach "$REF"
+    git -C "$DIR" sparse-checkout set --no-cone '/src/'
+    HEAD_SHA="$(git -C "$DIR" rev-parse HEAD)"
+    if [[ "$HEAD_SHA" != "$REF" ]]; then
+      echo "error: expected pinned ref $REF, got $HEAD_SHA" >&2
+      exit 1
+    fi
+  fi
 fi
 
 if [[ ! -x "$DIR/.venv/bin/python" ]]; then

--- a/service/scripts/setup_synthid.ps1
+++ b/service/scripts/setup_synthid.ps1
@@ -65,6 +65,18 @@ if (-not (Test-Path (Join-Path $Dir '.git'))) {
     if ($head -ne $Ref) { throw "error: se esperaba el ref fijado $Ref, se obtuvo $head" }
 } else {
     Write-Host "Usando checkout existente: $Dir"
+    $head = ''
+    try { $head = "$(git -C $Dir rev-parse HEAD)".Trim() } catch { $head = '' }
+    if ($head -ne $Ref) {
+        Write-Host "checkout existente no esta en el ref fijado $Ref (HEAD: $head); re-fijando"
+        Invoke-Checked 'git fetch' { git -C $Dir fetch --depth 1 origin $Ref }
+        Invoke-Checked 'git checkout' { git -C $Dir checkout --detach $Ref }
+        Invoke-Checked 'sparse-checkout' {
+            git -C $Dir sparse-checkout set --no-cone '/src/' '/artifacts/spectral_codebook_v4.npz' '/requirements.txt' '/LICENSE' '/README.md'
+        }
+        $head = (git -C $Dir rev-parse HEAD).Trim()
+        if ($head -ne $Ref) { throw "error: se esperaba el ref fijado $Ref, se obtuvo $head" }
+    }
 }
 
 $venvPython = Join-Path $Dir '.venv\Scripts\python.exe'

--- a/service/scripts/setup_synthid.sh
+++ b/service/scripts/setup_synthid.sh
@@ -88,6 +88,26 @@ if [[ ! -d "$DIR/.git" ]]; then
   fi
 else
   echo "Using existing checkout: $DIR"
+  HEAD_SHA="$(git -C "$DIR" rev-parse HEAD 2>/dev/null || true)"
+  if [[ "$HEAD_SHA" != "$REF" ]]; then
+    echo "existing checkout not at pinned ref $REF (HEAD: ${HEAD_SHA:-missing}); re-pinning"
+    git -C "$DIR" fetch --depth 1 origin "$REF" || {
+      echo "error: could not fetch pinned ref $REF" >&2
+      exit 1
+    }
+    git -C "$DIR" checkout --detach "$REF"
+    git -C "$DIR" sparse-checkout set --no-cone \
+      '/src/' \
+      '/artifacts/spectral_codebook_v4.npz' \
+      '/requirements.txt' \
+      '/LICENSE' \
+      '/README.md'
+    HEAD_SHA="$(git -C "$DIR" rev-parse HEAD)"
+    if [[ "$HEAD_SHA" != "$REF" ]]; then
+      echo "error: expected pinned ref $REF, got $HEAD_SHA" >&2
+      exit 1
+    fi
+  fi
 fi
 
 if [[ ! -x "$DIR/.venv/bin/python" ]]; then

--- a/skills/remove-ai-marks/SKILL.md
+++ b/skills/remove-ai-marks/SKILL.md
@@ -74,6 +74,11 @@ field and writes it to the output path itself.
 | POST | `/inspect` | `{"file": "<base64>", "name": "notes.md"}` | `{"ok", "kind", "suspicious", "report"}` |
 | POST | `/clean` | `{"file": "<base64>", "name": "notes.md", "options": {...}}` | `{"ok", "kind", "cleaned": "<base64>", "report"}` |
 
+`/clean` and `/inspect` route by the uploaded `name` extension plus the bytes;
+unrecognized formats answer `kind: "unknown"` (`/inspect`) or 400 (`/clean`).
+When writing a temp file for pasted text, keep a known extension (`.txt` /
+`.md`) in the `name` you send.
+
 The machine-readable contract lives at `$WM/openapi.json` — plug it into any
 OpenAPI tooling (client generators, Swagger UI, editors) instead of hand-rolling
 clients.
@@ -258,6 +263,11 @@ docker run --rm -v "$(pwd)/src:/data:ro" watermarks-remover \
 ```
 
 Or against a local checkout of the repo: `python3 service/scripts/audit_dir.py DIR --json`.
+
+Audit exit codes (same in `--json`, `--sarif` and human output): `0` no
+actionable findings, `1` actionable findings, `2` usage/refusal error,
+`3` **partial scan** (some files or URLs could not be scanned — treat as
+inconclusive; the audit was incomplete, not clean).
 
 ### 5. Report
 

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -389,6 +389,27 @@ def test_fetch_revalidates_redirect_before_second_connection(monkeypatch):
     assert connections == 1
 
 
+def test_audit_website_partial_scan_exit_3(monkeypatch):
+    """A URL that fails to fetch makes the audit partial: exit 3, distinct
+    from both "clean" (0) and "actionable findings" (1)."""
+
+    def _fetch(*_args, **_kwargs):
+        raise ValueError("connection refused")
+
+    monkeypatch.setattr(
+        audit_website,
+        "collect_urls",
+        lambda *_a, **_k: ["https://example.com/1", "https://example.com/2"],
+    )
+    monkeypatch.setattr(audit_website, "fetch", _fetch)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["audit_website.py", "--sitemap", "https://example.com/sitemap.xml"],
+    )
+    assert audit_website.main() == 3
+
+
 def test_main_rejects_private_base_cleanly(monkeypatch, capsys):
     monkeypatch.setattr(
         sys,

--- a/tests/test_audit_sarif_and_concurrency.py
+++ b/tests/test_audit_sarif_and_concurrency.py
@@ -17,6 +17,54 @@ from audit_lib import format_sarif
 from tests.test_clean_image import _minimal_png_with_text
 
 
+def test_audit_dir_partial_scan_exit_3(monkeypatch, tmp_path, capsys):
+    """Every output format reports a partial scan (skipped files) with the
+    same distinct exit code, 3."""
+    import audit_dir
+
+    (tmp_path / "clean.txt").write_text("hello", encoding="utf-8")
+    monkeypatch.setattr(
+        audit_dir,
+        "_scan_worker",
+        lambda _path, _check: (None, {"path": "x", "reason": "boom"}),
+    )
+    for extra in ((), ("--json",), ("--format", "sarif")):
+        monkeypatch.setattr(sys, "argv", ["audit_dir.py", str(tmp_path), *extra])
+        assert audit_dir.main() == 3, extra
+
+
+def test_audit_dir_partial_outranks_actionable(monkeypatch, tmp_path):
+    """Partial wins over actionable findings: an incomplete audit is the
+    more important CI signal."""
+    import audit_dir
+
+    calls = {"n": 0}
+
+    def _worker(path, _check):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return (
+                {
+                    "path": str(path),
+                    "kind": "text",
+                    "has_c2pa": False,
+                    "has_ai_metadata": True,
+                    "suspicious_total": 1,
+                    "findings": ["meta: ai"],
+                    "confidence": ["probable"],
+                    "notes": [],
+                },
+                None,
+            )
+        return (None, {"path": str(path), "reason": "boom"})
+
+    (tmp_path / "a.txt").write_text("a", encoding="utf-8")
+    (tmp_path / "b.txt").write_text("b", encoding="utf-8")
+    monkeypatch.setattr(audit_dir, "_scan_worker", _worker)
+    monkeypatch.setattr(sys, "argv", ["audit_dir.py", str(tmp_path), "--json"])
+    assert audit_dir.main() == 3
+
+
 def test_format_sarif_structure():
     fake_report = {
         "root": "/workspace/project",

--- a/tests/test_binary_guard.py
+++ b/tests/test_binary_guard.py
@@ -175,16 +175,67 @@ def test_clean_file_in_place_as_text_on_docx_leaves_no_backup(tmp_path):
     assert not (tmp_path / "doc.docx.bak").exists()
 
 
-def test_router_advice_is_not_circular(tmp_path):
-    """clean_file.py / inspect_file.py must not point back at themselves."""
+def test_clean_file_auto_refuses_unknown_text_like_bytes(tmp_path):
+    """Extension-less bytes with no magic classify as "unknown" and are
+    refused in auto mode — even when they look like plain text, because
+    "text" is no longer the catch-all for unrecognized files."""
+    blob = tmp_path / "no_extension"
+    blob.write_text("just plain text, no extension, no magic\n", encoding="utf-8")
+    before = blob.read_bytes()
+    r = run("clean_file.py", str(blob), "--in-place")
+    assert r.returncode == 2
+    assert blob.read_bytes() == before
+    assert not (tmp_path / "no_extension.bak").exists()
+
+
+def test_clean_file_as_text_opt_in_cleans_unknown(tmp_path):
+    """--as text is the explicit opt-in that turns an unknown file into a
+    text clean."""
+    blob = tmp_path / "no_extension"
+    blob.write_text("Hidden\u200bmark here.\n", encoding="utf-8")
+    out = tmp_path / "out.txt"
+    r = run("clean_file.py", str(blob), "-o", str(out), "--as", "text")
+    assert r.returncode == 0, r.stderr
+    assert out.read_text(encoding="utf-8") == "Hiddenmark here.\n"
+
+
+def test_clean_file_force_text_opt_in_on_unknown_binary(tmp_path):
+    """--force-text also opts in, bypassing both the unknown refusal and
+    the binary guard (explicit override)."""
     blob = tmp_path / "mystery.bin"
     blob.write_bytes(b"\x00\x01\x02\x03" * 64)
-    for script in ("clean_file.py", "inspect_file.py"):
-        r = run(script, str(blob))
-        assert r.returncode == 2, script
-        assert "no supported text, image or container format" in r.stderr, script
-        assert "Use inspect_file.py / clean_file.py" not in r.stderr, script
-        assert "--force-text" in r.stderr, script
+    out = tmp_path / "out.bin"
+    r = run("clean_file.py", str(blob), "-o", str(out), "--force-text")
+    assert r.returncode == 0, r.stderr
+    assert out.exists()
+
+
+def test_inspect_file_json_reports_unknown_kind(tmp_path):
+    blob = tmp_path / "no_extension"
+    blob.write_text("no magic, no extension\n", encoding="utf-8")
+    r = run("inspect_file.py", str(blob), "--json")
+    assert r.returncode == 0
+    import json
+
+    payload = json.loads(r.stdout)
+    assert payload["kind"] == "unknown"
+    assert "note" in payload
+
+
+def test_router_advice_is_not_circular(tmp_path):
+    """clean_file.py refuses unknown bytes with router advice (never a pointer
+    back at itself); inspect_file.py reports the file as unknown instead."""
+    blob = tmp_path / "mystery.bin"
+    blob.write_bytes(b"\x00\x01\x02\x03" * 64)
+    r = run("clean_file.py", str(blob))
+    assert r.returncode == 2
+    assert "no supported text, image or container format" in r.stderr
+    assert "Use inspect_file.py / clean_file.py" not in r.stderr
+    assert "--force-text" in r.stderr
+    r = run("inspect_file.py", str(blob))
+    assert r.returncode == 0
+    assert "Kind: unknown" in r.stdout
+    assert "--as text|image|container" in r.stdout
 
 
 def test_text_only_scripts_keep_the_pointer_to_the_routers(tmp_path):

--- a/tests/test_container_meta.py
+++ b/tests/test_container_meta.py
@@ -555,6 +555,78 @@ def test_odt_drops_generator(tmp_path: Path):
         assert "meta:generator" not in meta or "Anthropic" not in meta
 
 
+def _make_odt_with_manifest(manifest_entries: list[str], extra_parts: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    manifest = (
+        '<?xml version="1.0"?><manifest:manifest '
+        'xmlns:manifest="urn:oasis:names:tc:opendocument:xmlns:manifest:1.0">'
+        + "".join(manifest_entries)
+        + "</manifest:manifest>"
+    )
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("mimetype", "application/vnd.oasis.opendocument.text")
+        zf.writestr("content.xml", b'<?xml version="1.0"?><office:document-content/>')
+        zf.writestr("META-INF/manifest.xml", manifest)
+        for name, payload in extra_parts.items():
+            zf.writestr(name, payload)
+    return buf.getvalue()
+
+
+def test_odt_dropped_part_removes_manifest_entry():
+    """Dropping a marker-bearing part must also drop its manifest entry,
+    or readers flag the package as damaged."""
+    data = _make_odt_with_manifest(
+        [
+            '<manifest:file-entry manifest:media-type="application/vnd.oasis.opendocument.text" manifest:full-path="/"/>',
+            '<manifest:file-entry manifest:media-type="text/xml" manifest:full-path="content.xml"/>',
+            '<manifest:file-entry manifest:media-type="application/octet-stream" manifest:full-path="custommeta.xml"/>',
+        ],
+        extra_parts={"custommeta.xml": b"<meta><creator>Anthropic Claude</creator></meta>"},
+    )
+    cleaned, actions = clean_odt(data)
+    assert any("drop part custommeta.xml" in a for a in actions)
+    assert any("drop manifest entries" in a for a in actions)
+    with zipfile.ZipFile(io.BytesIO(cleaned)) as zf:
+        assert zf.namelist().count("META-INF/manifest.xml") == 1
+        manifest = zf.read("META-INF/manifest.xml").decode()
+        assert "custommeta.xml" not in manifest
+        assert 'full-path="content.xml"' in manifest
+        assert 'full-path="/"' in manifest
+
+
+def test_odt_manifest_rewrite_is_attribute_order_independent():
+    """The dropped entry has full-path before media-type; matching must not
+    depend on attribute order."""
+    data = _make_odt_with_manifest(
+        [
+            '<manifest:file-entry manifest:full-path="/"/>',
+            '<manifest:file-entry manifest:full-path="content.xml" manifest:media-type="text/xml"/>',
+            '<manifest:file-entry manifest:full-path="custommeta.xml" manifest:media-type="application/octet-stream"/>',
+        ],
+        extra_parts={"custommeta.xml": b"<meta><creator>Anthropic Claude</creator></meta>"},
+    )
+    cleaned, _actions = clean_odt(data)
+    with zipfile.ZipFile(io.BytesIO(cleaned)) as zf:
+        manifest = zf.read("META-INF/manifest.xml").decode()
+        assert "custommeta.xml" not in manifest
+        assert 'full-path="content.xml"' in manifest
+
+
+def test_odt_manifest_untouched_when_nothing_dropped():
+    data = _make_odt_with_manifest(
+        [
+            '<manifest:file-entry manifest:media-type="application/vnd.oasis.opendocument.text" manifest:full-path="/"/>',
+            '<manifest:file-entry manifest:media-type="text/xml" manifest:full-path="content.xml"/>',
+        ],
+        extra_parts={},
+    )
+    cleaned, actions = clean_odt(data)
+    assert not any("manifest" in a for a in actions)
+    with zipfile.ZipFile(io.BytesIO(cleaned)) as zf:
+        manifest = zf.read("META-INF/manifest.xml").decode()
+        assert 'full-path="content.xml"' in manifest
+
+
 def test_clean_container_markdown_file(tmp_path: Path):
     src = tmp_path / "x.md"
     src.write_text("---\ngenerator: OpenAI\n---\nHi\u200b\n", encoding="utf-8")

--- a/tests/test_epub.py
+++ b/tests/test_epub.py
@@ -197,3 +197,41 @@ def test_clean_epub_keeps_plain_creator():
         opf = zf.read("OEBPS/content.opf").decode("utf-8")
     assert "Jane Doe" in opf
     assert not any("creator" in a for a in actions)
+
+
+def test_clean_epub_prunes_opf_manifest_for_dropped_part():
+    """A dropped non-content part must also lose its <item> entry (and any
+    spine itemref) in the OPF manifest, or the book fails EPUB validation."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("mimetype", "application/epub+zip", compress_type=zipfile.ZIP_STORED)
+        zf.writestr(
+            "META-INF/container.xml",
+            '<container xmlns="urn:oasis:names:tc:opendocument:xmlns:container">'
+            '<rootfiles><rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/></rootfiles></container>',
+        )
+        zf.writestr(
+            "OEBPS/content.opf",
+            '<package xmlns="http://www.idpf.org/2007/opf" version="3.0">'
+            "<manifest>"
+            '<item id="c1" href="chapter1.xhtml" media-type="application/xhtml+xml"/>'
+            '<item id="m1" href="../META-INF/custommeta.xml" media-type="application/xml"/>'
+            "</manifest>"
+            '<spine><itemref idref="c1"/></spine>'
+            "</package>",
+        )
+        zf.writestr("OEBPS/chapter1.xhtml", "<html><body><p>hi</p></body></html>")
+        zf.writestr(
+            "META-INF/custommeta.xml",
+            '<metadata xmlns="http://www.idpf.org/2013/metadata">Anthropic Claude</metadata>',
+        )
+    data = buf.getvalue()
+
+    cleaned, actions = clean_epub(data)
+    assert any("drop part META-INF/custommeta.xml" in a for a in actions)
+    assert any("prune OPF manifest entries" in a for a in actions)
+    with zipfile.ZipFile(io.BytesIO(cleaned)) as zf:
+        assert "META-INF/custommeta.xml" not in zf.namelist()
+        opf = zf.read("OEBPS/content.opf").decode("utf-8")
+        assert "custommeta.xml" not in opf
+        assert 'id="c1"' in opf

--- a/tests/test_format_dispatch.py
+++ b/tests/test_format_dispatch.py
@@ -1,0 +1,68 @@
+"""Tests for format routing: unknown kind + header-only classification."""
+
+from __future__ import annotations
+
+import io
+import sys
+import zipfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "service" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from format_dispatch import classify, classify_bytes
+
+
+def _boom(*_args, **_kwargs):
+    raise AssertionError("full read_bytes() was not expected here")
+
+
+def test_classify_extension_wins_without_reading(monkeypatch, tmp_path):
+    f = tmp_path / "note.txt"
+    f.write_bytes(b"anything, the extension decides")
+    monkeypatch.setattr(Path, "read_bytes", _boom)
+    assert classify(f) == "text"
+
+
+def test_classify_header_sniffs_image_without_full_read(monkeypatch, tmp_path):
+    f = tmp_path / "no_extension"
+    f.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+    monkeypatch.setattr(Path, "read_bytes", _boom)
+    assert classify(f) == "image"
+
+
+def test_classify_header_sniffs_pdf_without_full_read(monkeypatch, tmp_path):
+    f = tmp_path / "no_extension"
+    f.write_bytes(b"%PDF-1.7\n" + b"0" * 100)
+    monkeypatch.setattr(Path, "read_bytes", _boom)
+    assert classify(f) == "container"
+
+
+def test_classify_zip_needs_full_read_for_central_directory(tmp_path):
+    # Extension-less DOCX: the container signature lives in the central
+    # directory at the end of the archive, so the full file must be read.
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("word/document.xml", "<w:document/>")
+    f = tmp_path / "no_extension"
+    f.write_bytes(buf.getvalue())
+    assert classify(f) == "container"
+
+
+def test_classify_truncated_zip_header_is_unknown(tmp_path):
+    f = tmp_path / "no_extension"
+    f.write_bytes(b"PK\x03\x04this is not a real zip")
+    assert classify(f) == "unknown"
+
+
+def test_classify_unknown_for_unrecognized_bytes(tmp_path):
+    f = tmp_path / "no_extension"
+    f.write_bytes(b"just plain text with no magic and no extension")
+    assert classify(f) == "unknown"
+
+
+def test_classify_bytes_unknown_fallback():
+    assert classify_bytes(b"random bytes \x00\xff", None) == "unknown"
+    assert classify_bytes(b"\x89PNG\r\n\x1a\nrest", None) == "image"
+    assert classify_bytes(b"PK\x03\x04rest", None) == "unknown"  # not a full zip

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -211,6 +211,22 @@ def test_binary_named_as_text_rejected(conn):
     assert status == 400
 
 
+def test_clean_unknown_format_rejected(conn):
+    data = b"no magic, no extension"
+    status, body = _post(conn, "/clean", {"file": _b64(data), "name": "input"})
+    assert status == 400
+    assert "unrecognized file format" in body["error"]
+
+
+def test_inspect_unknown_format_reports_kind(conn):
+    data = b"no magic, no extension"
+    status, body = _post(conn, "/inspect", {"file": _b64(data), "name": "input"})
+    assert status == 200
+    assert body["kind"] == "unknown"
+    assert body["suspicious"] is False
+    assert "note" in body["report"]
+
+
 def test_missing_file_field_rejected(conn):
     status, _body = _post(conn, "/inspect", {"name": "x.txt"})
     assert status == 400

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import os
+import struct
 import sys
 import zipfile
 from pathlib import Path
@@ -15,6 +16,7 @@ SCRIPTS = ROOT / "service" / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
 import common
+import container_meta
 from common import (
     backup_path,
     read_text_input,
@@ -26,6 +28,7 @@ from container_meta import (
     MAX_ZIP_DECOMPRESSED_BYTES,
     ZipBudgetExceeded,
     _check_zip_budget,
+    _read_zip_member,
     inspect_docx,
 )
 
@@ -57,24 +60,62 @@ def test_zip_budget_rejects_oversized_member():
     assert raised
 
 
-def test_zip_budget_accumulates_across_members():
-    buf = io.BytesIO()
-    with zipfile.ZipFile(buf, "w") as zf:
-        zf.writestr("a.xml", b"a")
-        zf.writestr("b.xml", b"b")
-    with zipfile.ZipFile(io.BytesIO(buf.getvalue())) as zf:
-        infos = zf.infolist()
-    for info in infos:
-        info.file_size = MAX_ZIP_DECOMPRESSED_BYTES // 2 + 1024
-    budget = [0]
-    raised = False
-    for info in infos:
-        try:
-            _check_zip_budget(info, budget)
-        except ZipBudgetExceeded:
-            raised = True
+def _patch_zip_declared_size(data: bytes, new_size: int) -> bytes:
+    """Rewrite the uncompressed-size field of every central-directory entry.
+
+    Produces the crafted-archive shape zip-bomb guards must defend
+    against: the central directory (which backs ZipInfo.file_size) claims
+    ``new_size`` decompressed bytes while the real deflate payload and its
+    CRC stay intact. The local headers are left untouched.
+    """
+    out = bytearray(data)
+    pos = 0
+    while True:
+        pos = out.find(b"PK\x01\x02", pos)
+        if pos == -1:
             break
-    assert raised
+        out[pos + 24 : pos + 28] = struct.pack("<I", new_size)
+        pos += 4
+    return bytes(out)
+
+
+def test_zip_budget_charges_real_bytes_not_declared(monkeypatch):
+    # The budget must be charged on bytes actually produced, not on the
+    # central directory claim (ZipInfo.file_size is attacker-controlled).
+    # Here the archive declares 150 KiB for a member that really carries
+    # 128 KiB; the accounting must follow reality.
+    monkeypatch.setattr(container_meta, "MAX_ZIP_DECOMPRESSED_BYTES", 1 << 20)
+    payload = b"y" * (1 << 17)  # 128 KiB
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_STORED) as zf:
+        zf.writestr("word/document.xml", payload)
+    crafted = _patch_zip_declared_size(buf.getvalue(), (1 << 17) + (1 << 16))
+    with zipfile.ZipFile(io.BytesIO(crafted)) as zf:
+        info = zf.infolist()[0]
+        assert info.file_size == (1 << 17) + (1 << 16)  # declared claim
+        budget = [0]
+        out = _read_zip_member(zf, info, budget)
+    assert out == payload
+    assert budget[0] == len(payload)  # real bytes, not the declared claim
+
+
+def test_zip_budget_accumulates_real_bytes_across_members(monkeypatch):
+    # The cap is cumulative across members: several members under the cap
+    # individually can still exhaust it together.
+    monkeypatch.setattr(container_meta, "MAX_ZIP_DECOMPRESSED_BYTES", 1 << 20)
+    payload = b"a" * (1 << 19)  # 512 KiB
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("a.xml", payload)
+        zf.writestr("b.xml", payload)
+        zf.writestr("c.xml", payload)  # 3 x 512 KiB > 1 MiB cap
+    with zipfile.ZipFile(io.BytesIO(buf.getvalue())) as zf:
+        budget = [0]
+        infos = zf.infolist()
+        _read_zip_member(zf, infos[0], budget)
+        _read_zip_member(zf, infos[1], budget)
+        with pytest.raises(ZipBudgetExceeded):
+            _read_zip_member(zf, infos[2], budget)
 
 
 def test_inspect_docx_with_ai_markers_does_not_crash():


### PR DESCRIPTION
Closes #122

Fixes the remaining correctness and security defects reported in #122 against the vendored skill scripts. Upstream, the same code lives in `service/scripts/` (the skill is a thin HTTP client), so all fixes land there.

## Fixes in this PR

**ODT/EPUB dangling references** — `clean_odt` dropped marker-bearing parts but left their entries in `META-INF/manifest.xml`, so readers flagged the package as damaged. It is now two-pass: compute the dropped set, then rewrite the manifest attribute-order-independently, writing each part exactly once. The same bug class in `clean_epub` (dropped parts left in the OPF manifest, plus dangling spine `itemref`s) gets the same treatment.

**Zip budget trusted the central directory** — `_check_zip_budget` summed `ZipInfo.file_size`, which is attacker-controlled; a crafted DOCX/ODT could declare a tiny size and still expand via `zf.read`. Budgets are now charged on actual decompressed bytes via `_read_zip_member` (streaming, cap enforced mid-read), with the declared size kept only as a fast-path pre-reject.

**Unknown files were auto-cleaned as text** — `classify_bytes` fell back to `"text"` for any unrecognized file, so a binary with valid UTF-8 runs could be decoded and written back mangled (corrupted with `--in-place`). Unrecognized bytes now classify as `"unknown"`; `clean_file` refuses them in auto mode (exit 2, no write) with `--as text` / `--force-text` as the explicit opt-ins. `inspect_file` reports `kind: unknown`, `audit_lib` records a non-actionable item, and the HTTP service answers `/inspect` with `kind: "unknown"` but 400s `/clean` of unknown formats.

**Header-only classification** — `classify(path)` read the whole file to sniff a header. It now routes known extensions without reading, sniffs a 4096-byte header once, and reads the whole file only when the header is a zip local header (`PK`), where the container signature lives in the central directory.

**Partial audits reported success** — `audit_dir`/`audit_website` computed the exit status only over successful items. New `EXIT_PARTIAL = 3`: a scan with any skipped/failed file or URL returns 3 in every output format (precedence: partial > actionable > clean).

**Setup scripts reused unverified checkouts** — the pinned-commit check ran only in the fresh-clone branch. All four scripts (`setup_ctrlregen.sh`, `setup_synthid.sh` + `.ps1`) now verify HEAD against the pinned ref on existing checkouts and repair via fetch + detach checkout, failing hard otherwise.

**Advisories / docs** — `requirements-ctrlregen.txt` documents the isolation expectation for the research-era pins (transformers 4.37.2, diffusers 0.27.2, Pillow 12.3.0 carry published advisories and are only ever installed in the dedicated venv, never the main image); README and SKILL.md document the `unknown` behavior, audit exit codes, and the backend isolation expectation. The XML parsing comment in `audit_website.py` records why stdlib ElementTree is used (stdlib-first policy; DTD rejection stays) with defusedxml as the fallback if that policy changes.

## Items from #122 already fixed upstream (verified, no change needed)

- `clean_markdown` blank-frontmatter IndexError and nested re-parenting — already fixed and tested
- DOCX dangling refs (`[Content_Types].xml`, `_rels`) — already fixed and tested (two-pass prune)
- `text_unicode` ZWNJ/ZWJ stripping — already preserved when both neighbours are in the same joining script
- `audit_website` SSRF / gzip bomb / unbounded sitemap recursion — already hardened and tested
- Format-independent exit status for `clean_file`/`clean_image` — already fixed and tested

## Tests

- ODT manifest rewrite (dropped entry removed, attribute-order-independent, byte-identical when nothing dropped, single manifest entry)
- EPUB OPF prune for dropped parts
- Zip budget charged on real bytes (crafted central directory lying about size) + cumulative real-byte caps
- Unknown-kind CLI/server behavior (refusal, opt-ins, `kind: "unknown"`, HTTP 400/200)
- Header-only classify (extension without read, header sniff, PK-only full read)
- Partial-scan exit code in human/JSON/SARIF for both audits

`pytest -q` green, `ruff check` / `ruff format --check` clean, setup scripts pass `bash -n` (pin-repair logic exercised against a real local repo pair).
