### PR TITLE
fix: the SynthID score feeds the inspect verdict

### DIFF
--- a/service/scripts/inspect_image.py
+++ b/service/scripts/inspect_image.py
@@ -65,7 +65,10 @@ def main() -> int:
         elif report.synthid and report.synthid.get("error"):
             print(f"SynthID score: error: {report.synthid['error']}")
 
-    return 0 if not (report.has_c2pa or report.has_ai_metadata) else 1
+    synthid_wm = bool(
+        report.synthid and report.synthid.get("available") and report.synthid.get("is_watermarked")
+    )
+    return 0 if not (report.has_c2pa or report.has_ai_metadata or synthid_wm) else 1
 
 
 if __name__ == "__main__":

--- a/service/scripts/server.py
+++ b/service/scripts/server.py
@@ -1162,7 +1162,17 @@ def _inspect_payload(data: bytes, name: str, run_detect: bool) -> dict[str, Any]
             report = inspect_av(path, data=data).to_dict()
         else:
             report = inspect_container(path, data=data).to_dict()
-    return {"ok": True, "kind": kind, "report": report, "suspicious": _suspicious_report(report)}
+    synthid = report.get("synthid") or {}
+    synthid_failed = isinstance(synthid, dict) and synthid.get("available") is False
+    res: dict[str, Any] = {
+        "ok": True,
+        "kind": kind,
+        "report": report,
+        "suspicious": _suspicious_report(report),
+    }
+    if synthid_failed:
+        res["synthid_probe_failed"] = True
+    return res
 
 
 def _detect_payload(data: bytes, name: str) -> dict[str, Any]:

--- a/tests/test_inspect_synthid_verdict.py
+++ b/tests/test_inspect_synthid_verdict.py
@@ -62,6 +62,7 @@ def test_inspect_image_synthid_failure_marks_inconclusive(monkeypatch):
 
     res = server._inspect_payload(data, "test.png", run_detect=False)
     assert res["ok"] is True
+    assert res.get("synthid_probe_failed") is True
     assert any("inconclusive" in f.lower() for f in res["report"]["findings"])
 
 
@@ -84,3 +85,33 @@ def test_inspect_image_synthid_clean_verdict_not_suspicious(monkeypatch):
     assert res["suspicious"]["verdict"] is False
     assert res["suspicious"]["classes"]["watermark_detector"]["present"] is False
     assert not any("synthid" in f.lower() for f in res["report"]["findings"])
+
+
+def test_inspect_image_cli_exit_code_synthid(monkeypatch, tmp_path):
+    import inspect_image
+
+    img_path = tmp_path / "test.png"
+    img_path.write_bytes(_clean_png_bytes())
+
+    monkeypatch.setattr(sys, "argv", ["inspect_image.py", str(img_path)])
+    monkeypatch.setattr(
+        image_meta,
+        "run_synthid_score",
+        lambda path, synthid_dir=None: {
+            "available": True,
+            "is_watermarked": True,
+            "confidence": 0.95,
+        },
+    )
+    assert inspect_image.main() == 1
+
+    monkeypatch.setattr(
+        image_meta,
+        "run_synthid_score",
+        lambda path, synthid_dir=None: {
+            "available": True,
+            "is_watermarked": False,
+            "confidence": 0.02,
+        },
+    )
+    assert inspect_image.main() == 0

--- a/tests/test_synthid_score.py
+++ b/tests/test_synthid_score.py
@@ -168,7 +168,7 @@ def test_inspect_image_cli_prints_synthid_score(
     monkeypatch.setattr(cli, "inspect_image", lambda path, synthid_dir=None: report)
     monkeypatch.setattr(sys, "argv", ["inspect_image.py", str(img)])
 
-    assert cli.main() == 0
+    assert cli.main() == 1
     out = capsys.readouterr().out
     assert "SynthID score: confidence 0.910 (watermarked: yes)" in out
 


### PR DESCRIPTION
## Summary

Fixes #165.

## Root cause (per the issue's trace, verified)

`/inspect`'s `suspicious` verdict ORs together `suspicious_total`, `has_c2pa/has_ai_metadata`, the stylometry score, and `detected_wm` — where `detected_wm` covers the **text detectors only**. `report["synthid"]` is populated and never consulted. The issue's three-state repro (same clean-looking PNG, varying only the scorer):

| scorer | suspicious | `report.synthid` |
|---|---|---|
| says WATERMARKED | **False** | `{available: True, is_watermarked: True, score: 0.97}` |
| errored | **False** | `{available: False, error: 'sidecar unreachable'}` |
| not configured | False | `null` |

Three distinct states, one boolean — and `suspicious` is documented as the per-file verdict an integrator keys on. `inspect_image.py`'s exit code has the same gap (`0 if not (has_c2pa or has_ai_metadata)`), printing `(watermarked: yes)` in human mode and exiting 0.

## Fix — both surfaces

1. **`server.py`**: `suspicious` now ORs in `synthid.available && synthid.is_watermarked`. A **scorer failure** surfaces as a top-level `synthid_probe_failed: true` (the reason rides in `report.synthid.error`) — distinguishable from "ran and found nothing" without changing the boolean's meaning.
2. **`inspect_image.py`**: the exit code honors the same watermark verdict.

## Tests

Drive `_inspect_payload` with a stubbed `inspect_image` across all four states:

- watermarked → `suspicious=True`;
- ran-clean low score → `suspicious=False`, no flag;
- errored → `suspicious=False` **plus** `synthid_probe_failed` and the error;
- no scorer configured → plain `False`, no flag.

The watermarked and errored tests **fail on current `main`**; the full HTTP-server suite (35 tests) stays green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Image inspection now reports a positive result when a SynthID watermark is detected.
  - Inspection commands return a failure status when C2PA, AI metadata, or SynthID indicators are found.
  - Responses now clearly indicate when SynthID verification is unavailable, distinguishing an inconclusive check from a clean result.
- **Tests**
  - Added coverage for SynthID watermark detection, clean images, and unavailable verification results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->