### PR TITLE
fix: the clean hook recognizes no-op actions instead of always changing

### DIFF
--- a/tests/test_precommit_hooks.py
+++ b/tests/test_precommit_hooks.py
@@ -465,3 +465,65 @@ def test_pre_commit_hooks_manifest_defines_both_hooks():
     assert "id: watermarks-remover-clean" in text
     assert text.count("entry: python3 service/scripts/") == 2
     assert text.count("language: system") == 2
+
+
+def test_changed_recognizes_noop_actions_as_unchanged():
+    """The exact no-op action strings every strip/clean emitter produces must
+    read as unchanged — before, any non-empty actions list was 'changed' and
+    the clean hook failed forever on non-text files (#173)."""
+    noop_actions = [
+        "no PNG metadata chunks removed (already clean or none matched)",
+        "no GIF metadata blocks removed (already clean or none matched)",
+        "no TIFF metadata tags removed (already clean or none matched)",
+        "no WebP metadata chunks removed (already clean or none matched)",
+        "no AVIF metadata boxes removed (already clean or none matched)",
+        "no MP4 metadata boxes removed (already clean or none matched)",
+        "no ID3v2 tag removed (no AI/C2PA markers found)",
+        "no ID3v2 frames removed (already clean or none matched)",
+        "no WAV metadata chunks removed (already clean or none matched)",
+        "no AI frontmatter keys or embedded data URIs removed",
+        "no HTML AI meta removed",
+        "no SVG metadata removed",
+        "no DOCX metadata parts removed",
+        "no ODT metadata removed",
+        "no OPF metadata removed",
+    ]
+    for action in noop_actions:
+        assert clean_staged._changed({"actions": [action]}) is False, action
+
+
+def test_changed_still_fires_on_real_actions():
+    assert clean_staged._changed({"actions": ["removed 3 tEXt chunks"]}) is True
+    assert clean_staged._changed({"actions": ["drop ID3v2.3 tag (210 bytes)"]}) is True
+    # A mix of noop + real is a change.
+    assert (
+        clean_staged._changed({"actions": ["no SVG metadata removed", "removed embedded data URI"]})
+        is True
+    )
+
+
+def test_changed_stats_path_unchanged():
+    assert clean_staged._changed({"stats": {"removed_count": 0, "replaced_count": 0}}) is False
+    assert clean_staged._changed({"stats": {"removed_count": 2, "replaced_count": 0}}) is True
+
+
+def test_clean_hook_passes_on_unchanged_png(tmp_path, monkeypatch):
+    """End to end: cleaning an already-clean PNG twice exits 0 both times."""
+    import struct
+    import zlib
+
+    def chunk(ctype, payload):
+        return (
+            struct.pack(">I", len(payload))
+            + ctype
+            + payload
+            + struct.pack(">I", zlib.crc32(ctype + payload) & 0xFFFFFFFF)
+        )
+
+    ihdr = struct.pack(">IIBBBBB", 1, 1, 8, 0, 0, 0, 0)
+    png = b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", ihdr) + chunk(b"IEND", b"")
+    f = tmp_path / "clean.png"
+    f.write_bytes(png)
+    monkeypatch.setattr(sys, "argv", ["clean_staged.py", str(f)])
+    assert clean_staged.main() == 0
+    assert f.read_bytes() == png


### PR DESCRIPTION
## Summary

Fixes #173.

## Root cause (per the issue's trace, verified)

Every `strip_*`/`clean_*` function appends a "nothing was removed" action instead of returning an empty list (16 sites across `image_meta` / `av_meta` / `container_meta`), so `actions` is never empty for any non-text file. `clean_staged._changed` decides "did this file change?" from `bool(result.get("actions"))` — only the text path carries `stats` — which is **unconditionally True**. The `watermarks-remover-clean` pre-commit hook exits 1 whenever it thinks it modified something, so for any non-text file it exits 1 on every run: the developer re-stages, the hook re-runs, still 1, forever — even on files it never modified.

## Fix — classify in `_changed`, don't touch the emitters

The actions are user-facing output (and other consumers may read them), so the fix lives in the hook-side classifier:

- the no-op phrasings the emitters produce — `no X removed …`, `(already clean or none matched)`, `no AI/C2PA markers found` — read as **unchanged**;
- a **mix** of no-op + real actions is still a change (conservative);
- the text path's `stats` decision is untouched.

Result: an already-clean PNG (or any non-text file) exits **0** on the first run and every re-run; a genuinely modified file still exits 1 so the developer reviews and re-stages.

## Tests

- all **fifteen** no-op action strings from the issue's table (GIF/TIFF/PNG/WebP/ISOBMFF boxes, MP4/ID3v2/WAV, frontmatter/HTML/SVG/DOCX/ODT/OPF) pinned as unchanged;
- real actions and the mixed no-op+real case still fire changed;
- the stats path unchanged;
- end-to-end: an already-clean PNG through `main()` exits 0 with bytes untouched.

The no-op table and the end-to-end test **fail on current `main`**; the full hook suite stays green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added coverage for distinguishing no-op cleanup results from actual file changes.
  - Added validation for cleanup statistics involving removed and replaced content.
  - Added an end-to-end check confirming clean files remain unchanged and can be processed repeatedly without errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->