### PR TITLE
feat: multi-scheme MarkLLM text benchmark and detection

### DIFF
--- a/service/scripts/bench_synthid_text.py
+++ b/service/scripts/bench_synthid_text.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-"""Benchmark for SynthID-text watermark removal (Layer B rewrite).
+"""Benchmark for MarkLLM text-watermark removal (Layer B rewrite).
 
 Orchestrates the repo's existing machinery into a reproducible, shareable
 benchmark:
 
-  1. Generate a watermarked + unwatermarked corpus with the MarkLLM SynthID
-     scheme (same-config generation and detection).
+  1. Generate a watermarked + unwatermarked corpus with a chosen MarkLLM
+     scheme (same-config generation and detection; --scheme/--config).
   2. Run removal variants (Layer A only, Layer B rewrites at chosen
      strength x max-attempt counts; the rewrite loop stops early when an
      attempt passes evaluation) and control rows (no removal, optional
@@ -17,7 +17,7 @@ benchmark:
        - cost (estimated tokens, wall time, optional USD at given prices)
   4. Emit results.json / results.csv / report.md for sharing.
 
-Detection: same-config-only MarkLLM research detection (reproducible,
+Detection: same-config-only MarkLLM detection (reproducible,
 no vendor APIs). Google retired SynthID text watermarking on its API in
 Aug 2026, so no vendor tier exists.
 
@@ -49,6 +49,7 @@ SCRIPTS_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPTS_DIR))
 
 from common import eprint  # noqa: E402
+from detect_text_watermark import SCHEMES  # noqa: E402  (single source of scheme names)
 from rewrite_text import _lexical_divergence  # noqa: E402
 from text_unicode import clean_text  # noqa: E402
 
@@ -60,7 +61,10 @@ except IndexError:
     # callers pass --corpus explicitly.
     DEFAULT_CORPUS = _RESOLVED_SCRIPT.parent / "benchmarks" / "corpus"
 DEFAULT_MARKLLM_MODEL = "facebook/opt-1.3b"
-SCHEME = "synthid"
+# Default scheme for the benchmark. Overridable with --scheme (any key of
+# detect_text_watermark.SCHEMES); --config overrides the scheme's config JSON
+# (default: <MarkLLM checkout>/config/<ALG>.json).
+DEFAULT_SCHEME = "synthid"
 LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
 
 # MarkLLM generation/detection can take minutes on CPU (model load per call).
@@ -193,6 +197,9 @@ def run_watermark(
     out_dir: Path,
     model: str,
     timeout: float,
+    *,
+    scheme: str,
+    config: str | None,
 ) -> dict[str, Any]:
     """Generate one watermarked (+ unwatermarked) sample via MarkLLM."""
     wm_path = out_dir / f"wm_seed{seed}.txt"
@@ -203,7 +210,7 @@ def run_watermark(
         "watermark",
         str(prompt_path),
         "--scheme",
-        SCHEME,
+        scheme,
         "--seed",
         str(seed),
         "--max-new-tokens",
@@ -218,6 +225,8 @@ def run_watermark(
         str(plain_path),
         "--json",
     ]
+    if config:
+        cmd += ["--config", config]
     try:
         proc = _run_cmd(cmd, timeout=timeout)
     except subprocess.TimeoutExpired:
@@ -256,6 +265,9 @@ def run_detect(
     text: str,
     model: str,
     timeout: float,
+    *,
+    scheme: str,
+    config: str | None,
 ) -> dict[str, Any]:
     """Same-config MarkLLM detection of *text*; fail-soft payload."""
     import tempfile
@@ -270,13 +282,15 @@ def run_detect(
             "detect",
             tmp,
             "--scheme",
-            SCHEME,
+            scheme,
             "--model",
             model,
             "--upstream-dir",
             str(upstream),
             "--json",
         ]
+        if config:
+            cmd += ["--config", config]
         try:
             proc = _run_cmd(cmd, timeout=timeout)
         except subprocess.TimeoutExpired:
@@ -316,6 +330,7 @@ def run_rewrite(
     api_key: str | None,
     markllm_model: str,
     markllm_timeout: float,
+    markllm_scheme: str,
 ) -> tuple[str, dict[str, Any]]:
     """Run the Layer B rewrite on *text* via rewrite_text.py (real product path).
 
@@ -356,7 +371,7 @@ def run_rewrite(
         "--timeout",
         str(timeout),
         "--markllm-scheme",
-        SCHEME,
+        markllm_scheme,
         "--markllm-dir",
         str(upstream),
         "--markllm-model",
@@ -467,6 +482,9 @@ class MarkLLMWorker:
         upstream: Path,
         model: str,
         timeout: float,
+        *,
+        scheme: str,
+        config: str | None,
     ) -> None:
         self._timeout = timeout
         cmd = [
@@ -474,7 +492,7 @@ class MarkLLMWorker:
             str(script),
             "serve",
             "--scheme",
-            SCHEME,
+            scheme,
             "--model",
             model,
             "--upstream-dir",
@@ -482,6 +500,8 @@ class MarkLLMWorker:
             "--port",
             "0",
         ]
+        if config:
+            cmd += ["--config", config]
         self._proc = subprocess.Popen(
             cmd,
             stdin=subprocess.PIPE,
@@ -501,7 +521,7 @@ class MarkLLMWorker:
         self.info = ready
         # Loopback port for OTHER processes (e.g. the rewrite subprocess's
         # MarkLLM detector) to reuse this resident model. The benchmark's own
-        # calls go over stdin; the port is published so children can too.
+        # calls go over stdin; the port is exposed so children can too.
         self.port = ready.get("port")
         if self.port is not None:
             os.environ["WATERMARKS_MARKLLM_PORT"] = str(self.port)
@@ -602,6 +622,8 @@ class Benchmark:
         self.variants = parse_variants(args.variants)
         self.corpus = load_corpus(args.corpus, args.docs)
         self.chars_per_token = args.chars_per_token
+        self.scheme = args.scheme
+        self.config = args.config
         self.worker = None
         if not args.no_worker:
             try:
@@ -611,6 +633,8 @@ class Benchmark:
                     self.upstream,
                     args.markllm_model,
                     args.markllm_timeout,
+                    scheme=self.scheme,
+                    config=self.config,
                 )
                 eprint(f"markllm worker: resident on {self.worker.info.get('device', '?')}")
             except Exception as e:
@@ -645,6 +669,8 @@ class Benchmark:
             out_dir,
             self.args.markllm_model,
             WATERMARK_TIMEOUT,
+            scheme=self.scheme,
+            config=self.config,
         )
 
     def detect(self, text: str) -> dict[str, Any]:
@@ -655,7 +681,14 @@ class Benchmark:
                 eprint(f"markllm worker failed ({e}); falling back to one-shot")
                 self._drop_worker()
         return run_detect(
-            self.python, self.script, self.upstream, text, self.args.markllm_model, DETECT_TIMEOUT
+            self.python,
+            self.script,
+            self.upstream,
+            text,
+            self.args.markllm_model,
+            DETECT_TIMEOUT,
+            scheme=self.scheme,
+            config=self.config,
         )
 
     def rewrite(
@@ -679,6 +712,7 @@ class Benchmark:
             api_key=a.rewrite_api_key,
             markllm_model=a.markllm_model,
             markllm_timeout=a.markllm_timeout,
+            markllm_scheme=self.scheme,
         )
 
     # -- phases ------------------------------------------------------------
@@ -1039,7 +1073,7 @@ def render_markdown(
     L.append("")
     L.append(
         "Watermarked and unwatermarked samples are generated with the MarkLLM "
-        f"{SCHEME} scheme (same config for generation and detection). "
+        f"{config['scheme']} scheme (same config for generation and detection). "
         "Each sample must pass a sanity gate (watermarked detected, non-empty) before it "
         "counts. Rows: control (no removal), layer-a (Unicode scrub only), "
         "rewrite-<strength>:<candidates> (Layer B rewrite), optional restamp-* "
@@ -1047,7 +1081,7 @@ def render_markdown(
     )
     L.append("")
     L.append(
-        "**Caveats:** MarkLLM's SynthID is a research reimplementation under a "
+        "**Caveats:** MarkLLM's SynthID is an independent reimplementation under a "
         "config the benchmark controls — detection is only valid against the same "
         "config+keys, and it is **not** Google's production SynthID-Text keying. "
         "(Google retired text watermarking on its API in Aug 2026, so no vendor "
@@ -1116,6 +1150,17 @@ def build_parser() -> argparse.ArgumentParser:
         "--corpus", type=Path, default=DEFAULT_CORPUS, help="Dir of .txt seeds or a single file"
     )
     p.add_argument("--docs", type=int, default=3, help="Max seed documents to use (default: 3)")
+    p.add_argument(
+        "--scheme",
+        default=DEFAULT_SCHEME,
+        choices=sorted(SCHEMES),
+        help="MarkLLM watermark scheme (default: synthid); any key of the detector's scheme map",
+    )
+    p.add_argument(
+        "--config",
+        default=None,
+        help="Algorithm config JSON (default: <MarkLLM checkout>/config/<ALG>.json)",
+    )
     p.add_argument("--seeds", type=int, default=1, help="Watermark seeds per doc (default: 1)")
     p.add_argument("--seed-base", type=int, default=1, help="First seed value (default: 1)")
     p.add_argument(
@@ -1223,6 +1268,8 @@ def main() -> int:
         "markllm_commit": _markllm_commit(upstream),
         "markllm_dir": str(upstream),
         "markllm_model": args.markllm_model,
+        "scheme": args.scheme,
+        "config": str(args.config) if args.config else None,
         "variants": [f"{s}:{c}" for s, c in bench.variants],
         "corpus": str(args.corpus),
         "docs": args.docs,
@@ -1242,6 +1289,8 @@ def main() -> int:
             [
                 "python3 service/scripts/bench_synthid_text.py",
                 f"--markllm-dir {args.markllm_dir}",
+                f"--scheme {args.scheme}",
+                *([f"--config {args.config}"] if args.config else []),
                 f"--corpus {args.corpus}",
                 f"--docs {args.docs} --seeds {args.seeds} --seed-base {args.seed_base}",
                 f"--max-new-tokens {args.max_new_tokens}",

--- a/service/scripts/detect_text_watermark.py
+++ b/service/scripts/detect_text_watermark.py
@@ -5,8 +5,8 @@ This script does NOT vendor upstream code. It imports ``AutoWatermark`` from a
 user-provided checkout (https://github.com/THU-BPM/MarkLLM) at runtime, using
 that environment's optional dependencies (torch, transformers, datasets, ...).
 
-MarkLLM is Apache-2.0. It is a research/verification harness: detection is only
-valid against the SAME scheme config + keys used at generation. It cannot
+MarkLLM is Apache-2.0. It is an independent verification harness: detection is
+only valid against the SAME scheme config + keys used at generation. It cannot
 certify that a vendor detector will fail on the given text.
 
 Subcommands:
@@ -39,10 +39,15 @@ sys.path.insert(0, str(SCRIPTS_DIR))
 from common import emit_json, eprint, read_text_input, safe_write_text  # noqa: E402
 
 # Scheme name as the user types it -> MarkLLM algorithm name (config/{ALG}.json).
+# All schemes ship configs in the MarkLLM checkout; SIR additionally needs
+# its transform/embedding models downloaded per the MarkLLM README.
 SCHEMES = {
     "kgw": "KGW",
     "synthid": "SynthID",
     "synthid-text": "SynthID",
+    "exp": "EXP",
+    "unigram": "Unigram",
+    "sir": "SIR",
 }
 
 DEFAULT_MODEL = "facebook/opt-1.3b"
@@ -84,9 +89,25 @@ def resolve_device(raw: str | None) -> str:
 
 
 def _load_algorithm(
-    upstream: Path, alg: str, config: Path, model: str, device: str, offline: bool = False
+    upstream: Path,
+    alg: str,
+    config: Path,
+    model: str,
+    device: str,
+    offline: bool = False,
+    temperature: float | None = None,
+    top_p: float | None = None,
 ):
-    """Import the checkout and build an ``AutoWatermark`` instance."""
+    """Import the checkout and build an ``AutoWatermark`` instance.
+
+    ``temperature``/``top_p`` (when not None) are folded into the generation
+    kwargs so callers can control sampling.
+    """
+    gen_kwargs_extra: dict[str, float] = {}
+    if temperature is not None:
+        gen_kwargs_extra["temperature"] = temperature
+    if top_p is not None:
+        gen_kwargs_extra["top_p"] = top_p
     sys.path.insert(0, str(upstream))
     try:
         from transformers import AutoModelForCausalLM, AutoTokenizer
@@ -114,6 +135,7 @@ def _load_algorithm(
         min_length=0,
         do_sample=True,
         no_repeat_ngram_size=4,
+        **gen_kwargs_extra,
     )
     return AutoWatermark.load(
         alg,
@@ -194,7 +216,16 @@ def _cmd_detect(args: argparse.Namespace, upstream: Path, alg: str) -> int:
     try:
         config = _resolve_config(upstream, alg, args.config)
         threshold = _threshold_from_config(config)
-        wm = _load_algorithm(upstream, alg, config, args.model, device, offline=args.offline)
+        wm = _load_algorithm(
+            upstream,
+            alg,
+            config,
+            args.model,
+            device,
+            offline=args.offline,
+            temperature=args.temperature,
+            top_p=args.top_p,
+        )
         det = _detect_payload(wm, text, threshold)
     except _Unavailable as e:
         eprint(str(e))
@@ -236,7 +267,16 @@ def _cmd_watermark(args: argparse.Namespace, upstream: Path, alg: str) -> int:
 
     try:
         config = _resolve_config(upstream, alg, args.config)
-        wm = _load_algorithm(upstream, alg, config, args.model, device, offline=args.offline)
+        wm = _load_algorithm(
+            upstream,
+            alg,
+            config,
+            args.model,
+            device,
+            offline=args.offline,
+            temperature=args.temperature,
+            top_p=args.top_p,
+        )
         watermarked, unwatermarked = _generate(
             wm,
             prompt,
@@ -264,6 +304,8 @@ def _cmd_watermark(args: argparse.Namespace, upstream: Path, alg: str) -> int:
         "config": str(config),
         "model": args.model,
         "device": device,
+        "temperature": args.temperature,
+        "top_p": args.top_p,
         "watermarked_output": wm_out,
         "unwatermarked_output": args.unwatermarked_output,
         "watermarked_chars": len(watermarked),
@@ -291,6 +333,11 @@ def _handle_serve_request(wm: Any, req: dict[str, Any], threshold: float | None)
             prompt = req.get("prompt")
             if not isinstance(prompt, str) or not prompt:
                 raise ValueError("'prompt' must be a non-empty string")
+            # Per-request generation knobs.
+            for key in ("temperature", "top_p"):
+                value = req.get(key)
+                if isinstance(value, (int, float)):
+                    wm.config.gen_kwargs[key] = float(value)
             watermarked, unwatermarked = _generate(
                 wm,
                 prompt,
@@ -326,9 +373,13 @@ def _cmd_serve(args: argparse.Namespace, upstream: Path, alg: str) -> int:
     torch + model load cost per call. Protocol:
 
       request:  {"op": "watermark", "id": N, "prompt": str, "seed": int|None,
-                 "max_new_tokens": int, "min_length": int}
+                 "max_new_tokens": int, "min_length": int,
+                 "temperature": float|None, "top_p": float|None}
                 {"op": "detect", "id": N, "text": str}
                 {"op": "exit", "id": N}
+
+    Per-request "temperature"/"top_p" override the worker's generation kwargs;
+    omitted keys keep the current value.
       response: {"ok": true, "id": N, ...} | {"ok": false, "id": N, "error": str}
 
     The first stdout line is a {"ready": true, ...} handshake emitted after
@@ -338,7 +389,16 @@ def _cmd_serve(args: argparse.Namespace, upstream: Path, alg: str) -> int:
     try:
         config = _resolve_config(upstream, alg, args.config)
         threshold = _threshold_from_config(config)
-        wm = _load_algorithm(upstream, alg, config, args.model, device, offline=args.offline)
+        wm = _load_algorithm(
+            upstream,
+            alg,
+            config,
+            args.model,
+            device,
+            offline=args.offline,
+            temperature=args.temperature,
+            top_p=args.top_p,
+        )
     except _Unavailable as e:
         eprint(str(e))
         return 3
@@ -349,7 +409,14 @@ def _cmd_serve(args: argparse.Namespace, upstream: Path, alg: str) -> int:
     def respond(payload: dict[str, Any]) -> None:
         print(json.dumps(payload), flush=True)
 
-    ready: dict[str, Any] = {"ready": True, "scheme": alg, "model": args.model, "device": device}
+    ready: dict[str, Any] = {
+        "ready": True,
+        "scheme": alg,
+        "model": args.model,
+        "device": device,
+        "temperature": args.temperature,
+        "top_p": args.top_p,
+    }
     lock = threading.Lock()
     server: socketserver.ThreadingTCPServer | None = None
     if args.port >= 0:
@@ -440,6 +507,18 @@ def _add_common(p: argparse.ArgumentParser) -> None:
         "--config",
         default=None,
         help="Algorithm config JSON (default: <checkout>/config/<ALG>.json)",
+    )
+    p.add_argument(
+        "--temperature",
+        type=float,
+        default=None,
+        help="Generation temperature (default: unset -> MarkLLM/HF default)",
+    )
+    p.add_argument(
+        "--top-p",
+        type=float,
+        default=None,
+        help="Generation nucleus-sampling top-p (default: unset -> MarkLLM/HF default)",
     )
     p.add_argument(
         "--model",

--- a/service/scripts/rewrite_text.py
+++ b/service/scripts/rewrite_text.py
@@ -599,12 +599,13 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--json-stats", action="store_true", help="Stats JSON on stderr")
     p.add_argument(
         "--markllm-scheme",
-        choices=("kgw", "synthid", "synthid-text"),
+        # Keep in sync with detect_text_watermark.SCHEMES.
+        choices=("kgw", "synthid", "synthid-text", "exp", "unigram", "sir"),
         default=None,
         help="Run MarkLLM before/after detection around the rewrite AND drive "
         "the iterative rewrite loop with it (the evaluator, when configured; "
         "otherwise lexical divergence selects the best variant). "
-        "Scheme = kgw or synthid.",
+        "Scheme = any key of detect_text_watermark.SCHEMES.",
     )
     p.add_argument(
         "--markllm-dir",

--- a/tests/test_bench_synthid_text.py
+++ b/tests/test_bench_synthid_text.py
@@ -58,6 +58,8 @@ def _args(**overrides):
         cost_per_mtok_in=0.0,
         cost_per_mtok_out=0.0,
         no_worker=True,
+        scheme="synthid",
+        config=None,
     )
     values.update(overrides)
     return argparse.Namespace(**values)
@@ -515,8 +517,8 @@ def test_worker_publishes_port_env(tmp_path, monkeypatch):
     """A live worker publishes WATERMARKS_MARKLLM_PORT for child processes."""
 
     class _PortWorker(_FakeWorker):
-        def __init__(self, python, script, upstream, model, timeout):
-            super().__init__(python, script, upstream, model, timeout)
+        def __init__(self, python, script, upstream, model, timeout, **kwargs):
+            super().__init__(python, script, upstream, model, timeout, **kwargs)
             self.port = 12345
             os.environ["WATERMARKS_MARKLLM_PORT"] = str(self.port)
 
@@ -566,7 +568,7 @@ def test_aggregate_tolerates_list_in_notes():
 class _FakeWorker:
     info: dict = {"device": "cuda"}  # noqa: RUF012 - test double
 
-    def __init__(self, python, script, upstream, model, timeout):
+    def __init__(self, python, script, upstream, model, timeout, *, scheme="synthid", config=None):
         pass
 
     def watermark(self, prompt, seed, max_new_tokens):
@@ -611,7 +613,7 @@ def test_worker_fallback_on_start_failure(tmp_path, monkeypatch):
     monkeypatch.setattr(bench, "MarkLLMWorker", _Boom)
     calls = []
 
-    def fake_detect(py, script, upstream, text, model, timeout):
+    def fake_detect(py, script, upstream, text, model, timeout, *, scheme="synthid", config=None):
         calls.append(text)
         return dict(DETECT_NEG)
 

--- a/tests/test_markllm_schemes.py
+++ b/tests/test_markllm_schemes.py
@@ -1,0 +1,62 @@
+"""Multi-scheme support in the MarkLLM text harness.
+
+CI-covered assertions that the extended scheme surface remains backward
+compatible: new scheme keys are additive, the bench's default is still
+synthid, and the rewrite loop accepts the new schemes.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "service" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from detect_text_watermark import SCHEMES
+
+
+def test_scheme_map_covers_all_schemes() -> None:
+    assert SCHEMES["kgw"] == "KGW"
+    assert SCHEMES["synthid"] == "SynthID"
+    assert SCHEMES["synthid-text"] == "SynthID"
+    # Additional schemes: EXP (Gumbel), Unigram, SIR.
+    assert SCHEMES["exp"] == "EXP"
+    assert SCHEMES["unigram"] == "Unigram"
+    assert SCHEMES["sir"] == "SIR"
+
+
+def test_scheme_map_is_additive_over_legacy_keys() -> None:
+    # The legacy surface must remain exactly as shipped (backward compat).
+    legacy = {"kgw": "KGW", "synthid": "SynthID", "synthid-text": "SynthID"}
+    for key, alg in legacy.items():
+        assert SCHEMES[key] == alg
+
+
+def test_bench_scheme_flag_defaults_to_synthid() -> None:
+    from bench_synthid_text import build_parser
+
+    parser = build_parser()
+    args = parser.parse_args(["--markllm-dir", ".", "--rewrite-model", "m"])
+    assert args.scheme == "synthid"
+    assert args.config is None
+    scheme_actions = [a for a in parser._actions if a.dest == "scheme" and a.choices]
+    assert scheme_actions, "no --scheme action with choices"
+    assert set(scheme_actions[0].choices) >= {"kgw", "synthid", "exp", "unigram", "sir"}
+
+
+def test_rewrite_accepts_new_schemes() -> None:
+    """--markllm-scheme must accept exp/unigram/sir for the adaptive loop."""
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPTS / "rewrite_text.py"), "--help"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    help_text = proc.stdout + proc.stderr
+    assert "--markllm-scheme" in help_text
+    for scheme in ("exp", "unigram", "sir"):
+        assert scheme in help_text


### PR DESCRIPTION
## Goal

Make the MarkLLM text-watermark benchmark and its detector scheme-generic: benchmark watermark removal across every supported watermarking scheme — KGW, SynthID-Text, EXP, Unigram, SIR — with a chosen config applied identically to generation and detection, so results are comparable across schemes. The benchmark should gain this capability without changing any existing invocation.

## Changes

- service/scripts/bench_synthid_text.py: new --scheme and --config flags to run any MarkLLM scheme; default stays synthid, so current usage, Docker images, and smoke targets are unaffected. The scheme/config now flow through the serve worker, one-shot generation, detection, and the Layer B rewrite loop.
- service/scripts/detect_text_watermark.py: scheme map extended with exp, unigram, sir (alongside the existing kgw, synthid, synthid-text); new optional --temperature/--top-p generation knobs, including per-request overrides in the JSON-lines serve worker.
- service/scripts/rewrite_text.py: --markllm-scheme now accepts exp/unigram/sir so the adaptive, detection-guided rewrite loop works for every scheme.
- tests/test_markllm_schemes.py (new): CI coverage that the scheme surface is additive and backward compatible.
- tests/test_bench_synthid_text.py: fixture updated for the new constructor arguments.

## Verification

- Full test suite passes (529 tests); ruff lint and format clean.
- Same-config guarantee preserved: the same --scheme + --config pair is used for generation and detection.
