### PR TITLE
feat: pre-commit hook integration (check + opt-in clean)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 !/.dockerignore
 !/.env.example
 !/.gitignore
+!/.pre-commit-hooks.yaml
 !/CODE_OF_CONDUCT.md
 !/compose-check.sh
 !/compose.yaml

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,16 @@
+- id: watermarks-remover-check
+  name: watermarks-remover check
+  description: Fail the commit if staged files carry AI/C2PA provenance marks.
+  entry: python3 service/scripts/check_staged.py
+  language: system
+  stages: [pre-commit]
+
+- id: watermarks-remover-clean
+  name: watermarks-remover clean (auto-fix)
+  description: >-
+    Strip AI/C2PA provenance marks from staged files in place. Opt-in: this
+    rewrites file contents, so add it only if you want staged files cleaned
+    automatically rather than just failing the commit.
+  entry: python3 service/scripts/clean_staged.py
+  language: system
+  stages: [pre-commit]

--- a/README.md
+++ b/README.md
@@ -780,6 +780,22 @@ Third-party projects that wrap or complement this repository, listed for discove
 
 To register a project here, open a PR adding a short entry — project name, what it wraps or adds, and a link to its own repository. Keep entries brief and factual; do not claim compatibility with, or endorsement by, this project. Please avoid names that start with or closely resemble `watermarks-remover` — look-alike names make it hard to tell which project is which.
 
+## Pre-commit hook
+
+CI gating already exists (`audit_dir.py`'s SARIF export, see [Coverage matrix](#coverage-matrix) context) — the [pre-commit](https://pre-commit.com/) hooks below catch the same class of problem earlier, before a marked file is even committed. Both wrap the existing CLIs (`audit_dir.py` / `clean_file.py`) — no separate detection logic.
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/guillaumemeyer/watermarks-remover
+    rev: v0.5.0   # pin to a tag/commit
+    hooks:
+      - id: watermarks-remover-check   # fails the commit if marks are found
+      # - id: watermarks-remover-clean # opt-in: cleans staged files in place instead
+```
+
+`watermarks-remover-check` fails the commit and lists findings; `watermarks-remover-clean` is opt-in and rewrites staged files in place (exits non-zero so you review the diff and re-stage — the same convention as auto-fixing hooks like `ruff --fix`). Run either by hand with `python3 service/scripts/check_staged.py <files...>` / `clean_staged.py <files...>`.
+
 ## Tests
 
 ```bash

--- a/service/scripts/check_staged.py
+++ b/service/scripts/check_staged.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Fail if any given file carries AI/C2PA provenance marks.
+
+Designed to run as a pre-commit hook: the pre-commit framework invokes this
+with the staged files as positional arguments, so it never touches git state
+itself — it just scans whatever paths it's given. Reuses scan_file() /
+is_actionable() from audit_lib.py (audit_dir.py's own per-file logic), so
+the pre-commit gate and the CI gate (#101's SARIF export) agree on exactly
+what counts as actionable.
+
+Exit codes match audit_dir.py: 0 = clean, 1 = actionable findings found,
+2 = usage error (a given path does not exist / is not a file).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from audit_lib import is_actionable, scan_file
+from common import MAX_INPUT_BYTES, eprint
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("paths", nargs="+", type=Path, help="Files to check (e.g. staged files)")
+    p.add_argument(
+        "--check-stylometry",
+        action="store_true",
+        help="Also evaluate text files for AI statistical & stylometric signals",
+    )
+    args = p.parse_args()
+
+    actionable: list[dict] = []
+    for path in args.paths:
+        if not path.is_file():
+            eprint(f"not a file: {path}")
+            return 2
+        if path.stat().st_size > MAX_INPUT_BYTES:
+            eprint(f"skipping {path}: larger than {MAX_INPUT_BYTES} bytes")
+            continue
+        item = scan_file(path, check_stylometry=args.check_stylometry)
+        if item.get("kind") == "unknown":
+            continue
+        if is_actionable(item):
+            actionable.append(item)
+
+    if not actionable:
+        return 0
+
+    eprint(f"watermarks-remover: {len(actionable)} file(s) carry AI/C2PA provenance marks:")
+    for item in actionable:
+        eprint(f"  {item['path']}")
+        for finding in item.get("findings", []):
+            eprint(f"    - {finding}")
+        if item.get("has_c2pa"):
+            eprint("    - C2PA manifest present")
+        if item.get("has_ai_metadata"):
+            eprint("    - AI-generator metadata present")
+    eprint(
+        "Run `python3 service/scripts/clean_file.py <path> --in-place` "
+        "(or the watermarks-remover-clean pre-commit hook) to strip these before committing."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/service/scripts/clean_staged.py
+++ b/service/scripts/clean_staged.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Strip AI/C2PA provenance marks from given files in place.
+
+Designed to run as a pre-commit hook: the pre-commit framework invokes this
+with the staged files as positional arguments. It wraps clean_file.py
+--in-place as a subprocess per file — no cleaning logic is duplicated here,
+this is purely a batch-over-staged-files wrapper.
+
+Rewriting a file a developer just staged is a real behavior change, not a
+lint-and-continue: following the standard pre-commit auto-fixer convention
+(same as e.g. black / ruff --fix hooks), this exits 1 whenever it modified
+at least one file, so the hook framework stops the commit and the developer
+reviews the diff and re-stages. Exit 0 means every file was already clean.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from common import eprint
+
+CLEAN_FILE_PY = Path(__file__).resolve().parent / "clean_file.py"
+
+
+def _changed(result: dict) -> bool:
+    stats = result.get("stats")
+    if stats is not None:
+        return bool(stats.get("removed_count") or stats.get("replaced_count"))
+    return bool(result.get("actions"))
+
+
+def _clean_one(path: Path) -> str:
+    """Returns 'changed', 'unchanged', or 'skipped'."""
+    proc = subprocess.run(
+        [sys.executable, str(CLEAN_FILE_PY), str(path), "--in-place", "--json"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode == 2:
+        # Unrecognized format or oversized input; clean_file.py already
+        # explained why on stderr, this is a non-fatal skip for the hook.
+        return "skipped"
+    if not proc.stdout.strip():
+        eprint(f"{path}: {proc.stderr.strip() or 'clean_file.py produced no output'}")
+        return "skipped"
+    try:
+        result = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        eprint(f"{path}: could not parse clean_file.py output")
+        return "skipped"
+    return "changed" if _changed(result) else "unchanged"
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "paths", nargs="+", type=Path, help="Files to clean in place (e.g. staged files)"
+    )
+    args = p.parse_args()
+
+    changed_paths: list[Path] = []
+    for path in args.paths:
+        if not path.is_file():
+            eprint(f"not a file: {path}")
+            continue
+        status = _clean_one(path)
+        if status == "changed":
+            changed_paths.append(path)
+
+    if not changed_paths:
+        return 0
+
+    eprint(f"watermarks-remover: cleaned {len(changed_paths)} file(s) in place:")
+    for path in changed_paths:
+        eprint(f"  {path}")
+    eprint("Review the changes and re-stage before committing.")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_precommit_hooks.py
+++ b/tests/test_precommit_hooks.py
@@ -1,0 +1,96 @@
+"""Tests for the pre-commit hook wrappers (check_staged.py / clean_staged.py)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "service" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import check_staged
+import clean_staged
+
+
+def _watermarked_text() -> str:
+    return "Hello" + chr(0x200B) + "World!"
+
+
+def test_check_staged_clean_file_exits_0(tmp_path, monkeypatch, capsys):
+    f = tmp_path / "clean.txt"
+    f.write_text("Nothing to see here.", encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", ["check_staged.py", str(f)])
+    assert check_staged.main() == 0
+
+
+def test_check_staged_marked_file_exits_1(tmp_path, monkeypatch, capsys):
+    f = tmp_path / "marked.txt"
+    f.write_text(_watermarked_text(), encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", ["check_staged.py", str(f)])
+    assert check_staged.main() == 1
+    err = capsys.readouterr().err
+    assert str(f) in err
+    assert "layer-a" in err
+
+
+def test_check_staged_multiple_files_one_marked(tmp_path, monkeypatch, capsys):
+    clean = tmp_path / "clean.txt"
+    clean.write_text("plain text", encoding="utf-8")
+    marked = tmp_path / "marked.txt"
+    marked.write_text(_watermarked_text(), encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", ["check_staged.py", str(clean), str(marked)])
+    assert check_staged.main() == 1
+    err = capsys.readouterr().err
+    assert str(marked) in err
+    assert str(clean) not in err
+
+
+def test_check_staged_unknown_format_skipped(tmp_path, monkeypatch):
+    f = tmp_path / "data.bin"
+    f.write_bytes(b"\x00\x01\x02\xff\xfe no known magic bytes here")
+    monkeypatch.setattr(sys, "argv", ["check_staged.py", str(f)])
+    assert check_staged.main() == 0
+
+
+def test_check_staged_missing_path_exits_2(tmp_path, monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["check_staged.py", str(tmp_path / "nope.txt")])
+    assert check_staged.main() == 2
+
+
+def test_clean_staged_marked_file_cleans_and_exits_1(tmp_path, monkeypatch, capsys):
+    f = tmp_path / "marked.txt"
+    f.write_text(_watermarked_text(), encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", ["clean_staged.py", str(f)])
+    assert clean_staged.main() == 1
+    assert f.read_text(encoding="utf-8") == "HelloWorld!"
+    err = capsys.readouterr().err
+    assert str(f) in err
+
+
+def test_clean_staged_already_clean_file_exits_0_unchanged(tmp_path, monkeypatch):
+    f = tmp_path / "clean.txt"
+    original = "Nothing to see here."
+    f.write_text(original, encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", ["clean_staged.py", str(f)])
+    assert clean_staged.main() == 0
+    assert f.read_text(encoding="utf-8") == original
+
+
+def test_clean_staged_unknown_format_skipped(tmp_path, monkeypatch):
+    f = tmp_path / "data.bin"
+    original = b"\x00\x01\x02\xff\xfe no known magic bytes here"
+    f.write_bytes(original)
+    monkeypatch.setattr(sys, "argv", ["clean_staged.py", str(f)])
+    assert clean_staged.main() == 0
+    assert f.read_bytes() == original
+
+
+def test_pre_commit_hooks_manifest_defines_both_hooks():
+    # No PyYAML in this project's stdlib-only test deps (requirements-dev.txt) —
+    # check the manifest's shape textually rather than adding a parser dependency.
+    text = (ROOT / ".pre-commit-hooks.yaml").read_text(encoding="utf-8")
+    assert "id: watermarks-remover-check" in text
+    assert "id: watermarks-remover-clean" in text
+    assert text.count("entry: python3 service/scripts/") == 2
+    assert text.count("language: system") == 2


### PR DESCRIPTION
Closes #135.

CI already catches this — `audit_dir.py`'s SARIF export and `-j` concurrency from #101 exist specifically to run in CI. But that only fires after a marked file's already committed and pushed. This catches it earlier, at `git commit`, using the [pre-commit](https://pre-commit.com/) framework.

Added `.pre-commit-hooks.yaml` with two hooks:

- `watermarks-remover-check` — fails the commit and lists what it found when staged files carry AI/C2PA marks. Runs the same `scan_file()`/`is_actionable()` logic from `audit_lib.py` that `audit_dir.py` already uses for CI, so the pre-commit gate and the CI gate agree on what counts as actionable by construction — I didn't write a second definition of "actionable" anywhere.
- `watermarks-remover-clean` — opt-in, not the default. Cleans staged files in place, exits non-zero so you go review the diff and re-stage, same pattern `ruff --fix` and friends already use. Rewriting someone's staged diff without asking felt like a bigger call than just failing their commit with a message, so I didn't want that to be the thing that runs by default.

Both are thin wrappers — `check_staged.py` and `clean_staged.py` don't do any new detection or cleaning, they just call into what already exists. They also work standalone as plain CLIs if someone wants the same check outside the pre-commit framework.

`.pre-commit-hooks.yaml` needed a line added to the deny-by-default `.gitignore`, same as every other root config file already listed there.

## Testing

- `python -m pytest` — 442 passed, 6 skipped (main's at 433/6, the 9 new ones are `tests/test_precommit_hooks.py`)
- `ruff check` / `ruff format --check` clean
- Ran it by hand too: a file with an actual U+200B in it fails `check_staged.py`, `clean_staged.py` strips it and exits 1 so you know to re-stage, then `check_staged.py` on the cleaned file passes.

Added a "Pre-commit hook" section to the README with the config snippet.