### PR TITLE
fix: report a failed c2patool probe as inconclusive, not negative

### DIFF
--- a/service/scripts/image_meta.py
+++ b/service/scripts/image_meta.py
@@ -1302,12 +1302,19 @@ def run_optional_tools(path: Path) -> dict[str, Any]:
             # missing manifest as "Error: No claim found", which contains
             # the substring "claim" and would otherwise read as a hit.
             no_manifest = "no claim" in low or "no jumbf" in low
+            # A probe that did not answer is inconclusive, not negative: a
+            # kill, OOM, arch mismatch, or timeout landing here must never be
+            # reported as "checked, nothing found" (#155). Nonzero exit means
+            # c2patool itself judged the run failed; a clean run exits 0.
+            probe_failed = r.returncode != 0
             tools["c2patool"] = {
                 "available": True,
                 "returncode": r.returncode,
                 "snippet": out[:2000],
                 "has_manifest": ("claim" in low or "c2pa" in low or "manifest" in low)
-                and not no_manifest,
+                and not no_manifest
+                and not probe_failed,
+                "probe_failed": probe_failed,
             }
         except Exception as e:
             tools["c2patool"] = {"available": True, "error": str(e)}
@@ -1669,6 +1676,13 @@ def inspect_image(
     if ct.get("has_manifest"):
         has_c2pa = True
         findings.append("c2patool reports a C2PA-related manifest")
+    if ct.get("probe_failed"):
+        notes.append(
+            "c2patool was found but failed to run (returncode "
+            f"{ct.get('returncode')}); the C2PA probe is inconclusive — "
+            "has_c2pa: false here means the probe did not answer, not that "
+            "the asset is clean (#155)"
+        )
 
     return ImageInspectReport(
         path=str(path),

--- a/tests/test_c2patool_report.py
+++ b/tests/test_c2patool_report.py
@@ -91,3 +91,35 @@ def test_missing_c2patool_is_reported_unavailable(monkeypatch, tmp_path):
     tools = image_meta.run_optional_tools(path)
 
     assert tools["c2patool"] == {"available": False}
+
+
+def test_failed_probe_is_inconclusive_not_negative(monkeypatch, tmp_path):
+    """A c2patool that crashes (kill, OOM, arch mismatch) must not report
+    has_manifest: False as if the asset were checked and clean (#155)."""
+    _fake_c2patool(monkeypatch, "rosetta error: failed to open elf\n", -5, on_stderr=True)
+    path = tmp_path / "any.jpg"
+    path.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 64)
+
+    tools = image_meta.run_optional_tools(path)
+    ct = tools["c2patool"]
+    assert ct["available"] is True
+    assert ct["probe_failed"] is True
+    assert ct["has_manifest"] is False, "a failed probe must not elevate a manifest"
+
+    # The end-to-end inspect report surfaces the inconclusive probe as a note.
+    report = image_meta.inspect_image(path)
+    assert report.has_c2pa is False
+    assert any("failed to run" in n and "inconclusive" in n for n in report.notes), report.notes
+
+
+def test_clean_run_zero_exit_still_negative_when_no_manifest(monkeypatch, tmp_path):
+    """A clean zero-exit run with the no-claim marker stays a normal negative
+    (no probe_failed, no note) — the new flag only fires on failed probes."""
+    _fake_c2patool(monkeypatch, "Error: No claim found\n", 0, on_stderr=True)
+    path = tmp_path / "clean2.png"
+    path.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    tools = image_meta.run_optional_tools(path)
+    ct = tools["c2patool"]
+    assert ct["probe_failed"] is False
+    assert ct["has_manifest"] is False


### PR DESCRIPTION
## Summary

Fixes #155.

## Root cause (as diagnosed in the issue, verified)

`run_optional_tools` decides `has_manifest` purely by substring-matching c2patool's output — the exit code is recorded and never read. Any probe that fails to run (kill, OOM, timeout, or the issue's arch-mismatch trigger: x86_64 c2patool on an arm64-resolved base dying before `main()` with `returncode -5`) lands in the same silent-negative path: `has_manifest: False`, and `/inspect` answers `has_c2pa: false` — **byte for byte the answer for a genuinely clean asset**.

## Fix — the three states are now distinguishable

1. `run_optional_tools` records **`probe_failed`** whenever the exit code is nonzero, and a failed probe can never elevate `has_manifest`.
2. `inspect_image` adds an explicit **note** when the probe failed — naming the returncode and stating that `has_c2pa: false` there means *the probe did not answer, not that the asset is clean*.

| probe outcome | has_c2pa | note |
|---|---|---|
| manifest found | `true` | finding (unchanged) |
| clean zero-exit, no claim | `false` | none (plain negative) |
| crashed / killed / nonzero exit | `false` | **"inconclusive" note with returncode** |

## Tests

- the issue's exact shape (`returncode -5`, rosetta error on stderr): `probe_failed: true`, no manifest elevation, and the end-to-end report carries the inconclusive note — **fails on current `main`**;
- a clean zero-exit no-claim run stays a plain negative with `probe_failed: false` and no note (the flag only fires on failed probes).

## Out of scope

The Dockerfile arch pin itself (no linux-aarch64 c2patool build exists upstream) is a packaging decision flagged on the issue for the maintainers.
