### PR TITLE
fix: cleaning the same PDF twice must produce the same bytes

### DIFF
--- a/service/scripts/container_meta.py
+++ b/service/scripts/container_meta.py
@@ -1815,7 +1815,17 @@ def _pdf_structural_rewrite(dest: Path, actions: list[str]) -> bool:
     tmp = dest.with_name(dest.name + ".qpdf-tmp")
     try:
         r = subprocess.run(
-            [qpdf, "--linearize", "--", safe_arg(str(dest)), safe_arg(str(tmp))],
+            [
+                qpdf,
+                "--linearize",
+                # qpdf regenerates the second half of the PDF /ID on every
+                # write, so without this cleaning the same file twice never
+                # produces the same bytes and the clean cannot converge.
+                "--deterministic-id",
+                "--",
+                safe_arg(str(dest)),
+                safe_arg(str(tmp)),
+            ],
             capture_output=True,
             text=True,
             timeout=120,

--- a/tests/test_pdf_structural_rewrite.py
+++ b/tests/test_pdf_structural_rewrite.py
@@ -142,6 +142,45 @@ def test_qpdf_failure_keeps_exiftool_output_and_warns(monkeypatch, tmp_path: Pat
     assert not list(tmp_path.glob("*.qpdf-tmp"))
 
 
+def test_qpdf_is_asked_for_a_deterministic_id(monkeypatch, tmp_path: Path):
+    """qpdf must be told to derive the /ID, not to invent one.
+
+    Left to itself qpdf regenerates the second half of the PDF /ID on every
+    write, so two cleans of the same document never produce the same bytes.
+    """
+    src = tmp_path / "in.pdf"
+    dest = tmp_path / "out.pdf"
+    src.write_bytes(_ai_pdf())
+    seen = _fake_tools(monkeypatch, qpdf=True)
+
+    clean_pdf(src, dest)
+
+    qpdf_cmds = [cmd for cmd in seen if cmd[0].endswith("qpdf")]
+    assert qpdf_cmds, seen
+    assert "--deterministic-id" in qpdf_cmds[0], qpdf_cmds[0]
+
+
+@pytest.mark.skipif(
+    shutil.which("exiftool") is None or shutil.which("qpdf") is None,
+    reason="needs real exiftool and qpdf",
+)
+def test_end_to_end_repeat_clean_converges(tmp_path: Path):
+    """Cleaning an already-cleaned PDF must produce identical bytes.
+
+    Against the real tools this fails without --deterministic-id: the two runs
+    differ only in the second half of the /ID array, which is enough to make
+    every clean look like a modification forever.
+    """
+    src = tmp_path / "in.pdf"
+    src.write_bytes(_ai_pdf())
+    first = tmp_path / "one.pdf"
+    clean_pdf(src, first)
+    second = tmp_path / "two.pdf"
+    clean_pdf(first, second)
+
+    assert second.read_bytes() == first.read_bytes()
+
+
 @pytest.mark.skipif(
     shutil.which("exiftool") is None or shutil.which("qpdf") is None,
     reason="needs real exiftool and qpdf",


### PR DESCRIPTION
## What

Adds `--deterministic-id` to the qpdf call in `_pdf_structural_rewrite`.

## Why

qpdf regenerates the second half of the PDF `/ID` array on every write, so the structural rewrite that follows the exiftool pass never converges. Cleaning an already-cleaned PDF produces a byte-different file, indefinitely:

```
--linearize                      run1=50a207f984 run2=57a4e98a36  converges=False
--linearize --deterministic-id   run1=703dd13666 run2=703dd13666  converges=True
```

The two outputs differ only inside `/ID [<permanent><changed>]` — same length, same objects, a fresh random changed-ID each run:

```
run1: /ID [<da24c9c4caf56e2b618570f0aef3eb14><da24c9c4caf56e2b618570f0aef3eb14>]
run2: /ID [<da24c9c4caf56e2b618570f0aef3eb14><a8ab56cb80fc489fad6332f9d1279fb7>]
```

Two consequences. Every commit that touches a PDF rewrites it, so `watermarks-remover-clean` dirties PDFs endlessly and the diff is noise. And "did this file change?" becomes unanswerable for PDFs however the answer is computed — which is why I ran into it from the #173 direction, though it is a separate defect and this PR does not touch #173.

`--deterministic-id` derives the ID from the document content instead. That suits this pipeline: the rewrite exists to drop objects exiftool only unlinked, not to make each run unique. The permanent half of the ID is unchanged either way.

I did not find a case where the random changed-ID is load-bearing here — nothing in the repo reads `/ID`, and the file is being rewritten specifically to discard provenance. Worth a second opinion if you disagree, since it does change output bytes for everyone.

## Checklist

- [x] Behaviour matches `SKILL.md` / `references/removal-matrix.md` when relevant
- [x] Unit tests updated or added under `tests/`
- [x] `python3 -m pytest -q` passes
- [x] Docs updated if user-facing behaviour changes — none describe the /ID
- [x] No drive-by refactors unrelated to the fix or feature

## Notes for the reviewer

Layer: Files (C2PA/metadata), PDF path only. One flag, two tests, no other changes.

Both tests live in the existing `tests/test_pdf_structural_rewrite.py` and reuse its `_fake_tools` helper. **Both fail without the flag** — I checked by reverting it and re-running:

- `test_qpdf_is_asked_for_a_deterministic_id` asserts the flag reaches qpdf's argv. Mocked, so it runs everywhere including CI, which installs neither exiftool nor qpdf.
- `test_end_to_end_repeat_clean_converges` cleans twice against the real binaries and asserts the bytes match. It carries the same `skipif` as `test_end_to_end_no_recoverable_metadata_bytes`, so **it will skip in CI** — the mocked one is what CI actually proves.

Verified in `python:3.12-slim` both ways: without the tools (CI's environment) the suite passes with 2 skips, `ruff check` and `ruff format --check` clean; with exiftool 13.25 and qpdf 12.2.0 installed, all 7 tests in that file pass.
