### PR TITLE
ci: add macOS to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
Add `macos-latest` to the CI test matrix so tests also run on macOS.

The existing Windows-only steps are gated with `if: matrix.os == 'windows-latest'`, so the macOS runner just installs deps and runs the test suite.