### PR TITLE
fix: linear-time metadata stripping for SVG/ODT (GHSA-7vpp-96qp-j9wh)

### DIFF
--- a/service/scripts/container_meta.py
+++ b/service/scripts/container_meta.py
@@ -332,6 +332,80 @@ def _clean_embedded_data_uris(
 
 
 # ---------------------------------------------------------------------------
+# Linear tag-block scanning
+# ---------------------------------------------------------------------------
+#
+# The lazy ".*?</close>" idiom is quadratic on adversarial input: with many
+# opening tags and no closing tag, the engine rescans to end-of-input from
+# every candidate start position (CPython's "re" holds the GIL, so one such
+# request stalls the whole single-process service for its duration). The
+# helpers below locate every opening and closing tag once and pair them with a
+# forward pointer - O(n) total regardless of input shape - while preserving
+# the exact match semantics of re.subn with a lazy ".*?" (the first closing
+# tag at/after each opening tag's end, blocks never overlapping).
+
+
+def _iter_tag_blocks(text, open_re, close_re):
+    """Yield (open_start, open_end, close_start, close_end) for each block.
+
+    Works on str and bytes alike. Linear in len(text): closing tags are
+    collected once with finditer and consumed by a forward pointer, so an
+    unbounded run of unclosed opening tags costs one pass, not one rescan per
+    opening tag.
+    """
+    closes = list(close_re.finditer(text))
+    ci = 0
+    last_end = 0
+    for om in open_re.finditer(text):
+        if om.start() < last_end:
+            continue
+        while ci < len(closes) and closes[ci].start() < om.end():
+            ci += 1
+        if ci >= len(closes):
+            return
+        cm = closes[ci]
+        yield om.start(), om.end(), cm.start(), cm.end()
+        last_end = cm.end()
+
+
+def _drop_tag_blocks(text, open_re, close_re):
+    """Remove every open...close block. Return (text, count). Linear time."""
+    out = []
+    last = 0
+    count = 0
+    for os_, _oe, _cs, ce in _iter_tag_blocks(text, open_re, close_re):
+        out.append(text[last:os_])
+        last = ce
+        count += 1
+    if not count:
+        return text, 0
+    out.append(text[last:])
+    return text[:0].join(out), count
+
+
+def _drop_blocks_if(text, open_re, close_re, predicate):
+    """Drop blocks whose full text satisfies predicate. Return (text, count).
+
+    Blocks failing the predicate are kept verbatim; predicate is called with
+    the whole block (open tag through closing tag), matching the
+    callback-based re.sub sites this replaces.
+    """
+    out = []
+    last = 0
+    count = 0
+    for os_, _oe, _cs, ce in _iter_tag_blocks(text, open_re, close_re):
+        if not predicate(text[os_:ce]):
+            continue
+        out.append(text[last:os_])
+        last = ce
+        count += 1
+    if not count:
+        return text, 0
+    out.append(text[last:])
+    return text[:0].join(out), count
+
+
+# ---------------------------------------------------------------------------
 # Markdown frontmatter
 # ---------------------------------------------------------------------------
 
@@ -479,10 +553,11 @@ def _is_cms_generator_meta(tag: str) -> bool:
     return not (_GENERATOR_AI_RE.search(attrs.get("content", "")) or _GENERATOR_AI_RE.search(tag))
 
 
-_JSONLD_RE = re.compile(
-    r"<script\b[^>]*type\s*=\s*[\"']application/ld\+json[\"'][^>]*>.*?</script>",
-    re.I | re.DOTALL,
+_JSONLD_OPEN_RE = re.compile(
+    r"""<script\b[^>]*type\s*=\s*["']application/ld\+json["'][^>]*>""",
+    re.I,
 )
+_JSONLD_CLOSE_RE = re.compile(r"</script>", re.I)
 
 
 def inspect_html(text: str) -> tuple[bool, bool, list[str], dict]:
@@ -500,8 +575,8 @@ def inspect_html(text: str) -> tuple[bool, bool, list[str], dict]:
         ):
             has_ai = True
             findings.append(f"meta: {tag[:120]}")
-    for m in _JSONLD_RE.finditer(text):
-        blob = m.group(0)
+    for os_, _oe, _cs, ce in _iter_tag_blocks(text, _JSONLD_OPEN_RE, _JSONLD_CLOSE_RE):
+        blob = text[os_:ce]
         if AI_META_NAME_RE.search(blob) or re.search(
             r"DigitalSourceType|trainedAlgorithmicMedia|SoftwareAgent", blob, re.I
         ):
@@ -540,16 +615,15 @@ def clean_html(text: str) -> tuple[str, list[str]]:
 
     out = _META_TAG_RE.sub(_meta_sub, text)
 
-    def _jsonld_sub(m: re.Match[str]) -> str:
-        blob = m.group(0)
-        if AI_META_NAME_RE.search(blob) or re.search(
+    def _jsonld_is_ai(blob: str) -> bool:
+        return AI_META_NAME_RE.search(blob) or re.search(
             r"DigitalSourceType|trainedAlgorithmicMedia|SoftwareAgent", blob, re.I
-        ):
-            actions.append("drop json-ld provenance-like script")
-            return ""
-        return blob
+        )
 
-    out = _JSONLD_RE.sub(_jsonld_sub, out)
+    new, n = _drop_blocks_if(out, _JSONLD_OPEN_RE, _JSONLD_CLOSE_RE, _jsonld_is_ai)
+    if n:
+        actions.extend(["drop json-ld provenance-like script"] * n)
+        out = new
     out2, n = re.subn(r"\sdata-ai[\w-]*\s*=\s*[\"'][^\"']*[\"']", "", out, flags=re.I)
     if n:
         actions.append(f"drop data-ai* attributes x{n}")
@@ -567,6 +641,19 @@ def clean_html(text: str) -> tuple[str, list[str]]:
 # ---------------------------------------------------------------------------
 # SVG
 # ---------------------------------------------------------------------------
+
+# Opening/closing tag patterns for the linear block scans below. Kept as
+# separate open/close halves: the lazy ".*?</close>" form is quadratic when
+# many opening tags have no closing tag (see _iter_tag_blocks).
+_SVG_METADATA_OPEN_RE = re.compile(r"<metadata\b[^>]*>", re.I)
+_SVG_METADATA_CLOSE_RE = re.compile(r"</metadata\s*>", re.I)
+_SVG_XMPMETA_OPEN_RE = re.compile(r"<x:xmpmeta\b[^>]*>", re.I)
+_SVG_XMPMETA_CLOSE_RE = re.compile(r"</x:xmpmeta\s*>", re.I)
+_SVG_COMMENT_OPEN_RE = re.compile(r"<!--")
+# HTML comment end tags are "-->" or "--!>" (CodeQL: bad HTML filtering
+# regexp otherwise). XML/SVG only emits "-->", but accepting both keeps the
+# scrub effective on HTML-flavoured inputs.
+_SVG_COMMENT_CLOSE_RE = re.compile(r"--!?>")
 
 
 def inspect_svg(data: bytes) -> tuple[bool, bool, list[str], dict]:
@@ -598,36 +685,25 @@ def inspect_svg(data: bytes) -> tuple[bool, bool, list[str], dict]:
 def clean_svg(data: bytes) -> tuple[bytes, list[str]]:
     actions: list[str] = []
     text = data.decode("utf-8", errors="surrogateescape")
-    # Drop metadata blocks
-    new, n = re.subn(
-        r"<metadata\b[^>]*>.*?</metadata\s*>",
-        "",
-        text,
-        flags=re.I | re.DOTALL,
-    )
+    # Drop metadata blocks (linear scan - lazy .*? is quadratic on unclosed tags)
+    new, n = _drop_tag_blocks(text, _SVG_METADATA_OPEN_RE, _SVG_METADATA_CLOSE_RE)
     if n:
         actions.append(f"drop <metadata> x{n}")
         text = new
     # Drop adobe xmp packets
-    new, n = re.subn(
-        r"<x:xmpmeta\b[^>]*>.*?</x:xmpmeta\s*>",
-        "",
-        text,
-        flags=re.I | re.DOTALL,
-    )
+    new, n = _drop_tag_blocks(text, _SVG_XMPMETA_OPEN_RE, _SVG_XMPMETA_CLOSE_RE)
     if n:
         actions.append(f"drop xmpmeta x{n}")
         text = new
 
-    # Drop comments that look like provenance
-    def _cmt(m: re.Match[str]) -> str:
-        body = m.group(0)
-        if AI_META_NAME_RE.search(body):
-            actions.append("drop SVG comment with AI markers")
-            return ""
-        return body
+    # Drop comments that look like provenance (linear scan)
+    def _cmt(block: str) -> bool:
+        return bool(AI_META_NAME_RE.search(block))
 
-    text = re.sub(r"<!--.*?-->", _cmt, text, flags=re.DOTALL)
+    new, n = _drop_blocks_if(text, _SVG_COMMENT_OPEN_RE, _SVG_COMMENT_CLOSE_RE, _cmt)
+    if n:
+        actions.extend(["drop SVG comment with AI markers"] * n)
+        text = new
 
     # Clean embedded data URIs
     text, uri_actions = _clean_embedded_data_uris(text)
@@ -653,6 +729,12 @@ def clean_svg(data: bytes) -> tuple[bytes, list[str]]:
 # ---------------------------------------------------------------------------
 # DOCX / ODT (zip + XML)
 # ---------------------------------------------------------------------------
+
+# Open/close tag halves for the linear metadata-block scans in clean_odt.
+_ODT_GENERATOR_OPEN_RE = re.compile(r"<meta:generator\b[^>]*>", re.I)
+_ODT_GENERATOR_CLOSE_RE = re.compile(r"</meta:generator\s*>", re.I)
+_DC_CREATOR_OPEN_RE = re.compile(r"<dc:creator\b[^>]*>", re.I)
+_DC_CREATOR_CLOSE_RE = re.compile(r"</dc:creator\s*>", re.I)
 
 DOCX_META_PARTS = (
     "docProps/core.xml",
@@ -816,6 +898,39 @@ def inspect_pptx(data: bytes) -> tuple[bool, bool, list[str], dict]:
     return _inspect_ooxml_zip(data, "pptx")
 
 
+def _scrub_text_runs(
+    xml_text: str, open_re: re.Pattern[str], close_re: re.Pattern[str]
+) -> tuple[str, int, int]:
+    """Run Layer A over the text runs delimited by open_re/close_re.
+
+    Shared by the DOCX/XLSX/PPTX/ODT body scrubs. Linear scan (see
+    _iter_tag_blocks) - the previous "(<tag>)(.*?)(</tag>)" lazy pattern was
+    quadratic on a run of unclosed opening tags.
+    """
+    from text_unicode import clean_text  # local import to avoid cycles
+
+    removed = 0
+    replaced = 0
+    out = []
+    last = 0
+    for os_, oe, cs_, ce in _iter_tag_blocks(xml_text, open_re, close_re):
+        open_tag = xml_text[os_:oe]
+        inner = xml_text[oe:cs_]
+        close_tag = xml_text[cs_:ce]
+        new_inner, stats = clean_text(inner)
+        if not (stats["removed_count"] or stats["replaced_count"]):
+            continue
+        removed += stats["removed_count"]
+        replaced += stats["replaced_count"]
+        if (new_inner[:1].isspace() or new_inner[-1:].isspace()) and "xml:space" not in open_tag:
+            open_tag = open_tag[:-1] + ' xml:space="preserve">'
+        out.append(xml_text[last:os_])
+        out.append(open_tag + new_inner + close_tag)
+        last = ce
+    out.append(xml_text[last:])
+    return "".join(out), removed, replaced
+
+
 def _scrub_docx_text(xml_text: str) -> tuple[str, int, int]:
     """Run Layer A over the ``<w:t>`` text runs of a DOCX part.
 
@@ -824,69 +939,17 @@ def _scrub_docx_text(xml_text: str) -> tuple[str, int, int]:
     trailing whitespace survives the clean, the node keeps
     ``xml:space="preserve"`` so Word does not trim it.
     """
-    from text_unicode import clean_text  # local import to avoid cycles
-
-    removed = 0
-    replaced = 0
-
-    def _repl(m: re.Match[str]) -> str:
-        nonlocal removed, replaced
-        open_tag, inner, close_tag = m.group(1), m.group(2), m.group(3)
-        new_inner, stats = clean_text(inner)
-        if not (stats["removed_count"] or stats["replaced_count"]):
-            return m.group(0)
-        removed += stats["removed_count"]
-        replaced += stats["replaced_count"]
-        if (new_inner[:1].isspace() or new_inner[-1:].isspace()) and "xml:space" not in open_tag:
-            open_tag = open_tag[:-1] + ' xml:space="preserve">'
-        return open_tag + new_inner + close_tag
-
-    new = re.sub(r"(<w:t\b[^>]*>)(.*?)(</w:t>)", _repl, xml_text, flags=re.S)
-    return new, removed, replaced
+    return _scrub_text_runs(xml_text, re.compile(r"<w:t\b[^>]*>"), re.compile(r"</w:t>"))
 
 
 def _scrub_xlsx_text(xml_text: str) -> tuple[str, int, int]:
     """Run Layer A over the ``<t>`` text elements of an XLSX part."""
-    from text_unicode import clean_text  # local import to avoid cycles
-
-    removed = 0
-    replaced = 0
-
-    def _repl(m: re.Match[str]) -> str:
-        nonlocal removed, replaced
-        open_tag, inner, close_tag = m.group(1), m.group(2), m.group(3)
-        new_inner, stats = clean_text(inner)
-        if not (stats["removed_count"] or stats["replaced_count"]):
-            return m.group(0)
-        removed += stats["removed_count"]
-        replaced += stats["replaced_count"]
-        if (new_inner[:1].isspace() or new_inner[-1:].isspace()) and "xml:space" not in open_tag:
-            open_tag = open_tag[:-1] + ' xml:space="preserve">'
-        return open_tag + new_inner + close_tag
-
-    new = re.sub(r"(<t\b[^>]*>)(.*?)(</t>)", _repl, xml_text, flags=re.S)
-    return new, removed, replaced
+    return _scrub_text_runs(xml_text, re.compile(r"<t\b[^>]*>"), re.compile(r"</t>"))
 
 
 def _scrub_pptx_text(xml_text: str) -> tuple[str, int, int]:
     """Run Layer A over the ``<a:t>`` text elements of a PPTX part."""
-    from text_unicode import clean_text  # local import to avoid cycles
-
-    removed = 0
-    replaced = 0
-
-    def _repl(m: re.Match[str]) -> str:
-        nonlocal removed, replaced
-        open_tag, inner, close_tag = m.group(1), m.group(2), m.group(3)
-        new_inner, stats = clean_text(inner)
-        if not (stats["removed_count"] or stats["replaced_count"]):
-            return m.group(0)
-        removed += stats["removed_count"]
-        replaced += stats["replaced_count"]
-        return open_tag + new_inner + close_tag
-
-    new = re.sub(r"(<a:t\b[^>]*>)(.*?)(</a:t>)", _repl, xml_text, flags=re.S)
-    return new, removed, replaced
+    return _scrub_text_runs(xml_text, re.compile(r"<a:t\b[^>]*>"), re.compile(r"</a:t>"))
 
 
 def _scrub_odt_text(xml_text: str) -> tuple[str, int, int]:
@@ -896,23 +959,7 @@ def _scrub_odt_text(xml_text: str) -> tuple[str, int, int]:
     so cleaning the paragraph content covers the visible text. The markup
     itself is untouched.
     """
-    from text_unicode import clean_text  # local import to avoid cycles
-
-    removed = 0
-    replaced = 0
-
-    def _repl(m: re.Match[str]) -> str:
-        nonlocal removed, replaced
-        open_tag, inner, close_tag = m.group(1), m.group(2), m.group(3)
-        new_inner, stats = clean_text(inner)
-        if not (stats["removed_count"] or stats["replaced_count"]):
-            return m.group(0)
-        removed += stats["removed_count"]
-        replaced += stats["replaced_count"]
-        return open_tag + new_inner + close_tag
-
-    new = re.sub(r"(<text:p\b[^>]*>)(.*?)(</text:p>)", _repl, xml_text, flags=re.S)
-    return new, removed, replaced
+    return _scrub_text_runs(xml_text, re.compile(r"<text:p\b[^>]*>"), re.compile(r"</text:p>"))
 
 
 def _prune_dangling_relationships(
@@ -1095,14 +1142,21 @@ def _scrub_ooxml_zip(
                 text = raw.decode("utf-8", errors="replace")
                 new = text
                 for tag, label in DOCX_SCRUB_FIELDS:
-                    pat = rf"(<{tag}\b[^>]*>)(.*?)(</{tag}>)"
-
-                    def _empty(m: re.Match[str], _label=label, _name=name) -> str:
-                        if m.group(2):
-                            actions.append(f"scrub {_name} field {_label}")
-                        return m.group(1) + m.group(3)
-
-                    new = re.sub(pat, _empty, new, flags=re.I | re.DOTALL)
+                    open_re = re.compile(rf"<{tag}\b[^>]*>", re.I)
+                    close_re = re.compile(rf"</{tag}>", re.I)
+                    out = []
+                    last = 0
+                    n = 0
+                    for os_, oe, cs_, ce in _iter_tag_blocks(new, open_re, close_re):
+                        out.append(new[last:os_])
+                        out.append(new[os_:oe] + new[cs_:ce])
+                        last = ce
+                        if new[oe:cs_]:
+                            n += 1
+                            actions.append(f"scrub {name} field {label}")
+                    if n:
+                        out.append(new[last:])
+                        new = "".join(out)
                 raw = new.encode("utf-8")
 
             # 4. [Content_Types].xml overrides
@@ -1227,29 +1281,23 @@ def clean_odt(data: bytes, *, also_layer_a_text: bool = True) -> tuple[bytes, li
             raw = _read_zip_member(zin, info, budget)
             if name == "meta.xml":
                 text = raw.decode("utf-8", errors="replace")
-                new, n = re.subn(
-                    r"<meta:generator\b[^>]*>.*?</meta:generator\s*>",
-                    "",
-                    text,
-                    flags=re.I | re.DOTALL,
-                )
+                # Drop meta:generator blocks (linear scan - lazy .*? is
+                # quadratic on unclosed tags, see _iter_tag_blocks)
+                new, n = _drop_tag_blocks(text, _ODT_GENERATOR_OPEN_RE, _ODT_GENERATOR_CLOSE_RE)
                 if n:
                     actions.append("drop meta:generator")
                     text = new
 
-                # scrub creator-like if AI
-                def _creator(m: re.Match[str]) -> str:
-                    if AI_META_NAME_RE.search(m.group(0)):
-                        actions.append("scrub creator-like meta")
-                        return ""
-                    return m.group(0)
+                # scrub creator-like if AI (linear scan)
+                def _is_ai_creator(block: str) -> bool:
+                    return bool(AI_META_NAME_RE.search(block))
 
-                text = re.sub(
-                    r"<dc:creator\b[^>]*>.*?</dc:creator\s*>",
-                    _creator,
-                    text,
-                    flags=re.I | re.DOTALL,
+                new, n = _drop_blocks_if(
+                    text, _DC_CREATOR_OPEN_RE, _DC_CREATOR_CLOSE_RE, _is_ai_creator
                 )
+                if n:
+                    actions.extend(["scrub creator-like meta"] * n)
+                    text = new
                 raw = text.encode("utf-8")
             else:
                 c2, ai, _ = _blob_hits(raw)
@@ -1402,6 +1450,19 @@ def inspect_epub(data: bytes) -> tuple[bool, bool, list[str], dict]:
     return has_c2pa, has_ai or has_c2pa, findings, {"parts": len(names)}
 
 
+# Open/close tag halves for the linear OPF scans in _scrub_epub_opf.
+_OPF_META_OPEN_RE = re.compile(r"<meta\b[^>]*>", re.I)
+_OPF_META_CLOSE_RE = re.compile(r"</meta\s*>", re.I)
+_DC_FIELDS_OPEN_RE = re.compile(
+    r"<(dc:(?:creator|contributor|publisher|description|rights|source))\b[^>]*>",
+    re.I,
+)
+_DC_FIELDS_CLOSE_RE = re.compile(
+    r"</(dc:(?:creator|contributor|publisher|description|rights|source))\s*>",
+    re.I,
+)
+
+
 def _scrub_epub_opf(text: str) -> tuple[str, list[str]]:
     """Scrub AI-ish metadata from the EPUB package document (OPF)."""
     actions: list[str] = []
@@ -1414,20 +1475,49 @@ def _scrub_epub_opf(text: str) -> tuple[str, list[str]]:
         return tag
 
     new = re.sub(r"<meta\b[^>]*/>", _meta, text, flags=re.I)
-    new = re.sub(r"<meta\b[^>]*>.*?</meta\s*>", _meta, new, flags=re.I | re.DOTALL)
 
-    def _dc(m: re.Match[str]) -> str:
-        if AI_META_NAME_RE.search(m.group(0)):
-            actions.append(f"scrub {m.group(1)} (AI vendor name)")
-            return f"<{m.group(1)}/>"
-        return m.group(0)
+    # Block-form <meta>...</meta> (linear scan; the lazy .*? form is
+    # quadratic on unclosed opening tags, see _iter_tag_blocks)
+    def _meta_block_is_ai(block: str) -> bool:
+        if AI_META_NAME_RE.search(block):
+            actions.append("drop OPF meta tag")
+            return True
+        return False
 
-    new = re.sub(
-        r"<(dc:(?:creator|contributor|publisher|description|rights|source))\b[^>]*>.*?</\1\s*>",
-        _dc,
-        new,
-        flags=re.I | re.DOTALL,
-    )
+    # The predicate itself records the per-block action, so the count is unused.
+    new, _n = _drop_blocks_if(new, _OPF_META_OPEN_RE, _OPF_META_CLOSE_RE, _meta_block_is_ai)
+
+    # dc:... provenance fields. The original pattern paired each opening tag
+    # with its backreferenced closing tag via a lazy .*? - quadratic on
+    # unclosed openings. Pair opens with same-name closes directly: linear,
+    # exact same match semantics (first same-name close at/after the open).
+    out = []
+    last = 0
+    dc_closes: dict[str, list[re.Match[str]]] = {}
+    for m in re.finditer(_DC_FIELDS_CLOSE_RE, new):
+        dc_closes.setdefault(m.group(1), []).append(m)
+    ptr: dict[str, int] = {name: 0 for name in dc_closes}
+    for om in re.finditer(_DC_FIELDS_OPEN_RE, new):
+        name = om.group(1)
+        if om.start() < last:
+            continue
+        closes = dc_closes.get(name, ())
+        i = ptr.get(name, 0)
+        while i < len(closes) and closes[i].start() < om.end():
+            i += 1
+        ptr[name] = i
+        if i >= len(closes):
+            continue  # no same-name close - block never matches (kept)
+        cm = closes[i]
+        block = new[om.start() : cm.end()]
+        if AI_META_NAME_RE.search(block):
+            out.append(new[last : om.start()])
+            out.append(f"<{name}/>")
+            last = cm.end()
+            actions.append(f"scrub {name} (AI vendor name)")
+    if last:
+        out.append(new[last:])
+        new = "".join(out)
 
     if not actions:
         actions.append("no OPF metadata removed")
@@ -1564,10 +1654,13 @@ def clean_epub(data: bytes, *, also_layer_a_text: bool = True) -> tuple[bytes, l
 # PDF
 # ---------------------------------------------------------------------------
 
-_XMP_PACKET_RE = re.compile(
-    rb"<\?xpacket begin.*?<\?xpacket end[^?]*\?>",
-    re.I | re.DOTALL,
-)
+# Open/close halves for the linear XMP packet scan below. The lazy
+# ".*?</\?xpacket end..." form was quadratic on a flood of "<?xpacket begin"
+# markers with no end marker.
+_XMP_PACKET_OPEN_RE = re.compile(rb"<\?xpacket begin", re.I)
+_XMP_PACKET_CLOSE_RE = re.compile(rb"<\?xpacket end[^?]*\?>", re.I)
+_PDF_STREAM_OPEN_RE = re.compile(rb"stream\r?\n")
+_PDF_STREAM_CLOSE_RE = re.compile(rb"endstream")
 
 
 def _pdf_structured_blob(data: bytes) -> bytes:
@@ -1577,13 +1670,18 @@ def _pdf_structured_blob(data: bytes) -> bytes:
     sequence (e.g. "AIGC") can occur by chance. Scanning only dictionaries and
     XMP packets avoids treating those collisions as metadata findings.
     """
-    no_streams = re.sub(
-        rb"stream\r?\n.*?endstream",
-        b"stream endstream",
-        data,
-        flags=re.DOTALL,
+    parts = []
+    last = 0
+    for os_, _oe, _cs, ce in _iter_tag_blocks(data, _PDF_STREAM_OPEN_RE, _PDF_STREAM_CLOSE_RE):
+        parts.append(data[last:os_])
+        parts.append(b"stream endstream")
+        last = ce
+    parts.append(data[last:])
+    no_streams = b"".join(parts)
+    xmp = b"\n".join(
+        data[os_:ce]
+        for os_, _oe, _cs, ce in _iter_tag_blocks(data, _XMP_PACKET_OPEN_RE, _XMP_PACKET_CLOSE_RE)
     )
-    xmp = b"\n".join(_XMP_PACKET_RE.findall(data))
     return no_streams + b"\n" + xmp
 
 
@@ -1592,7 +1690,10 @@ def inspect_pdf(path: Path, data: bytes) -> tuple[bool, bool, list[str], dict]:
     has_c2pa, has_ai, hits = _blob_hits(_pdf_structured_blob(data))
     findings.extend(f"pdf-structured:{h}" for h in hits)
     # XMP packet scan
-    xmp_blob = b"\n".join(_XMP_PACKET_RE.findall(data))
+    xmp_blob = b"\n".join(
+        data[os_:ce]
+        for os_, _oe, _cs, ce in _iter_tag_blocks(data, _XMP_PACKET_OPEN_RE, _XMP_PACKET_CLOSE_RE)
+    )
     if xmp_blob:
         findings.append("XMP packet present")
         has_ai = has_ai or bool(
@@ -1693,13 +1794,9 @@ def clean_pdf(path: Path, dest: Path) -> tuple[list[str], dict]:
         return actions, {"mode": "exiftool", "structural_rewrite": rewritten}
 
     # Degraded: strip obvious XMP packets between <?xpacket begin and end
+    # (linear scan - the lazy .*? form is quadratic on unclosed begin markers)
     text = data
-    new, n = re.subn(
-        rb"<\?xpacket begin.*?<\?xpacket end[^?]*\?>",
-        b"",
-        text,
-        flags=re.I | re.DOTALL,
-    )
+    new, n = _drop_tag_blocks(text, _XMP_PACKET_OPEN_RE, _XMP_PACKET_CLOSE_RE)
     if n:
         actions.append(f"stripped XMP xpacket x{n} (degraded; may leave offsets broken)")
         # PDF structural risk: document degraded mode clearly

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import io
 import os
+import re
 import struct
 import sys
+import time
 import zipfile
 from pathlib import Path
 
@@ -25,10 +27,17 @@ from common import (
     safe_write_text,
 )
 from container_meta import (
+    _SVG_METADATA_CLOSE_RE,
+    _SVG_METADATA_OPEN_RE,
     MAX_ZIP_DECOMPRESSED_BYTES,
     ZipBudgetExceeded,
     _check_zip_budget,
+    _drop_tag_blocks,
+    _pdf_structured_blob,
     _read_zip_member,
+    clean_html,
+    clean_odt,
+    clean_svg,
     inspect_docx,
 )
 
@@ -230,6 +239,130 @@ def test_read_stdin_under_cap_ok(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(common, "MAX_STDIN_BYTES", 1024)
     monkeypatch.setattr(sys, "stdin", io.StringIO("hello stdin"))
     assert read_text_input(None) == "hello stdin"
+
+
+# ---------------------------------------------------------------------------
+# Quadratic-regex DoS (GHSA-7vpp-96qp-j9wh): lazy .*? block stripping
+# ---------------------------------------------------------------------------
+#
+# clean_svg / clean_odt (and the other tag-block scans below) used lazy
+# ".*?</close>" regexes. With many opening tags and no closing tag, CPython
+# rescans to end-of-input from every candidate start - quadratic, and the
+# GIL stalls the whole single-process service. The scans are now linear;
+# these tests assert both the timing fix and the preserved behavior.
+
+
+def _assert_completes_fast(fn, *args, budget_s: float = 5.0):
+    start = time.perf_counter()
+    result = fn(*args)
+    elapsed = time.perf_counter() - start
+    assert elapsed < budget_s, f"took {elapsed:.1f}s (linear scan expected < {budget_s}s)"
+    return result
+
+
+def test_clean_svg_metadata_flood_is_linear():
+    # ~256 KiB of unclosed <metadata> tags. The old lazy regex measured
+    # ~25 s at this size; the linear scan is milliseconds.
+    flood = b"<metadata>" * (256 * 1024 // 11)
+    assert b"</metadata>" not in flood
+    cleaned, actions = _assert_completes_fast(clean_svg, flood)
+    # No closing tag exists, so nothing is stripped - the block is preserved.
+    assert cleaned == flood
+    assert not any(a.startswith("drop <metadata>") for a in actions)
+
+
+def test_clean_svg_mixed_closed_and_unclosed_metadata():
+    svg = b"<svg><metadata>c2pa Anthropic</metadata><metadata>open</svg>"
+    cleaned, actions = clean_svg(svg)
+    # The closed block is stripped; the unclosed one is preserved verbatim.
+    assert b"<metadata>c2pa" not in cleaned
+    assert b"<metadata>open</svg>" in cleaned
+    assert any(a.startswith("drop <metadata>") for a in actions)
+
+
+def test_clean_odt_generator_flood_is_linear():
+    # GHSA-7vpp-96qp-j9wh PoC shape: an ODT whose meta.xml is ~512 KiB of
+    # unclosed <meta:generator> tags (about 1.4 KiB on the wire after DEFLATE).
+    payload = b"<meta:generator>" * (512 * 1024 // 16)
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("mimetype", b"application/vnd.oasis.opendocument.text")
+        zf.writestr("content.xml", b"<x/>")
+        zf.writestr("meta.xml", payload)
+    cleaned, _actions = _assert_completes_fast(clean_odt, buf.getvalue())
+    # Unclosed blocks are preserved: the payload round-trips untouched.
+    with zipfile.ZipFile(io.BytesIO(cleaned)) as zf:
+        assert zf.read("meta.xml") == payload
+
+
+def test_clean_svg_comment_end_forms():
+    # HTML comment end tags are "-->" or "--!>" (CodeQL bad-html-filtering
+    # regexp). Comments in either form must be stripped when they carry AI
+    # provenance markers and kept otherwise.
+    svg = b"<svg><!-- Anthropic --!><!-- plain --></svg>"
+    cleaned, actions = clean_svg(svg)
+    assert b"Anthropic" not in cleaned
+    assert b"plain" in cleaned
+    assert any("comment" in a for a in actions)
+
+
+def test_clean_html_jsonld_flood_is_linear():
+    flood = '<script type="application/ld+json">' * (128 * 1024 // 39)
+    assert "</script>" not in flood
+    cleaned, _actions = _assert_completes_fast(clean_html, flood)
+    assert cleaned == flood
+
+
+def test_pdf_stream_and_xpacket_floods_are_linear():
+    stream_flood = b"stream\n" * (256 * 1024 // 8)
+    assert b"endstream" not in stream_flood
+    blob = _assert_completes_fast(_pdf_structured_blob, stream_flood)
+    assert blob == stream_flood + b"\n"
+
+    xpacket_flood = b"<?xpacket begin" * (256 * 1024 // 15)
+    assert b"<?xpacket end" not in xpacket_flood
+    blob = _assert_completes_fast(_pdf_structured_blob, xpacket_flood)
+    assert blob == xpacket_flood + b"\n"
+
+
+def test_tag_block_scan_matches_lazy_regex_semantics():
+    # The linear scan must strip exactly what the old lazy regex stripped,
+    # on well- and malformed inputs alike (closed, unclosed, mixed, nested,
+    # case variants, and a closing tag smuggled inside an attribute value).
+    lazy = re.compile(r"<metadata\b[^>]*>.*?</metadata\s*>", re.I | re.DOTALL)
+    samples = [
+        "",
+        "<metadata>a</metadata>",
+        "<metadata>a</metadata><metadata>b</metadata>",
+        "<metadata>unclosed",
+        "<metadata>a</metadata><metadata>unclosed",
+        "x<metadata>a</metadata>y",
+        "<metadata foo='x'>a</metadata >",
+        "<METADATA>a</METADATA>",
+        "<metadata><metadata>nested</metadata>",
+        "<metadata>a</metadata><metadata>b</metadata><metadata>c",
+        "<metadata foo='" + "</metadata>" + "'>tail</metadata>",
+    ]
+    for sample in samples:
+        expected, n_expected = re.subn(lazy, "", sample)
+        got, n_got = _drop_tag_blocks(sample, _SVG_METADATA_OPEN_RE, _SVG_METADATA_CLOSE_RE)
+        assert got == expected, (sample, expected, got)
+        assert n_got == n_expected, (sample, n_expected, n_got)
+
+
+def test_scrub_text_runs_is_linear_on_unclosed_runs():
+    # (w:t)-style body scrubs share the same lazy pattern class; a run of
+    # unclosed <w:t> tags must not blow up either.
+    from container_meta import _scrub_docx_text
+
+    flood = "<w:t>" * (128 * 1024 // 5)
+    assert "</w:t>" not in flood
+    start = time.perf_counter()
+    out, removed, replaced = _scrub_docx_text(flood)
+    elapsed = time.perf_counter() - start
+    assert elapsed < 5.0, f"took {elapsed:.1f}s"
+    assert out == flood
+    assert removed == 0 and replaced == 0
 
 
 def test_reconfigure_stream_writes_utf8():


### PR DESCRIPTION
## Summary

Fixes the **remote unauthenticated denial of service** reported in GHSA-7vpp-96qp-j9wh (quadratic-time regex on crafted SVG/ODT metadata).

`clean_svg`/`clean_odt` stripped `<metadata>`/`<meta:generator>` blocks with lazy dot-matches-all regexes. With many opening tags and no closing tag, CPython rescans to end-of-input from every candidate start position — O(n²) — and because the regex holds the GIL, one ~1.4 KB ODT request pinned a core for ~99 s and stalled every other request on the single-process service.

Verified in code: the exact regexes from the advisory are in `container_meta.py`, `_authorized()` fails open when `WATERMARKS_SERVER_API_KEY` is unset, and the PoC path (POST /clean → clean_odt) is reachable unauthenticated by default.

## Fix

Replaced **every** lazy `.*?</close>` block scan in `service/scripts/container_meta.py` with linear-time scanning (`_iter_tag_blocks`/`_drop_tag_blocks`/`_drop_blocks_if`): opening tags are paired with closing tags via a forward pointer over a single `finditer` pass, preserving the exact match semantics of the old regexes (first close at/after each open, blocks never overlapping). Sites converted:

- `clean_svg`: `<metadata>`, `<x:xmpmeta>`, `<!--...-->` comments
- `clean_odt`: `<meta:generator>`, `<dc:creator>`
- `clean_html`/`inspect_html`: JSON-LD `<script>` blocks
- DOCX/XLSX/PPTX/ODT body text-run scrubs (`_scrub_*_text` → shared `_scrub_text_runs`)
- docProps provenance-field scrubbing
- EPUB OPF `<meta>` and backreferenced `<dc:*>` fields
- PDF XMP packet and `stream`/`endstream` scans (`_pdf_structured_blob`, `inspect_pdf`, degraded `clean_pdf`)

## Verification

- Advisory PoC end-to-end on the fixed code: **512 KiB unclosed `<meta:generator>` ODT (1.4 KB wire) — 5 ms** vs ~99 s before.
- Regression tests added in `tests/test_security_hardening.py`: floods for SVG/ODT/HTML/PDF complete in <5 s; unclosed blocks are preserved verbatim; closed blocks still stripped; a parity test proves `_drop_tag_blocks` strips exactly what the old lazy regex stripped across closed/unclosed/mixed/nested/case-variant/attr-smuggled inputs.
- Full test suite passes; `ruff check` + `ruff format` clean.

## Out of scope (noted in the advisory, not fixed here)

- ZIP entry-table amplification bypassing `_check_zip_budget` (Medium)
- Missing socket timeout / unbounded threads in the HTTP server (Medium)

