### PR TITLE
feat(app): native macOS front end over the HTTP service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,29 @@ jobs:
         run: python -m pip install -r requirements-dev.txt
 
       - name: Lint
-        run: python -m ruff check service tests
+        run: python -m ruff check service tests app/macos/Scripts
 
       - name: Format check
-        run: python -m ruff format --check service tests
+        run: python -m ruff format --check service tests app/macos/Scripts
+
+  macos-app:
+    name: Build the macOS app
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Swift version
+        run: swift --version
+
+      - name: Build the app bundle
+        run: ./app/macos/Scripts/build-app.sh
+
+      - name: Check the bundle layout
+        run: |
+          app="app/macos/build/Watermarks Remover.app"
+          test -x "$app/Contents/MacOS/WatermarksRemover"
+          test -f "$app/Contents/Info.plist"
+          test -f "$app/Contents/Resources/AppIcon.icns"
+          test -f "$app/Contents/Resources/service/scripts/server.py"
+          # The bundled service must run under the OS Python the app will find.
+          python3 "$app/Contents/Resources/service/scripts/server.py" --version

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 # Local test artifacts, secrets (.env), and tooling stay out without a rule
 # for each one. Tracked files are unaffected.
 /*
+!/app/
+!/app/**
 !/.github/
 !/.github/**
 !/benchmarks/
@@ -32,6 +34,8 @@
 
 # Exceptions even inside allowed trees
 .env
+/app/macos/.build/
+/app/macos/build/
 **/__pycache__/
 *.pyc
 .venv/

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 	smoke-markdiffusion bootstrap-markdiffusion docker-markdiffusion-build docker-markdiffusion-help \
 	bench-synthid-text \
 	docker-core-build docker-core-help serve compose-up compose-up-heavy compose-check \
-	install-skill install-cursor-text-skill clean
+	install-skill install-cursor-text-skill mac-app mac-app-run mac-app-icon clean
 
 SCRIPTS := service/scripts
 PYTHON ?= $(shell if [ -x .venv/bin/python ]; then echo .venv/bin/python; else echo python3; fi)
@@ -13,13 +13,13 @@ test:
 	$(PYTHON) -m pytest
 
 lint:
-	$(PYTHON) -m ruff check service tests
+	$(PYTHON) -m ruff check service tests app/macos/Scripts
 
 format:
-	$(PYTHON) -m ruff format --check service tests
+	$(PYTHON) -m ruff format --check service tests app/macos/Scripts
 
 lint-fix:
-	$(PYTHON) -m ruff check --fix service tests
+	$(PYTHON) -m ruff check --fix service tests app/macos/Scripts
 
 smoke:
 	-python3 $(SCRIPTS)/inspect_text.py tests/fixtures/sample_watermarked.txt
@@ -128,6 +128,16 @@ install-skill:
 install-cursor-text-skill:
 	$(PYTHON) install_skill.py
 
+# macOS app (SwiftUI front end over the same HTTP service). macOS + Swift only.
+mac-app:
+	./app/macos/Scripts/build-app.sh
+
+mac-app-run: mac-app
+	open "app/macos/build/Watermarks Remover.app"
+
+mac-app-icon:
+	$(PYTHON) app/macos/Scripts/make_icon.py --out app/macos/build/AppIcon.iconset
+
 clean:
 	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
-	rm -rf .pytest_cache .venv
+	rm -rf .pytest_cache .venv app/macos/.build app/macos/build

--- a/README.md
+++ b/README.md
@@ -101,6 +101,26 @@ Optional system tools (auto-used when present — preinstalled in the core Docke
 
 Core scripts need **Python 3.10+** stdlib only. Layer B model calls are optional.
 
+## macOS app
+
+A native SwiftUI front end lives in [`app/macos/`](app/macos/). It is a thin
+client like the skill: it starts `service/scripts/server.py` on a private
+loopback port with a per-launch bearer token and drives the documented HTTP API,
+so it inherits every format and every fix from the pipeline below.
+
+```bash
+make mac-app        # -> app/macos/build/Watermarks Remover.app
+make mac-app-run    # build and launch
+```
+
+Requires macOS 13+, Swift 5.9+ (Xcode or the Command Line Tools) and a Python
+3.10+ interpreter. Drag files or folders in for a per-file verdict (hidden
+characters with codepoints and confidence, metadata findings, C2PA flags,
+stylometry, detector results), clean them next to the original / into a folder /
+in place, and export the whole run as JSON. A text scratchpad inspects and
+cleans pasted drafts in memory. Detector toggles that call vendor APIs are off
+by default. Details in [`app/macos/README.md`](app/macos/README.md).
+
 ## Quick use (scripts)
 
 ```bash

--- a/app/macos/Info.plist
+++ b/app/macos/Info.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>Watermarks Remover</string>
+	<key>CFBundleDisplayName</key>
+	<string>Watermarks Remover</string>
+	<key>CFBundleExecutable</key>
+	<string>WatermarksRemover</string>
+	<key>CFBundleIdentifier</key>
+	<string>io.github.guillaumemeyer.watermarks-remover</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.5.0</string>
+	<key>CFBundleVersion</key>
+	<string>0.5.0</string>
+	<key>CFBundleIconFile</key>
+	<string>AppIcon</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>13.0</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.utilities</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>MIT licensed. Use on content you own.</string>
+	<key>NSSupportsAutomaticTermination</key>
+	<false/>
+	<key>NSSupportsSuddenTermination</key>
+	<false/>
+</dict>
+</plist>

--- a/app/macos/Package.swift
+++ b/app/macos/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "WatermarksRemover",
+    platforms: [.macOS(.v13)],
+    targets: [
+        .executableTarget(
+            name: "WatermarksRemover",
+            path: "Sources/WatermarksRemover"
+        )
+    ]
+)

--- a/app/macos/README.md
+++ b/app/macos/README.md
@@ -1,0 +1,95 @@
+# Watermarks Remover for macOS
+
+A native SwiftUI front end for the tools in this repo: drop files in, see what
+AI provenance marks they carry, strip them, keep the report.
+
+The app is a **thin client**, exactly like the agent skill. It does not
+re-implement any cleaning logic: it starts `service/scripts/server.py` on a
+private loopback port and speaks the documented HTTP API to it. Whatever the
+Python pipeline supports, the app supports — the day a new format lands in
+`format_dispatch.py`, the app routes it too.
+
+```
+┌──────────────────────┐   HTTP (127.0.0.1, bearer token)   ┌───────────────────┐
+│ Watermarks Remover   │ ─────────────────────────────────► │ server.py         │
+│ SwiftUI · macOS 13+  │ ◄───────────────────────────────── │ stdlib Python     │
+└──────────────────────┘   /inspect /clean /detect          └───────────────────┘
+```
+
+## Build
+
+```bash
+make mac-app          # -> app/macos/build/Watermarks Remover.app
+make mac-app-run      # build and launch
+```
+
+Requirements: macOS 13 Ventura or newer, Swift 5.9+ (Xcode 15 or the Command
+Line Tools), and a Python 3.10+ interpreter on the machine that runs the app.
+
+The build script compiles the SwiftPM executable, wraps it in an app bundle,
+copies `service/scripts/*.py` into `Contents/Resources`, renders the icon
+(`Scripts/make_icon.py`, stdlib-only) and ad-hoc signs the result.
+
+## What it does
+
+| Panel | What it gives you |
+| --- | --- |
+| **File queue** | Drag in files or folders. Each row shows the routed kind, a status dot, and a one-line verdict. |
+| **Inspection** | Layer A hidden-character hits with codepoints and confidence, metadata findings, C2PA / AI-metadata flags, stylometry gauge, detector results, and the raw JSON. |
+| **Clean** | Removed/replaced counts, per-action list, residue warnings, and a reveal button for the output. |
+| **Text scratchpad** | Paste a draft, inspect or clean it in memory, copy the result back. Nothing touches disk. |
+| **Capabilities** | Which of `c2patool`, `exiftool`, `qpdf`, pixel backends and text detectors the service actually found. |
+
+Cleaned files are written next to the original as `name.cleaned.ext` by
+default; a chosen output folder and in-place replacement (with a confirmation
+step) are the other two modes.
+
+## How the service is started
+
+- Port: the kernel hands out a free loopback port per launch.
+- Auth: a random bearer token per launch, passed through
+  `WATERMARKS_SERVER_API_KEY` in the child environment — never through `argv`,
+  so it does not show up in `ps`.
+- `PATH`: extended with `/opt/homebrew/bin` and `/usr/local/bin`, because a GUI
+  app inherits a bare `PATH` and would otherwise report Homebrew's `exiftool`
+  and `qpdf` as missing.
+- Shutdown: the child is terminated when the app quits (`ProcessRegistry`), so
+  no interpreter is left listening.
+- Settings → Service can point the app at a service you already run instead
+  (Docker, a remote box) with its own URL and API key.
+
+Nothing leaves the machine unless you explicitly turn on a detector that calls
+a vendor API — those toggles are off by default and labelled.
+
+## Layout
+
+```
+app/macos/
+├── Package.swift                  SwiftPM executable, macOS 13+
+├── Info.plist                     bundle metadata
+├── Scripts/build-app.sh           compile + assemble + icon + ad-hoc sign
+├── Scripts/make_icon.py           icon renderer (stdlib PNG writer)
+└── Sources/WatermarksRemover/
+    ├── WatermarksRemoverApp.swift entry point, menus, settings scene
+    ├── AppModel.swift             queue, actions, output paths, report export
+    ├── Model/                     JSON view, report summaries, options, prefs
+    ├── Service/                   interpreter discovery, process lifecycle, client
+    └── Views/                     sidebar, detail cards, scratchpad, footer
+```
+
+## Limits
+
+- The app is not sandboxed: it reads and writes the files you point it at and
+  spawns a local interpreter. Do not ship this build to the App Store as-is.
+- Files are sent to the service one at a time (the batch endpoints exist, but
+  per-file progress and bounded memory matter more here); the service's 256 MB
+  input cap applies.
+- Layer B rewriting is not wired into the UI. Stylometry scores are shown, and
+  rewriting stays a deliberate step you take with `rewrite_text.py` or an agent.
+
+## Responsible use
+
+Same as the rest of the repo: this is for content **you own**. Removing
+provenance from someone else's work, or to pass AI output off as human where
+that matters (school, journalism, legal filings), is not what it is for. See
+[`skills/remove-ai-marks/references/ethics.md`](../../skills/remove-ai-marks/references/ethics.md).

--- a/app/macos/Scripts/build-app.sh
+++ b/app/macos/Scripts/build-app.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Build WatermarksRemover.app: compile the SwiftUI front end, then wrap it in a
+# bundle together with the Python service it drives.
+#
+#   ./app/macos/Scripts/build-app.sh                 # release build
+#   CONFIGURATION=debug ./app/macos/Scripts/build-app.sh
+#   OUTPUT_DIR=~/Applications ./app/macos/Scripts/build-app.sh
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo="$(cd "$here/../.." && pwd)"
+configuration="${CONFIGURATION:-release}"
+output_dir="${OUTPUT_DIR:-$here/build}"
+app="$output_dir/Watermarks Remover.app"
+python="${PYTHON:-python3}"
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "error: this app builds on macOS only (found $(uname -s))" >&2
+  exit 1
+fi
+
+if ! command -v swift >/dev/null 2>&1; then
+  echo "error: swift not found. Install Xcode or the Command Line Tools." >&2
+  exit 1
+fi
+
+echo "==> Building ($configuration)"
+swift build --package-path "$here" -c "$configuration"
+binary="$(swift build --package-path "$here" -c "$configuration" --show-bin-path)/WatermarksRemover"
+test -x "$binary" || { echo "error: build produced no binary at $binary" >&2; exit 1; }
+
+echo "==> Assembling bundle"
+rm -rf "$app"
+mkdir -p "$app/Contents/MacOS" "$app/Contents/Resources/service/scripts"
+cp "$binary" "$app/Contents/MacOS/WatermarksRemover"
+cp "$here/Info.plist" "$app/Contents/Info.plist"
+printf 'APPL????' > "$app/Contents/PkgInfo"
+
+# The service is stdlib-only, so the bundle only needs the scripts themselves.
+cp "$repo"/service/scripts/*.py "$app/Contents/Resources/service/scripts/"
+cp "$repo/LICENSE" "$app/Contents/Resources/LICENSE"
+
+echo "==> Rendering icon"
+iconset="$(mktemp -d)/AppIcon.iconset"
+if "$python" "$here/Scripts/make_icon.py" --out "$iconset" >/dev/null; then
+  if command -v iconutil >/dev/null 2>&1; then
+    iconutil -c icns -o "$app/Contents/Resources/AppIcon.icns" "$iconset"
+  else
+    echo "    iconutil missing; shipping without an icon"
+  fi
+else
+  echo "    icon generation failed; shipping without an icon"
+fi
+
+# Ad-hoc signature: without it macOS re-prompts for local-network and file
+# access on every rebuild, and quarantine handling is noisier.
+if command -v codesign >/dev/null 2>&1; then
+  echo "==> Signing (ad-hoc)"
+  codesign --force --sign - --timestamp=none "$app" >/dev/null 2>&1 ||
+    echo "    ad-hoc signing failed; the app still runs after right-click > Open"
+fi
+
+echo "==> Done: $app"

--- a/app/macos/Scripts/make_icon.py
+++ b/app/macos/Scripts/make_icon.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Render the app icon into an .iconset directory. Stdlib only.
+
+The icon is drawn once at 2x the largest size and box-downsampled to every
+size macOS asks for; the downsample is what antialiases the edges, so there is
+no separate supersampling pass. Kept in Python (rather than checked-in PNGs)
+so the icon stays diffable and the repo stays free of binaries.
+
+Usage:
+    python3 make_icon.py --out build/AppIcon.iconset
+"""
+
+from __future__ import annotations
+
+import argparse
+import struct
+import zlib
+from pathlib import Path
+
+# Palette. Indigo -> violet, the same family the README badges sit in.
+TOP = (0x5B, 0x69, 0xF5)
+BOTTOM = (0x7C, 0x3A, 0xED)
+SHEET = (0xFF, 0xFF, 0xFF)
+LINE = (0xC7, 0xD2, 0xFE)
+MARK = (0xFB, 0xBF, 0x24)
+SWEEP = (0xFF, 0xFF, 0xFF)
+
+RENDER_SIZE = 2048
+ICONSET_SIZES = [
+    ("icon_16x16.png", 16),
+    ("icon_16x16@2x.png", 32),
+    ("icon_32x32.png", 32),
+    ("icon_32x32@2x.png", 64),
+    ("icon_128x128.png", 128),
+    ("icon_128x128@2x.png", 256),
+    ("icon_256x256.png", 256),
+    ("icon_256x256@2x.png", 512),
+    ("icon_512x512.png", 512),
+    ("icon_512x512@2x.png", 1024),
+]
+
+
+def rounded_rect(x, y, left, top, right, bottom, radius):
+    """True when (x, y) is inside the rounded rectangle."""
+    if x < left or x > right or y < top or y > bottom:
+        return False
+    cx = min(max(x, left + radius), right - radius)
+    cy = min(max(y, top + radius), bottom - radius)
+    dx = x - cx
+    dy = y - cy
+    return dx * dx + dy * dy <= radius * radius
+
+
+def blend(base, color, alpha):
+    return tuple(round(b + (c - b) * alpha) for b, c in zip(base, color, strict=True))
+
+
+def render(size: int) -> bytearray:
+    """Draw the icon at `size` px and return RGBA rows."""
+    pixels = bytearray(size * size * 4)
+
+    # Body: 0.04..0.96 leaves the margin macOS icons are drawn with.
+    body = (0.055, 0.055, 0.945, 0.945)
+    body_radius = 0.21
+    sheet = (0.285, 0.235, 0.715, 0.775)
+    # Diagonal sweep, expressed as distance to the line through two points.
+    sweep_a = (0.14, 0.86)
+    sweep_b = (0.90, 0.16)
+    dx = sweep_b[0] - sweep_a[0]
+    dy = sweep_b[1] - sweep_a[1]
+    length = (dx * dx + dy * dy) ** 0.5
+    nx, ny = -dy / length, dx / length
+
+    lines = [
+        (0.345, 0.345, 0.655, 0.373),
+        (0.345, 0.415, 0.610, 0.443),
+        (0.345, 0.485, 0.640, 0.513),
+    ]
+    marks = [0.345 + i * 0.052 for i in range(5)]
+
+    for py in range(size):
+        y = (py + 0.5) / size
+        row = py * size * 4
+        gradient = blend(TOP, BOTTOM, min(max((y - body[1]) / (body[3] - body[1]), 0.0), 1.0))
+        for px in range(size):
+            x = (px + 0.5) / size
+            index = row + px * 4
+
+            if not rounded_rect(x, y, *body, body_radius):
+                continue  # stays transparent
+
+            color = gradient
+
+            # Subtle top-left sheen.
+            sheen = max(0.0, 0.55 - (x + y))
+            if sheen > 0:
+                color = blend(color, (0xFF, 0xFF, 0xFF), sheen * 0.18)
+
+            if rounded_rect(x, y, *sheet, 0.045):
+                color = SHEET
+                for lx0, ly0, lx1, ly1 in lines:
+                    if rounded_rect(x, y, lx0, ly0, lx1, ly1, 0.014):
+                        color = LINE
+                if 0.555 <= y <= 0.585:
+                    for mx in marks:
+                        if rounded_rect(x, y, mx, 0.555, mx + 0.030, 0.585, 0.012):
+                            color = MARK
+
+            # The sweep crosses everything: it is the "removal" gesture.
+            distance = abs((x - sweep_a[0]) * nx + (y - sweep_a[1]) * ny)
+            if distance < 0.052:
+                edge = 1.0 - (distance / 0.052) ** 2
+                color = blend(color, SWEEP, 0.30 + 0.45 * edge)
+
+            pixels[index] = color[0]
+            pixels[index + 1] = color[1]
+            pixels[index + 2] = color[2]
+            pixels[index + 3] = 255
+
+    return pixels
+
+
+def downsample(pixels: bytearray, size: int, target: int) -> bytearray:
+    """Box-filter `pixels` (size x size RGBA) down to target x target.
+
+    Alpha-weighted, so the transparent margin outside the icon body does not
+    bleed dark pixels into the rounded corners.
+    """
+    if target == size:
+        return pixels
+    if target > size:
+        raise ValueError(f"cannot upscale {size} to {target}")
+    out = bytearray(target * target * 4)
+    for ty in range(target):
+        y0 = ty * size // target
+        y1 = max(y0 + 1, (ty + 1) * size // target)
+        for tx in range(target):
+            x0 = tx * size // target
+            x1 = max(x0 + 1, (tx + 1) * size // target)
+            r = g = b = a = 0
+            for sy in range(y0, y1):
+                base = (sy * size + x0) * 4
+                for offset in range(0, (x1 - x0) * 4, 4):
+                    index = base + offset
+                    alpha = pixels[index + 3]
+                    r += pixels[index] * alpha
+                    g += pixels[index + 1] * alpha
+                    b += pixels[index + 2] * alpha
+                    a += alpha
+            index = (ty * target + tx) * 4
+            if a:
+                out[index] = r // a
+                out[index + 1] = g // a
+                out[index + 2] = b // a
+            out[index + 3] = a // ((y1 - y0) * (x1 - x0))
+    return out
+
+
+def write_png(path: Path, pixels: bytearray, size: int) -> None:
+    raw = bytearray()
+    stride = size * 4
+    for y in range(size):
+        raw.append(0)  # filter type 0
+        raw.extend(pixels[y * stride : (y + 1) * stride])
+
+    def chunk(tag: bytes, payload: bytes) -> bytes:
+        return (
+            struct.pack(">I", len(payload))
+            + tag
+            + payload
+            + struct.pack(">I", zlib.crc32(tag + payload) & 0xFFFFFFFF)
+        )
+
+    png = b"\x89PNG\r\n\x1a\n"
+    png += chunk(b"IHDR", struct.pack(">IIBBBBB", size, size, 8, 6, 0, 0, 0))
+    png += chunk(b"IDAT", zlib.compress(bytes(raw), 9))
+    png += chunk(b"IEND", b"")
+    path.write_bytes(png)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", required=True, help="iconset directory to write")
+    parser.add_argument(
+        "--render-size", type=int, default=RENDER_SIZE, help="internal render resolution"
+    )
+    args = parser.parse_args()
+
+    largest = max(size for _, size in ICONSET_SIZES)
+    if args.render_size < largest:
+        parser.error(f"--render-size must be at least {largest}")
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+
+    master = render(args.render_size)
+    for name, size in ICONSET_SIZES:
+        write_png(out / name, downsample(master, args.render_size, size), size)
+    print(f"wrote {len(ICONSET_SIZES)} icons to {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/app/macos/Sources/WatermarksRemover/AppModel.swift
+++ b/app/macos/Sources/WatermarksRemover/AppModel.swift
@@ -1,0 +1,296 @@
+import AppKit
+import Foundation
+import UniformTypeIdentifiers
+
+/// Queue orchestration: turns dropped URLs into service calls and collects the
+/// results the views render.
+@MainActor
+final class AppModel: ObservableObject {
+    @Published var items: [FileItem] = []
+    @Published var selection: Set<FileItem.ID> = []
+    @Published var options = CleanOptions()
+    @Published var isProcessing = false
+    @Published var progress: (done: Int, total: Int)?
+    @Published var alert: AppAlert?
+
+    let settings: AppSettings
+    let service: ServiceController
+
+    /// Directories are walked, but never without a ceiling: a stray drop of a
+    /// home folder should not enqueue a hundred thousand files.
+    static let maxFilesPerDrop = 500
+
+    init(settings: AppSettings, service: ServiceController) {
+        self.settings = settings
+        self.service = service
+    }
+
+    /// The detail pane follows the first selected row; multi-selection exists
+    /// for batch actions, not for a split detail view.
+    var selectedItem: FileItem? {
+        items.first { selection.contains($0.id) }
+    }
+
+    var actionTargets: Set<FileItem.ID> {
+        selection.isEmpty ? Set(items.map(\.id)) : selection
+    }
+
+    var suspiciousCount: Int { items.filter(\.isSuspicious).count }
+
+    // MARK: - Queue
+
+    func add(urls: [URL]) {
+        let expanded = expand(urls: urls)
+        var added = 0
+        for url in expanded {
+            let standardized = url.standardizedFileURL
+            guard !items.contains(where: { $0.url.standardizedFileURL == standardized }) else {
+                continue
+            }
+            let attributes = try? FileManager.default.attributesOfItem(atPath: standardized.path)
+            let size = (attributes?[.size] as? NSNumber)?.intValue ?? 0
+            items.append(FileItem(url: standardized, byteCount: size))
+            added += 1
+        }
+        if selection.isEmpty, let first = items.first { selection = [first.id] }
+        guard added > 0 else { return }
+        if settings.autoInspectOnAdd {
+            Task { await inspectPending() }
+        }
+    }
+
+    func remove(ids: Set<FileItem.ID>) {
+        items.removeAll { ids.contains($0.id) }
+        selection.subtract(ids)
+        if selection.isEmpty, let first = items.first { selection = [first.id] }
+    }
+
+    func clearAll() {
+        items.removeAll()
+        selection = []
+    }
+
+    private func expand(urls: [URL]) -> [URL] {
+        var result: [URL] = []
+        let manager = FileManager.default
+        for url in urls {
+            var isDirectory: ObjCBool = false
+            guard manager.fileExists(atPath: url.path, isDirectory: &isDirectory) else { continue }
+            if !isDirectory.boolValue {
+                result.append(url)
+                continue
+            }
+            let enumerator = manager.enumerator(
+                at: url,
+                includingPropertiesForKeys: [.isRegularFileKey],
+                options: [.skipsHiddenFiles, .skipsPackageDescendants])
+            while let next = enumerator?.nextObject() as? URL {
+                guard result.count < Self.maxFilesPerDrop else { break }
+                let values = try? next.resourceValues(forKeys: [.isRegularFileKey])
+                if values?.isRegularFile == true { result.append(next) }
+            }
+        }
+        if result.count > Self.maxFilesPerDrop {
+            alert = AppAlert(
+                title: "Too many files",
+                message: "Only the first \(Self.maxFilesPerDrop) files were added.")
+            result = Array(result.prefix(Self.maxFilesPerDrop))
+        }
+        return result
+    }
+
+    // MARK: - Actions
+
+    func inspectPending() async {
+        await run(over: items.indices.filter { items[$0].inspection == nil }) { index, client in
+            try await self.inspect(index: index, client: client)
+        }
+    }
+
+    func inspectAll() async {
+        await run(over: Array(items.indices)) { index, client in
+            try await self.inspect(index: index, client: client)
+        }
+    }
+
+    func cleanAll() async {
+        await run(over: Array(items.indices)) { index, client in
+            try await self.clean(index: index, client: client)
+        }
+    }
+
+    func clean(ids: Set<FileItem.ID>) async {
+        let targets = items.indices.filter { ids.contains(items[$0].id) }
+        await run(over: targets) { index, client in
+            try await self.clean(index: index, client: client)
+        }
+    }
+
+    /// Shared driver: resolves the client once, walks the targets in order and
+    /// records per-file failures without stopping the run.
+    private func run(
+        over targets: [Int],
+        body: @escaping (Int, ServiceClient) async throws -> Void
+    ) async {
+        guard !targets.isEmpty else { return }
+        guard let client = service.client else {
+            alert = AppAlert(
+                title: "Service not running",
+                message: "Start the local service from the status bar, then try again.")
+            return
+        }
+        isProcessing = true
+        progress = (0, targets.count)
+        defer {
+            isProcessing = false
+            progress = nil
+        }
+        for (offset, index) in targets.enumerated() {
+            guard items.indices.contains(index) else { continue }
+            do {
+                try await body(index, client)
+            } catch {
+                if items.indices.contains(index) {
+                    items[index].status = .failed(message(for: error))
+                }
+            }
+            progress = (offset + 1, targets.count)
+        }
+    }
+
+    private func inspect(index: Int, client: ServiceClient) async throws {
+        let item = items[index]
+        items[index].status = .working("Inspecting…")
+        let data = try Data(contentsOf: item.url)
+        items[index].byteCount = data.count
+        let result = try await client.inspect(
+            data: data, name: item.name, detect: settings.runDetectorsOnInspect)
+        guard let current = items.firstIndex(where: { $0.id == item.id }) else { return }
+        items[current].inspection = InspectSummary(
+            kind: result.kind, suspicious: result.suspicious, report: result.report)
+        items[current].status = .inspected
+    }
+
+    private func clean(index: Int, client: ServiceClient) async throws {
+        let item = items[index]
+        items[index].status = .working("Cleaning…")
+        let data = try Data(contentsOf: item.url)
+        let result = try await client.clean(data: data, name: item.name, options: options)
+        let destination = try outputURL(for: item.url)
+        try write(result.cleaned, to: destination)
+        guard let current = items.firstIndex(where: { $0.id == item.id }) else { return }
+        items[current].cleanResult = CleanSummary(kind: result.kind, report: result.report)
+        items[current].outputURL = destination
+        items[current].status = .cleaned
+    }
+
+    // MARK: - Output
+
+    func outputURL(for source: URL) throws -> URL {
+        switch settings.outputMode {
+        case .inPlace:
+            return source
+        case .sibling:
+            return uniqueURL(cleanedName(for: source, in: source.deletingLastPathComponent()))
+        case .folder:
+            guard let folder = settings.outputFolder else {
+                throw AppError.noOutputFolder
+            }
+            try FileManager.default.createDirectory(
+                at: folder, withIntermediateDirectories: true)
+            return uniqueURL(cleanedName(for: source, in: folder))
+        }
+    }
+
+    private func cleanedName(for source: URL, in folder: URL) -> URL {
+        let base = source.deletingPathExtension().lastPathComponent
+        let ext = source.pathExtension
+        let name = ext.isEmpty ? "\(base).cleaned" : "\(base).cleaned.\(ext)"
+        return folder.appendingPathComponent(name)
+    }
+
+    private func uniqueURL(_ candidate: URL) -> URL {
+        var result = candidate
+        var counter = 2
+        let base = candidate.deletingPathExtension().lastPathComponent
+        let ext = candidate.pathExtension
+        let folder = candidate.deletingLastPathComponent()
+        while FileManager.default.fileExists(atPath: result.path) {
+            let name = ext.isEmpty ? "\(base) \(counter)" : "\(base) \(counter).\(ext)"
+            result = folder.appendingPathComponent(name)
+            counter += 1
+        }
+        return result
+    }
+
+    /// Writes through a temporary file in the destination directory so an
+    /// interrupted write can never leave a half-cleaned file behind.
+    private func write(_ data: Data, to destination: URL) throws {
+        let folder = destination.deletingLastPathComponent()
+        let temporary = folder.appendingPathComponent(".\(UUID().uuidString).tmp")
+        try data.write(to: temporary, options: .atomic)
+        if FileManager.default.fileExists(atPath: destination.path) {
+            _ = try FileManager.default.replaceItemAt(destination, withItemAt: temporary)
+        } else {
+            try FileManager.default.moveItem(at: temporary, to: destination)
+        }
+    }
+
+    // MARK: - Reveal / export
+
+    func reveal(_ url: URL) {
+        NSWorkspace.shared.activateFileViewerSelecting([url])
+    }
+
+    func exportReport() {
+        let panel = NSSavePanel()
+        panel.nameFieldStringValue = "watermarks-report.json"
+        panel.allowedContentTypes = [.json]
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        let payload = JSONValue.array(
+            items.map { item in
+                var entry: [String: JSONValue] = [
+                    "name": .string(item.name),
+                    "path": .string(item.url.path),
+                ]
+                if let inspection = item.inspection {
+                    entry["kind"] = .string(inspection.kind.rawValue)
+                    entry["suspicious"] = .bool(inspection.suspicious)
+                    entry["inspect_report"] = inspection.raw
+                }
+                if let cleanResult = item.cleanResult {
+                    entry["clean_report"] = cleanResult.raw
+                }
+                if let output = item.outputURL {
+                    entry["output"] = .string(output.path)
+                }
+                return .object(entry)
+            })
+        do {
+            try Data(payload.prettyPrinted.utf8).write(to: url, options: .atomic)
+        } catch {
+            alert = AppAlert(title: "Could not save the report", message: error.localizedDescription)
+        }
+    }
+
+    private func message(for error: Error) -> String {
+        (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+    }
+}
+
+enum AppError: LocalizedError {
+    case noOutputFolder
+
+    var errorDescription: String? {
+        switch self {
+        case .noOutputFolder:
+            return "Choose an output folder in Settings first."
+        }
+    }
+}
+
+struct AppAlert: Identifiable {
+    let id = UUID()
+    let title: String
+    let message: String
+}

--- a/app/macos/Sources/WatermarksRemover/Model/AppSettings.swift
+++ b/app/macos/Sources/WatermarksRemover/Model/AppSettings.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// User preferences, persisted in `UserDefaults`.
+@MainActor
+final class AppSettings: ObservableObject {
+    private let defaults: UserDefaults
+
+    @Published var pythonPath: String { didSet { store("pythonPath", pythonPath) } }
+    @Published var useExternalService: Bool { didSet { store("useExternalService", useExternalService) } }
+    @Published var externalServiceURL: String { didSet { store("externalServiceURL", externalServiceURL) } }
+    @Published var externalAPIKey: String { didSet { store("externalAPIKey", externalAPIKey) } }
+    @Published var outputMode: OutputMode { didSet { store("outputMode", outputMode.rawValue) } }
+    @Published var outputFolderPath: String { didSet { store("outputFolderPath", outputFolderPath) } }
+    @Published var runDetectorsOnInspect: Bool { didSet { store("runDetectorsOnInspect", runDetectorsOnInspect) } }
+    @Published var autoInspectOnAdd: Bool { didSet { store("autoInspectOnAdd", autoInspectOnAdd) } }
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        self.pythonPath = defaults.string(forKey: "pythonPath") ?? ""
+        self.useExternalService = defaults.bool(forKey: "useExternalService")
+        self.externalServiceURL =
+            defaults.string(forKey: "externalServiceURL") ?? "http://127.0.0.1:8765"
+        self.externalAPIKey = defaults.string(forKey: "externalAPIKey") ?? ""
+        self.outputMode =
+            OutputMode(rawValue: defaults.string(forKey: "outputMode") ?? "") ?? .sibling
+        self.outputFolderPath = defaults.string(forKey: "outputFolderPath") ?? ""
+        self.runDetectorsOnInspect = defaults.bool(forKey: "runDetectorsOnInspect")
+        self.autoInspectOnAdd = defaults.object(forKey: "autoInspectOnAdd") as? Bool ?? true
+    }
+
+    var outputFolder: URL? {
+        outputFolderPath.isEmpty ? nil : URL(fileURLWithPath: outputFolderPath)
+    }
+
+    private func store(_ key: String, _ value: Any) {
+        defaults.set(value, forKey: key)
+    }
+}

--- a/app/macos/Sources/WatermarksRemover/Model/Capabilities.swift
+++ b/app/macos/Sources/WatermarksRemover/Model/Capabilities.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// The service's `/capabilities` answer, reduced to what the UI surfaces.
+struct Capabilities {
+    struct Item: Identifiable {
+        let id = UUID()
+        let name: String
+        let available: Bool
+        let hint: String
+    }
+
+    let version: String
+    let tools: [Item]
+    let backends: [Item]
+    let detectors: [Item]
+
+    init(json: JSONValue) {
+        self.version = json["version"]?.stringValue ?? "unknown"
+
+        let toolHints = [
+            "c2patool": "Reads C2PA manifests",
+            "exiftool": "Strips residual metadata (needed for PDF)",
+            "qpdf": "Structural PDF rebuild",
+        ]
+        self.tools = (json["tools"]?.objectValue ?? [:])
+            .map { key, value in
+                Item(
+                    name: key, available: value.boolValue ?? false,
+                    hint: toolHints[key] ?? "Optional system tool")
+            }
+            .sorted { $0.name < $1.name }
+
+        var backends: [Item] = []
+        for (key, value) in json["pixel_backends"]?.objectValue ?? [:] {
+            backends.append(
+                Item(
+                    name: key, available: value.boolValue ?? false,
+                    hint: "Pixel-level watermark removal"))
+        }
+        for (key, value) in json["scorers"]?.objectValue ?? [:] {
+            backends.append(
+                Item(
+                    name: key, available: value.boolValue ?? false, hint: "Watermark scorer"))
+        }
+        self.backends = backends.sorted { $0.name < $1.name }
+
+        self.detectors = (json["text_detectors"]?.objectValue ?? [:])
+            .map { key, value in
+                Item(
+                    name: key, available: value.boolValue ?? false,
+                    hint: "Text watermark detector")
+            }
+            .sorted { $0.name < $1.name }
+    }
+
+    var pixelBackendAvailable: Bool {
+        backends.contains { ($0.name == "ctrlregen" || $0.name == "diffusion") && $0.available }
+    }
+
+    var anyDetectorAvailable: Bool {
+        detectors.contains { $0.available }
+    }
+}

--- a/app/macos/Sources/WatermarksRemover/Model/CleanOptions.swift
+++ b/app/macos/Sources/WatermarksRemover/Model/CleanOptions.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// Where cleaned files are written.
+enum OutputMode: String, CaseIterable, Identifiable {
+    case sibling
+    case folder
+    case inPlace
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .sibling: return "Next to the original"
+        case .folder: return "Into a folder"
+        case .inPlace: return "Replace the original"
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .sibling: return "Writes name.cleaned.ext beside each source file."
+        case .folder: return "Writes every cleaned file into one chosen folder."
+        case .inPlace: return "Overwrites the source file. There is no undo."
+        }
+    }
+}
+
+/// Which pixel-level remover to run, when a heavy backend is configured.
+enum PixelRemover: String, CaseIterable, Identifiable {
+    case none
+    case ctrlregen
+    case diffusion
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .none: return "Off"
+        case .ctrlregen: return "CtrlRegen"
+        case .diffusion: return "Diffusion purification"
+        }
+    }
+
+    var wireValue: String? { self == .none ? nil : rawValue }
+}
+
+/// The `options` object of a `/clean` request, plus the app-side choices that
+/// never reach the service.
+struct CleanOptions: Equatable {
+    var nfkc = false
+    var aggressiveHomoglyphs = false
+    var keepNonAIMetadata = false
+    var alsoLayerAText = true
+    var pixelRemover: PixelRemover = .none
+    var detectBefore = false
+    var detectAfter = false
+
+    /// Only the keys the server accepts, and only the ones that differ from its
+    /// own defaults, so requests stay minimal and forward-compatible.
+    var wireOptions: [String: JSONValue] {
+        var options: [String: JSONValue] = [
+            "nfkc": .bool(nfkc),
+            "aggressive_homoglyphs": .bool(aggressiveHomoglyphs),
+            "keep_non_ai_metadata": .bool(keepNonAIMetadata),
+            "also_layer_a_text": .bool(alsoLayerAText),
+        ]
+        if let remover = pixelRemover.wireValue {
+            options["remove_pixel"] = .string(remover)
+        }
+        if detectBefore { options["detect_before"] = .bool(true) }
+        if detectAfter { options["detect_after"] = .bool(true) }
+        return options
+    }
+}

--- a/app/macos/Sources/WatermarksRemover/Model/FileItem.swift
+++ b/app/macos/Sources/WatermarksRemover/Model/FileItem.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// One file in the queue, with whatever the service has said about it so far.
+struct FileItem: Identifiable {
+    enum Status: Equatable {
+        case queued
+        case working(String)
+        case inspected
+        case cleaned
+        case failed(String)
+
+        var isBusy: Bool {
+            if case .working = self { return true }
+            return false
+        }
+    }
+
+    let id = UUID()
+    let url: URL
+    var byteCount: Int
+    var status: Status = .queued
+    var inspection: InspectSummary?
+    var cleanResult: CleanSummary?
+    var outputURL: URL?
+
+    var name: String { url.lastPathComponent }
+
+    var kind: FileKind { inspection?.kind ?? FileKind(raw: nil) }
+
+    /// The row's short status line.
+    var subtitle: String {
+        switch status {
+        case .queued: return ByteCountFormatter.string(fromByteCount: Int64(byteCount), countStyle: .file)
+        case .working(let phase): return phase
+        case .inspected: return inspection?.headline ?? "Inspected"
+        case .cleaned: return cleanResult?.headline ?? "Cleaned"
+        case .failed(let message): return message
+        }
+    }
+
+    var isSuspicious: Bool { inspection?.suspicious ?? false }
+}

--- a/app/macos/Sources/WatermarksRemover/Model/JSONValue.swift
+++ b/app/macos/Sources/WatermarksRemover/Model/JSONValue.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// A loss-free view of arbitrary JSON.
+///
+/// The service's reports are open-ended: every format contributes its own keys
+/// and new ones land with new detectors. Decoding them into fixed structs would
+/// silently drop whatever the app does not know about yet, so reports are kept
+/// as `JSONValue` and read through key lookups. Everything unknown still shows
+/// up in the raw-report inspector.
+enum JSONValue: Codable, Equatable {
+    case null
+    case bool(Bool)
+    case number(Double)
+    case string(String)
+    case array([JSONValue])
+    case object([String: JSONValue])
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .number(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([JSONValue].self) {
+            self = .array(value)
+        } else if let value = try? container.decode([String: JSONValue].self) {
+            self = .object(value)
+        } else {
+            throw DecodingError.dataCorruptedError(
+                in: container, debugDescription: "unsupported JSON value")
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .null: try container.encodeNil()
+        case .bool(let value): try container.encode(value)
+        case .number(let value): try container.encode(value)
+        case .string(let value): try container.encode(value)
+        case .array(let value): try container.encode(value)
+        case .object(let value): try container.encode(value)
+        }
+    }
+
+    // MARK: - Lookups
+
+    subscript(key: String) -> JSONValue? {
+        guard case .object(let dict) = self else { return nil }
+        return dict[key]
+    }
+
+    var stringValue: String? {
+        if case .string(let value) = self { return value }
+        return nil
+    }
+
+    var doubleValue: Double? {
+        switch self {
+        case .number(let value): return value
+        case .string(let value): return Double(value)
+        default: return nil
+        }
+    }
+
+    var intValue: Int? {
+        guard let double = doubleValue else { return nil }
+        return Int(double)
+    }
+
+    var boolValue: Bool? {
+        switch self {
+        case .bool(let value): return value
+        case .number(let value): return value != 0
+        default: return nil
+        }
+    }
+
+    var arrayValue: [JSONValue]? {
+        if case .array(let value) = self { return value }
+        return nil
+    }
+
+    var objectValue: [String: JSONValue]? {
+        if case .object(let value) = self { return value }
+        return nil
+    }
+
+    /// Strings from an array field, skipping entries that are not strings.
+    var stringArray: [String] {
+        (arrayValue ?? []).compactMap { $0.stringValue }
+    }
+
+    var isEmptyish: Bool {
+        switch self {
+        case .null: return true
+        case .array(let value): return value.isEmpty
+        case .object(let value): return value.isEmpty
+        case .string(let value): return value.isEmpty
+        default: return false
+        }
+    }
+
+    /// Pretty-printed JSON for the raw report drawer.
+    var prettyPrinted: String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        guard let data = try? encoder.encode(self),
+            let text = String(data: data, encoding: .utf8)
+        else { return "<unrenderable>" }
+        return text
+    }
+}

--- a/app/macos/Sources/WatermarksRemover/Model/Reports.swift
+++ b/app/macos/Sources/WatermarksRemover/Model/Reports.swift
@@ -1,0 +1,230 @@
+import Foundation
+
+/// Which pipeline the service routed a file through.
+enum FileKind: String, Codable {
+    case text
+    case image
+    case container
+    case av
+    case unknown
+
+    var label: String {
+        switch self {
+        case .text: return "Text"
+        case .image: return "Image"
+        case .container: return "Document"
+        case .av: return "Audio / Video"
+        case .unknown: return "Unrecognized"
+        }
+    }
+
+    var symbol: String {
+        switch self {
+        case .text: return "doc.plaintext"
+        case .image: return "photo"
+        case .container: return "doc.richtext"
+        case .av: return "waveform"
+        case .unknown: return "questionmark.square.dashed"
+        }
+    }
+
+    init(raw: String?) {
+        self = FileKind(rawValue: raw ?? "") ?? .unknown
+    }
+}
+
+/// How strongly a finding implicates AI provenance. Mirrors the service's own
+/// `findings_confidence` / per-hit `confidence` strings.
+enum Confidence: String {
+    case high
+    case medium
+    case low
+    case unknown
+
+    init(raw: String?) {
+        self = Confidence(rawValue: (raw ?? "").lowercased()) ?? .unknown
+    }
+
+    var label: String {
+        switch self {
+        case .high: return "High"
+        case .medium: return "Medium"
+        case .low: return "Low"
+        case .unknown: return "—"
+        }
+    }
+}
+
+struct LayerAHit: Identifiable {
+    let id = UUID()
+    let codepoint: String
+    let label: String
+    let count: Int
+    let kind: String
+    let confidence: Confidence
+
+    init?(json: JSONValue) {
+        guard let label = json["label"]?.stringValue else { return nil }
+        self.codepoint = json["codepoint"]?.stringValue ?? ""
+        self.label = label
+        self.count = json["count"]?.intValue ?? 0
+        self.kind = json["kind"]?.stringValue ?? ""
+        self.confidence = Confidence(raw: json["confidence"]?.stringValue)
+    }
+}
+
+struct Finding: Identifiable {
+    let id = UUID()
+    let text: String
+    let confidence: Confidence
+}
+
+struct StylometrySummary {
+    let score: Double
+    let confidenceLevel: String
+    let status: String
+    let wordCount: Int
+    let burstiness: Double?
+    let lexicalDiversity: Double
+    let markers: [String]
+
+    init?(json: JSONValue?) {
+        guard let json, let score = json["score"]?.doubleValue else { return nil }
+        self.score = score
+        self.confidenceLevel = json["confidence_level"]?.stringValue ?? "unknown"
+        self.status = json["status"]?.stringValue ?? ""
+        self.wordCount = json["word_count"]?.intValue ?? 0
+        self.burstiness = json["burstiness_cv"]?.doubleValue
+        self.lexicalDiversity = json["lexical_diversity"]?.doubleValue ?? 0
+        self.markers = (json["matched_markers"]?.arrayValue ?? []).compactMap {
+            $0["phrase"]?.stringValue ?? $0.stringValue
+        }
+    }
+}
+
+struct DetectorSummary: Identifiable {
+    let id = UUID()
+    let name: String
+    let available: Bool
+    let watermarked: Bool?
+    let detail: String?
+
+    init(json: JSONValue) {
+        self.name = json["detector"]?.stringValue ?? "detector"
+        self.available = json["available"]?.boolValue ?? false
+        self.watermarked = json["is_watermarked"]?.boolValue
+        if let error = json["error"]?.stringValue {
+            self.detail = error
+        } else if let score = json["score"]?.doubleValue {
+            self.detail = String(format: "score %.3f", score)
+        } else if let pvalue = json["p_value"]?.doubleValue {
+            self.detail = String(format: "p = %.4f", pvalue)
+        } else {
+            self.detail = json["status"]?.stringValue
+        }
+    }
+}
+
+/// Everything the detail pane renders, distilled from one `/inspect` report.
+struct InspectSummary {
+    let kind: FileKind
+    let suspicious: Bool
+    let layerATotal: Int
+    let hits: [LayerAHit]
+    let findings: [Finding]
+    let notes: [String]
+    let hasC2PA: Bool
+    let hasAIMetadata: Bool
+    let format: String?
+    let stylometry: StylometrySummary?
+    let detectors: [DetectorSummary]
+    let raw: JSONValue
+
+    init(kind: FileKind, suspicious: Bool, report: JSONValue) {
+        self.kind = kind
+        self.suspicious = suspicious
+        self.raw = report
+        self.layerATotal = report["suspicious_total"]?.intValue ?? 0
+        self.hasC2PA = report["has_c2pa"]?.boolValue ?? false
+        self.hasAIMetadata = report["has_ai_metadata"]?.boolValue ?? false
+        self.format = report["format"]?.stringValue
+        self.notes = report["notes"]?.stringArray ?? []
+        self.stylometry = StylometrySummary(json: report["stylometry"])
+
+        // Layer-A hits live under "hits" for text and "layer_a_hits" for
+        // containers that also carry a text body.
+        let hitSource = report["hits"] ?? report["layer_a_hits"]
+        self.hits = (hitSource?.arrayValue ?? []).compactMap(LayerAHit.init(json:))
+
+        let findingTexts = report["findings"]?.stringArray ?? []
+        let confidences = report["findings_confidence"]?.stringArray ?? []
+        self.findings = findingTexts.enumerated().map { index, text in
+            Finding(
+                text: text,
+                confidence: Confidence(raw: index < confidences.count ? confidences[index] : nil))
+        }
+
+        let detectorSource = report["text_detectors"]?.arrayValue ?? []
+        self.detectors = detectorSource.map(DetectorSummary.init(json:))
+    }
+
+    /// One-line verdict for the file row.
+    var headline: String {
+        if !suspicious { return "No AI provenance marks found" }
+        var parts: [String] = []
+        if layerATotal > 0 { parts.append("\(layerATotal) hidden character\(layerATotal == 1 ? "" : "s")") }
+        if hasC2PA { parts.append("C2PA manifest") }
+        if hasAIMetadata { parts.append("AI metadata") }
+        if let stylometry, stylometry.score >= 0.65 {
+            parts.append(String(format: "stylometry %.2f", stylometry.score))
+        }
+        if detectors.contains(where: { $0.available && $0.watermarked == true }) {
+            parts.append("detector hit")
+        }
+        if parts.isEmpty { parts.append("suspicious") }
+        return parts.joined(separator: " · ")
+    }
+}
+
+/// Everything the detail pane renders after a `/clean` round-trip.
+struct CleanSummary {
+    let kind: FileKind
+    let actions: [String]
+    let removedCount: Int
+    let replacedCount: Int
+    let removedLabels: [(String, Int)]
+    let bytesIn: Int?
+    let bytesOut: Int?
+    let stillHasC2PA: Bool
+    let stillHasAIMetadata: Bool
+    let raw: JSONValue
+
+    init(kind: FileKind, report: JSONValue) {
+        self.kind = kind
+        self.raw = report
+        self.actions = report["actions"]?.stringArray ?? []
+        self.bytesIn = report["bytes_in"]?.intValue
+        self.bytesOut = report["bytes_out"]?.intValue
+        self.stillHasC2PA = report["still_has_c2pa"]?.boolValue ?? false
+        self.stillHasAIMetadata = report["still_has_ai_metadata"]?.boolValue ?? false
+
+        let stats = report["stats"]
+        self.removedCount = stats?["removed_count"]?.intValue ?? 0
+        self.replacedCount = stats?["replaced_count"]?.intValue ?? 0
+        let removed = stats?["removed"]?.objectValue ?? [:]
+        let replaced = stats?["replaced"]?.objectValue ?? [:]
+        self.removedLabels = (removed.merging(replaced) { lhs, _ in lhs })
+            .compactMap { key, value in value.intValue.map { (key, $0) } }
+            .sorted { lhs, rhs in lhs.1 == rhs.1 ? lhs.0 < rhs.0 : lhs.1 > rhs.1 }
+    }
+
+    var headline: String {
+        var parts: [String] = []
+        if removedCount > 0 { parts.append("\(removedCount) removed") }
+        if replacedCount > 0 { parts.append("\(replacedCount) replaced") }
+        if !actions.isEmpty { parts.append("\(actions.count) action\(actions.count == 1 ? "" : "s")") }
+        if parts.isEmpty { parts.append("Nothing to change") }
+        if stillHasC2PA || stillHasAIMetadata { parts.append("residue remains") }
+        return parts.joined(separator: " · ")
+    }
+}

--- a/app/macos/Sources/WatermarksRemover/Service/PortFinder.swift
+++ b/app/macos/Sources/WatermarksRemover/Service/PortFinder.swift
@@ -1,0 +1,41 @@
+import Darwin
+import Foundation
+
+/// Asks the kernel for a free loopback port.
+///
+/// The port is released before the service is spawned, so there is a small
+/// window where something else could claim it. `ServiceController` treats a
+/// service that never becomes healthy as a start failure and retries with a
+/// fresh port, which covers that race.
+enum PortFinder {
+    static func freeLoopbackPort() -> Int? {
+        let descriptor = socket(AF_INET, SOCK_STREAM, 0)
+        guard descriptor >= 0 else { return nil }
+        defer { Darwin.close(descriptor) }
+
+        var address = sockaddr_in()
+        address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = 0
+        address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+
+        let bound = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { generic in
+                Darwin.bind(descriptor, generic, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bound == 0 else { return nil }
+
+        var assigned = sockaddr_in()
+        var length = socklen_t(MemoryLayout<sockaddr_in>.size)
+        let named = withUnsafeMutablePointer(to: &assigned) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { generic in
+                getsockname(descriptor, generic, &length)
+            }
+        }
+        guard named == 0 else { return nil }
+
+        let port = Int(UInt16(bigEndian: assigned.sin_port))
+        return port > 0 ? port : nil
+    }
+}

--- a/app/macos/Sources/WatermarksRemover/Service/ProcessRegistry.swift
+++ b/app/macos/Sources/WatermarksRemover/Service/ProcessRegistry.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Holds the running service process so it can be killed from anywhere,
+/// including `applicationWillTerminate`, without hopping to the main actor.
+///
+/// A leaked interpreter would keep listening on a loopback port after the app
+/// is gone, which is exactly the kind of surprise a privacy tool should not
+/// leave behind.
+final class ProcessRegistry: @unchecked Sendable {
+    static let shared = ProcessRegistry()
+
+    private let lock = NSLock()
+    private var processes: [Process] = []
+
+    func register(_ process: Process) {
+        lock.lock()
+        defer { lock.unlock() }
+        processes.removeAll { !$0.isRunning }
+        processes.append(process)
+    }
+
+    func forget(_ process: Process) {
+        lock.lock()
+        defer { lock.unlock() }
+        processes.removeAll { $0 === process }
+    }
+
+    func terminateAll() {
+        lock.lock()
+        let running = processes
+        processes.removeAll()
+        lock.unlock()
+        for process in running where process.isRunning {
+            process.terminate()
+        }
+    }
+}

--- a/app/macos/Sources/WatermarksRemover/Service/PythonLocator.swift
+++ b/app/macos/Sources/WatermarksRemover/Service/PythonLocator.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+struct PythonInterpreter: Equatable {
+    let url: URL
+    let version: String
+}
+
+/// Finds a Python 3.10+ interpreter for the bundled service.
+///
+/// The service is stdlib-only, so any modern interpreter works. Homebrew comes
+/// first because `/usr/bin/python3` is a Command Line Tools stub on a machine
+/// where they were never installed — running it pops an installer dialog and
+/// exits non-zero, which the probe treats as "not available".
+enum PythonLocator {
+    static let searchPaths = [
+        "/opt/homebrew/bin/python3",
+        "/usr/local/bin/python3",
+        "/opt/homebrew/bin/python3.13",
+        "/opt/homebrew/bin/python3.12",
+        "/opt/homebrew/bin/python3.11",
+        "/usr/bin/python3",
+    ]
+
+    static func discover(preferred: String?) -> PythonInterpreter? {
+        var candidates: [String] = []
+        if let preferred, !preferred.trimmingCharacters(in: .whitespaces).isEmpty {
+            candidates.append(preferred)
+        }
+        candidates.append(contentsOf: searchPaths)
+        for candidate in candidates {
+            if let interpreter = probe(path: candidate) { return interpreter }
+        }
+        return nil
+    }
+
+    /// Runs the candidate and keeps it only if it reports 3.10 or newer.
+    static func probe(path: String) -> PythonInterpreter? {
+        let url = URL(fileURLWithPath: path)
+        guard FileManager.default.isExecutableFile(atPath: url.path) else { return nil }
+
+        let process = Process()
+        process.executableURL = url
+        process.arguments = [
+            "-c", "import sys; print('%d.%d.%d' % sys.version_info[:3])",
+        ]
+        let output = Pipe()
+        process.standardOutput = output
+        process.standardError = Pipe()
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+        let data = output.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0,
+            let text = String(data: data, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        else { return nil }
+
+        let parts = text.split(separator: ".").compactMap { Int($0) }
+        guard parts.count >= 2, parts[0] == 3, parts[1] >= 10 else { return nil }
+        return PythonInterpreter(url: url, version: text)
+    }
+}

--- a/app/macos/Sources/WatermarksRemover/Service/ServiceClient.swift
+++ b/app/macos/Sources/WatermarksRemover/Service/ServiceClient.swift
@@ -1,0 +1,147 @@
+import Foundation
+
+enum ServiceError: LocalizedError {
+    case tooLarge(Int)
+    case badResponse
+    case server(String)
+    case http(Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .tooLarge(let limit):
+            return "The file is larger than the service's \(limit / (1 << 20)) MB limit."
+        case .badResponse:
+            return "The service returned a response the app could not read."
+        case .server(let message):
+            return message
+        case .http(let status):
+            return "The service answered with HTTP \(status)."
+        }
+    }
+}
+
+struct InspectResult {
+    let kind: FileKind
+    let suspicious: Bool
+    let report: JSONValue
+}
+
+struct CleanResult {
+    let kind: FileKind
+    let cleaned: Data
+    let report: JSONValue
+}
+
+struct DetectResult {
+    let kind: FileKind
+    let detections: [DetectorSummary]
+    let raw: JSONValue
+}
+
+/// A typed client for the endpoints documented in `service/scripts/server.py`.
+struct ServiceClient {
+    /// Mirrors `common.MAX_INPUT_BYTES`; requests above it are rejected before
+    /// the app spends time base64-encoding a payload the service will refuse.
+    static let maxInputBytes = 256 << 20
+
+    let endpoint: ServiceEndpoint
+    let session: URLSession
+
+    // MARK: - GET
+
+    func health() async throws -> String {
+        let payload = try await get("/health")
+        return payload["version"]?.stringValue ?? "unknown"
+    }
+
+    func capabilities() async throws -> Capabilities {
+        Capabilities(json: try await get("/capabilities"))
+    }
+
+    // MARK: - POST
+
+    func inspect(data: Data, name: String, detect: Bool) async throws -> InspectResult {
+        var body = try envelope(data: data, name: name)
+        if detect { body["detect"] = .bool(true) }
+        let payload = try await post("/inspect", body: body)
+        return InspectResult(
+            kind: FileKind(raw: payload["kind"]?.stringValue),
+            suspicious: payload["suspicious"]?.boolValue ?? false,
+            report: payload["report"] ?? .object([:]))
+    }
+
+    func clean(data: Data, name: String, options: CleanOptions) async throws -> CleanResult {
+        var body = try envelope(data: data, name: name)
+        body["options"] = .object(options.wireOptions)
+        let payload = try await post("/clean", body: body)
+        guard let encoded = payload["cleaned"]?.stringValue,
+            let cleaned = Data(base64Encoded: encoded)
+        else { throw ServiceError.badResponse }
+        return CleanResult(
+            kind: FileKind(raw: payload["kind"]?.stringValue),
+            cleaned: cleaned,
+            report: payload["report"] ?? .object([:]))
+    }
+
+    func detect(data: Data, name: String) async throws -> DetectResult {
+        let payload = try await post("/detect", body: try envelope(data: data, name: name))
+        let detections = (payload["detections"]?.arrayValue ?? []).map(DetectorSummary.init(json:))
+        return DetectResult(
+            kind: FileKind(raw: payload["kind"]?.stringValue),
+            detections: detections,
+            raw: payload)
+    }
+
+    // MARK: - Plumbing
+
+    private func envelope(data: Data, name: String) throws -> [String: JSONValue] {
+        guard data.count <= Self.maxInputBytes else {
+            throw ServiceError.tooLarge(Self.maxInputBytes)
+        }
+        return [
+            "file": .string(data.base64EncodedString()),
+            "name": .string(name),
+        ]
+    }
+
+    /// Joins `path` onto the base URL by string, because
+    /// `appendingPathComponent` treats a multi-segment path as one component.
+    private func url(for path: String) -> URL {
+        var base = endpoint.baseURL.absoluteString
+        while base.hasSuffix("/") { base.removeLast() }
+        return URL(string: base + path) ?? endpoint.baseURL
+    }
+
+    private func request(_ path: String) -> URLRequest {
+        var request = URLRequest(url: url(for: path))
+        if let apiKey = endpoint.apiKey {
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
+        return request
+    }
+
+    private func get(_ path: String) async throws -> JSONValue {
+        try await send(request(path))
+    }
+
+    private func post(_ path: String, body: [String: JSONValue]) async throws -> JSONValue {
+        var request = self.request(path)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(JSONValue.object(body))
+        return try await send(request)
+    }
+
+    private func send(_ request: URLRequest) async throws -> JSONValue {
+        let (data, response) = try await session.data(for: request)
+        let payload = try? JSONDecoder().decode(JSONValue.self, from: data)
+        if let payload, payload["ok"]?.boolValue == false {
+            throw ServiceError.server(payload["error"]?.stringValue ?? "the service refused the request")
+        }
+        if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+            throw ServiceError.http(http.statusCode)
+        }
+        guard let payload else { throw ServiceError.badResponse }
+        return payload
+    }
+}

--- a/app/macos/Sources/WatermarksRemover/Service/ServiceController.swift
+++ b/app/macos/Sources/WatermarksRemover/Service/ServiceController.swift
@@ -1,0 +1,246 @@
+import Foundation
+
+struct ServiceEndpoint: Equatable {
+    let baseURL: URL
+    let apiKey: String?
+}
+
+enum ServiceState: Equatable {
+    case idle
+    case starting
+    case running(ServiceEndpoint)
+    case failed(String)
+
+    var endpoint: ServiceEndpoint? {
+        if case .running(let endpoint) = self { return endpoint }
+        return nil
+    }
+
+    var isRunning: Bool { endpoint != nil }
+
+    var label: String {
+        switch self {
+        case .idle: return "Stopped"
+        case .starting: return "Starting…"
+        case .running: return "Ready"
+        case .failed: return "Unavailable"
+        }
+    }
+}
+
+/// Owns the local `service/scripts/server.py` process.
+///
+/// The app never shells out to the CLI scripts one file at a time: it starts
+/// the same HTTP service the agent skill talks to, on a private loopback port
+/// with a per-launch bearer token, and speaks the documented API to it. That
+/// keeps the app a thin client over the pipeline the repo already tests.
+@MainActor
+final class ServiceController: ObservableObject {
+    @Published private(set) var state: ServiceState = .idle
+    @Published private(set) var interpreter: PythonInterpreter?
+    @Published private(set) var capabilities: Capabilities?
+    @Published private(set) var log: [String] = []
+
+    private var process: Process?
+    private let session: URLSession
+
+    /// Where the service scripts live inside the app bundle, with a fallback to
+    /// the checkout for `swift run` during development.
+    static var bundledScriptURL: URL? {
+        if let resource = Bundle.main.resourceURL {
+            let bundled = resource.appendingPathComponent("service/scripts/server.py")
+            if FileManager.default.fileExists(atPath: bundled.path) { return bundled }
+        }
+        // swift run leaves the binary in .build/<config>/; walk up to the repo.
+        var directory = URL(fileURLWithPath: CommandLine.arguments[0])
+            .resolvingSymlinksInPath()
+            .deletingLastPathComponent()
+        for _ in 0..<8 {
+            let candidate = directory.appendingPathComponent("service/scripts/server.py")
+            if FileManager.default.fileExists(atPath: candidate.path) { return candidate }
+            directory = directory.deletingLastPathComponent()
+        }
+        return nil
+    }
+
+    init() {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = 600
+        configuration.timeoutIntervalForResource = 1800
+        configuration.waitsForConnectivity = false
+        self.session = URLSession(configuration: configuration)
+    }
+
+    var client: ServiceClient? {
+        state.endpoint.map { ServiceClient(endpoint: $0, session: session) }
+    }
+
+    // MARK: - Lifecycle
+
+    func start(settings: AppSettings) async {
+        guard !state.isRunning, state != .starting else { return }
+        state = .starting
+        log.removeAll()
+
+        if settings.useExternalService {
+            await attachToExternalService(settings: settings)
+            return
+        }
+
+        guard let script = Self.bundledScriptURL else {
+            state = .failed(
+                "The bundled service scripts are missing. Rebuild the app with "
+                    + "app/macos/Scripts/build-app.sh.")
+            return
+        }
+        guard let python = PythonLocator.discover(preferred: settings.pythonPath) else {
+            state = .failed(
+                "No Python 3.10+ interpreter found. Install one with `brew install python` "
+                    + "or `xcode-select --install`, then set its path in Settings.")
+            return
+        }
+        interpreter = python
+
+        guard let port = PortFinder.freeLoopbackPort() else {
+            state = .failed("Could not reserve a loopback port.")
+            return
+        }
+        let apiKey = Self.makeAPIKey()
+
+        let process = Process()
+        process.executableURL = python.url
+        // --host/--port are safe in argv; the API key goes through the
+        // environment instead, so it never shows up in `ps` output.
+        process.arguments = [script.path, "--host", "127.0.0.1", "--port", String(port)]
+        var environment = ProcessInfo.processInfo.environment
+        environment["WATERMARKS_SERVER_API_KEY"] = apiKey
+        environment["PYTHONUNBUFFERED"] = "1"
+        environment["PYTHONDONTWRITEBYTECODE"] = "1"
+        // A GUI app inherits a bare PATH, so exiftool/qpdf/c2patool installed by
+        // Homebrew would look absent to the capability probe without this.
+        let extraPaths = ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin"]
+        let existing = environment["PATH"].map { $0.split(separator: ":").map(String.init) } ?? []
+        environment["PATH"] = (existing + extraPaths.filter { !existing.contains($0) })
+            .joined(separator: ":")
+        process.environment = environment
+
+        let errorPipe = Pipe()
+        process.standardError = errorPipe
+        // Nothing reads stdout, and an undrained pipe would eventually block
+        // the child; stderr is the stream the service actually logs to.
+        process.standardOutput = FileHandle.nullDevice
+        errorPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            guard !data.isEmpty, let text = String(data: data, encoding: .utf8) else { return }
+            Task { @MainActor in self?.appendLog(text) }
+        }
+
+        do {
+            try process.run()
+        } catch {
+            state = .failed("Could not launch the service: \(error.localizedDescription)")
+            return
+        }
+        self.process = process
+        ProcessRegistry.shared.register(process)
+        process.terminationHandler = { finished in
+            Task { @MainActor [weak self] in
+                self?.serviceDidExit(finished)
+            }
+        }
+
+        let endpoint = ServiceEndpoint(
+            baseURL: URL(string: "http://127.0.0.1:\(port)")!, apiKey: apiKey)
+        if await waitForHealth(endpoint: endpoint, process: process) {
+            state = .running(endpoint)
+            await refreshCapabilities()
+        } else {
+            let tail = log.suffix(6).joined(separator: "\n")
+            stop()
+            state = .failed(
+                "The service did not become healthy."
+                    + (tail.isEmpty ? "" : "\n\n\(tail)"))
+        }
+    }
+
+    private func attachToExternalService(settings: AppSettings) async {
+        guard let url = URL(string: settings.externalServiceURL),
+            url.scheme != nil, url.host != nil
+        else {
+            state = .failed("\(settings.externalServiceURL) is not a valid service URL.")
+            return
+        }
+        let key = settings.externalAPIKey.isEmpty ? nil : settings.externalAPIKey
+        let endpoint = ServiceEndpoint(baseURL: url, apiKey: key)
+        let client = ServiceClient(endpoint: endpoint, session: session)
+        do {
+            _ = try await client.health()
+            state = .running(endpoint)
+            await refreshCapabilities()
+        } catch {
+            state = .failed("Could not reach \(url.absoluteString): \(error.localizedDescription)")
+        }
+    }
+
+    func stop() {
+        if let process {
+            (process.standardError as? Pipe)?.fileHandleForReading.readabilityHandler = nil
+            if process.isRunning { process.terminate() }
+            ProcessRegistry.shared.forget(process)
+        }
+        process = nil
+        capabilities = nil
+        state = .idle
+    }
+
+    /// Called when the interpreter exits on its own — a crash, a port grab, a
+    /// user killing it from Activity Monitor. Without this the UI would keep
+    /// claiming the service is ready.
+    private func serviceDidExit(_ finished: Process) {
+        ProcessRegistry.shared.forget(finished)
+        guard process === finished else { return }
+        process = nil
+        capabilities = nil
+        guard state.isRunning else { return }
+        let tail = log.suffix(4).joined(separator: "\n")
+        state = .failed(
+            "The service stopped unexpectedly (exit \(finished.terminationStatus))."
+                + (tail.isEmpty ? "" : "\n\n\(tail)"))
+    }
+
+    func restart(settings: AppSettings) async {
+        stop()
+        await start(settings: settings)
+    }
+
+    func refreshCapabilities() async {
+        guard let client else { return }
+        capabilities = try? await client.capabilities()
+    }
+
+    // MARK: - Helpers
+
+    private func waitForHealth(endpoint: ServiceEndpoint, process: Process) async -> Bool {
+        let client = ServiceClient(endpoint: endpoint, session: session)
+        let deadline = Date().addingTimeInterval(20)
+        while Date() < deadline {
+            if !process.isRunning { return false }
+            if (try? await client.health()) != nil { return true }
+            try? await Task.sleep(nanoseconds: 200_000_000)
+        }
+        return false
+    }
+
+    private func appendLog(_ text: String) {
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: true).map(String.init)
+        log.append(contentsOf: lines)
+        if log.count > 200 { log.removeFirst(log.count - 200) }
+    }
+
+    private static func makeAPIKey() -> String {
+        var generator = SystemRandomNumberGenerator()
+        return (0..<4)
+            .map { _ in String(UInt64.random(in: UInt64.min...UInt64.max, using: &generator), radix: 16) }
+            .joined()
+    }
+}

--- a/app/macos/Sources/WatermarksRemover/Views/Components.swift
+++ b/app/macos/Sources/WatermarksRemover/Views/Components.swift
@@ -1,0 +1,140 @@
+import SwiftUI
+
+/// A titled panel used throughout the detail pane.
+struct Card<Content: View>: View {
+    let title: String
+    var symbol: String?
+    var accessory: String?
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 6) {
+                if let symbol {
+                    Image(systemName: symbol)
+                        .foregroundStyle(.secondary)
+                }
+                Text(title)
+                    .font(.headline)
+                Spacer()
+                if let accessory {
+                    Text(accessory)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            content()
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color(nsColor: .controlBackgroundColor))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .strokeBorder(Color.primary.opacity(0.07))
+        )
+    }
+}
+
+/// Small pill for a count or a label.
+struct Chip: View {
+    let text: String
+    var tint: Color = .secondary
+
+    var body: some View {
+        Text(text)
+            .font(.caption)
+            .fontWeight(.medium)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+            .background(tint.opacity(0.14), in: Capsule())
+            .foregroundStyle(tint)
+    }
+}
+
+extension Confidence {
+    var tint: Color {
+        switch self {
+        case .high: return .red
+        case .medium: return .orange
+        case .low: return .yellow
+        case .unknown: return .secondary
+        }
+    }
+}
+
+/// Headline number with a caption, used in the summary row.
+struct StatTile: View {
+    let value: String
+    let caption: String
+    var tint: Color = .primary
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(value)
+                .font(.system(size: 22, weight: .semibold, design: .rounded))
+                .foregroundStyle(tint)
+            Text(caption)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 10)
+        .padding(.horizontal, 12)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(tint.opacity(0.08))
+        )
+    }
+}
+
+/// Collapsible pretty-printed JSON, so nothing the service reports is hidden.
+struct RawReportView: View {
+    let title: String
+    let value: JSONValue
+    @State private var expanded = false
+
+    var body: some View {
+        DisclosureGroup(isExpanded: $expanded) {
+            ScrollView([.horizontal, .vertical]) {
+                Text(value.prettyPrinted)
+                    .font(.system(.caption, design: .monospaced))
+                    .textSelection(.enabled)
+                    .padding(8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .frame(maxHeight: 260)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(Color(nsColor: .textBackgroundColor))
+            )
+        } label: {
+            Text(title)
+                .font(.subheadline)
+        }
+    }
+}
+
+/// A dot that reads at a glance in the file list.
+struct StatusDot: View {
+    let item: FileItem
+
+    var body: some View {
+        Circle()
+            .fill(tint)
+            .frame(width: 8, height: 8)
+            .overlay(Circle().strokeBorder(Color.black.opacity(0.08)))
+    }
+
+    private var tint: Color {
+        switch item.status {
+        case .queued: return .secondary.opacity(0.5)
+        case .working: return .blue
+        case .failed: return .red
+        case .inspected: return item.isSuspicious ? .orange : .green
+        case .cleaned: return .green
+        }
+    }
+}

--- a/app/macos/Sources/WatermarksRemover/Views/ContentView.swift
+++ b/app/macos/Sources/WatermarksRemover/Views/ContentView.swift
@@ -1,0 +1,118 @@
+import AppKit
+import SwiftUI
+
+struct ContentView: View {
+    @EnvironmentObject private var model: AppModel
+    @ObservedObject var service: ServiceController
+    @State private var mode: WorkspaceMode = .files
+    @State private var showingOptions = false
+    @State private var confirmingInPlace = false
+
+    var body: some View {
+        NavigationSplitView {
+            SidebarView(mode: $mode)
+        } detail: {
+            Group {
+                switch mode {
+                case .files: DetailView()
+                case .text: ScratchpadView()
+                }
+            }
+            .frame(minWidth: 460, minHeight: 380)
+        }
+        .navigationTitle("Watermarks Remover")
+        .toolbar { toolbarContent }
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            StatusFooter(service: service)
+        }
+        .alert(
+            model.alert?.title ?? "",
+            isPresented: Binding(
+                get: { model.alert != nil },
+                set: { if !$0 { model.alert = nil } }),
+            presenting: model.alert
+        ) { _ in
+            Button("OK", role: .cancel) {}
+        } message: { alert in
+            Text(alert.message)
+        }
+        .confirmationDialog(
+            "Replace the original files?",
+            isPresented: $confirmingInPlace,
+            titleVisibility: .visible
+        ) {
+            Button("Replace \(model.actionTargets.count) file(s)", role: .destructive) {
+                Task { await model.clean(ids: model.actionTargets) }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Cleaned bytes overwrite the source files. This cannot be undone.")
+        }
+        .task {
+            if !service.state.isRunning {
+                await service.start(settings: model.settings)
+            }
+        }
+    }
+
+    @ToolbarContentBuilder
+    private var toolbarContent: some ToolbarContent {
+        ToolbarItemGroup(placement: .navigation) {
+            Button {
+                addFiles()
+            } label: {
+                Label("Add Files", systemImage: "plus")
+            }
+            .help("Add files or folders to the queue")
+            .disabled(mode == .text)
+        }
+
+        ToolbarItemGroup(placement: .primaryAction) {
+            Button {
+                Task { await model.inspectAll() }
+            } label: {
+                Label("Inspect", systemImage: "magnifyingglass")
+            }
+            .disabled(!canRun)
+
+            Button {
+                startClean()
+            } label: {
+                Label("Clean", systemImage: "sparkles")
+            }
+            .disabled(!canRun)
+
+            Button {
+                showingOptions = true
+            } label: {
+                Label("Options", systemImage: "slider.horizontal.3")
+            }
+            .popover(isPresented: $showingOptions, arrowEdge: .bottom) {
+                OptionsPopover(settings: model.settings, capabilities: service.capabilities)
+                    .environmentObject(model)
+            }
+        }
+    }
+
+    private var canRun: Bool {
+        mode == .files && !model.items.isEmpty && !model.isProcessing && service.state.isRunning
+    }
+
+    private func startClean() {
+        if model.settings.outputMode == .inPlace {
+            confirmingInPlace = true
+        } else {
+            Task { await model.clean(ids: model.actionTargets) }
+        }
+    }
+
+    private func addFiles() {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = true
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = true
+        if panel.runModal() == .OK {
+            model.add(urls: panel.urls)
+        }
+    }
+}

--- a/app/macos/Sources/WatermarksRemover/Views/DetailView.swift
+++ b/app/macos/Sources/WatermarksRemover/Views/DetailView.swift
@@ -1,0 +1,392 @@
+import SwiftUI
+
+/// The right-hand pane: what the service found, and what it changed.
+struct DetailView: View {
+    @EnvironmentObject private var model: AppModel
+
+    var body: some View {
+        Group {
+            if let item = model.selectedItem {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 16) {
+                        header(item)
+                        if model.selection.count > 1 {
+                            multiSelectionNotice
+                        }
+                        if case .failed(let message) = item.status {
+                            failureCard(message)
+                        }
+                        if let inspection = item.inspection {
+                            InspectionCards(inspection: inspection)
+                        } else if !item.status.isBusy {
+                            Card(title: "Not inspected yet", symbol: "clock") {
+                                Text("Run Inspect to see what this file carries.")
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        if let cleanResult = item.cleanResult {
+                            CleanCards(result: cleanResult, outputURL: item.outputURL)
+                        }
+                    }
+                    .padding(18)
+                }
+            } else {
+                emptyState
+            }
+        }
+        .frame(minWidth: 420)
+    }
+
+    private func header(_ item: FileItem) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                Image(systemName: item.kind.symbol)
+                    .font(.title2)
+                    .foregroundStyle(.tint)
+                Text(item.name)
+                    .font(.title2)
+                    .fontWeight(.semibold)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                if item.status.isBusy { ProgressView().controlSize(.small) }
+            }
+            HStack(spacing: 8) {
+                Chip(text: item.kind.label)
+                Chip(
+                    text: ByteCountFormatter.string(
+                        fromByteCount: Int64(item.byteCount), countStyle: .file))
+                if let inspection = item.inspection {
+                    Chip(
+                        text: inspection.suspicious ? "Marks found" : "Clean",
+                        tint: inspection.suspicious ? .orange : .green)
+                }
+                Spacer()
+                Button {
+                    model.reveal(item.outputURL ?? item.url)
+                } label: {
+                    Label("Reveal", systemImage: "folder")
+                }
+                .buttonStyle(.borderless)
+            }
+            Text(item.url.deletingLastPathComponent().path)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
+    }
+
+    private var multiSelectionNotice: some View {
+        Label(
+            "\(model.selection.count) files selected — actions apply to all of them.",
+            systemImage: "square.stack.3d.up"
+        )
+        .font(.callout)
+        .foregroundStyle(.secondary)
+    }
+
+    private func failureCard(_ message: String) -> some View {
+        Card(title: "Failed", symbol: "exclamationmark.triangle") {
+            Text(message)
+                .foregroundStyle(.red)
+                .textSelection(.enabled)
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "shield.lefthalf.filled")
+                .font(.system(size: 42, weight: .light))
+                .foregroundStyle(.tint)
+            Text("Nothing selected")
+                .font(.title3)
+                .fontWeight(.medium)
+            Text("Add files on the left, or switch to the text scratchpad.")
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+/// Inspection results, one card per layer of the pipeline.
+struct InspectionCards: View {
+    let inspection: InspectSummary
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            summary
+            if !inspection.hits.isEmpty { hitsCard }
+            if !inspection.findings.isEmpty { findingsCard }
+            if let stylometry = inspection.stylometry { stylometryCard(stylometry) }
+            if !inspection.detectors.isEmpty { detectorsCard }
+            if !inspection.notes.isEmpty { notesCard }
+            Card(title: "Raw report", symbol: "curlybraces") {
+                RawReportView(title: "Show the service's JSON", value: inspection.raw)
+            }
+        }
+    }
+
+    private var summary: some View {
+        HStack(spacing: 10) {
+            StatTile(
+                value: "\(inspection.layerATotal)",
+                caption: "Hidden characters",
+                tint: inspection.layerATotal > 0 ? .orange : .green)
+            StatTile(
+                value: inspection.hasC2PA ? "Yes" : "No",
+                caption: "C2PA manifest",
+                tint: inspection.hasC2PA ? .orange : .green)
+            StatTile(
+                value: inspection.hasAIMetadata ? "Yes" : "No",
+                caption: "AI metadata",
+                tint: inspection.hasAIMetadata ? .orange : .green)
+            if let stylometry = inspection.stylometry {
+                StatTile(
+                    value: String(format: "%.2f", stylometry.score),
+                    caption: "Stylometry",
+                    tint: stylometry.score >= 0.65 ? .orange : .green)
+            }
+        }
+    }
+
+    private var hitsCard: some View {
+        Card(
+            title: "Layer A — invisible characters", symbol: "eye.slash",
+            accessory: "\(inspection.hits.count) kinds"
+        ) {
+            VStack(spacing: 0) {
+                ForEach(inspection.hits) { hit in
+                    HStack(spacing: 10) {
+                        Text(hit.codepoint)
+                            .font(.system(.caption, design: .monospaced))
+                            .frame(width: 66, alignment: .leading)
+                        Text(hit.label)
+                            .lineLimit(1)
+                        Spacer(minLength: 8)
+                        Chip(text: hit.kind, tint: .secondary)
+                        Chip(text: hit.confidence.label, tint: hit.confidence.tint)
+                        Text("×\(hit.count)")
+                            .font(.callout.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.vertical, 5)
+                    if hit.id != inspection.hits.last?.id { Divider() }
+                }
+            }
+        }
+    }
+
+    private var findingsCard: some View {
+        Card(
+            title: "Metadata findings", symbol: "tag",
+            accessory: inspection.format.map { $0.uppercased() }
+        ) {
+            VStack(alignment: .leading, spacing: 7) {
+                ForEach(inspection.findings) { finding in
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        Chip(text: finding.confidence.label, tint: finding.confidence.tint)
+                        Text(finding.text)
+                            .textSelection(.enabled)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+        }
+    }
+
+    private func stylometryCard(_ stylometry: StylometrySummary) -> some View {
+        Card(
+            title: "Layer B — stylometry", symbol: "waveform.path.ecg",
+            accessory: stylometry.status
+        ) {
+            VStack(alignment: .leading, spacing: 10) {
+                Gauge(value: min(max(stylometry.score, 0), 1)) {
+                    Text("LLM-likeness")
+                } currentValueLabel: {
+                    Text(String(format: "%.2f", stylometry.score))
+                }
+                .gaugeStyle(.accessoryLinearCapacity)
+                .tint(stylometry.score >= 0.65 ? .orange : .green)
+
+                HStack(spacing: 14) {
+                    LabeledContent("Confidence", value: stylometry.confidenceLevel)
+                    LabeledContent("Words", value: "\(stylometry.wordCount)")
+                    LabeledContent(
+                        "Burstiness",
+                        value: stylometry.burstiness.map { String(format: "%.2f", $0) }
+                            ?? "unmeasurable")
+                    LabeledContent(
+                        "Diversity", value: String(format: "%.2f", stylometry.lexicalDiversity))
+                }
+                .font(.callout)
+
+                if !stylometry.markers.isEmpty {
+                    Text("Marker phrases")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    FlowText(items: Array(stylometry.markers.prefix(24)))
+                }
+                Text(
+                    "Stylometry is a heuristic on writing style, not a watermark detector. "
+                        + "A high score is a prompt to rewrite (Layer B), never proof."
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var detectorsCard: some View {
+        Card(title: "Watermark detectors", symbol: "antenna.radiowaves.left.and.right") {
+            VStack(spacing: 0) {
+                ForEach(inspection.detectors) { detector in
+                    HStack {
+                        Text(detector.name)
+                        Spacer()
+                        if !detector.available {
+                            Chip(text: "not configured")
+                        } else if let watermarked = detector.watermarked {
+                            Chip(
+                                text: watermarked ? "watermarked" : "no mark",
+                                tint: watermarked ? .red : .green)
+                        }
+                        if let detail = detector.detail {
+                            Text(detail)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                    if detector.id != inspection.detectors.last?.id { Divider() }
+                }
+            }
+        }
+    }
+
+    private var notesCard: some View {
+        Card(title: "Notes", symbol: "info.circle") {
+            VStack(alignment: .leading, spacing: 5) {
+                ForEach(inspection.notes, id: \.self) { note in
+                    Text("• \(note)")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+    }
+}
+
+/// What the clean pass changed.
+struct CleanCards: View {
+    let result: CleanSummary
+    let outputURL: URL?
+    @EnvironmentObject private var model: AppModel
+
+    var body: some View {
+        Card(title: "Cleaned", symbol: "sparkles", accessory: result.headline) {
+            VStack(alignment: .leading, spacing: 12) {
+                if result.removedCount > 0 || result.replacedCount > 0 {
+                    HStack(spacing: 10) {
+                        StatTile(value: "\(result.removedCount)", caption: "Removed", tint: .blue)
+                        StatTile(value: "\(result.replacedCount)", caption: "Replaced", tint: .blue)
+                        if let bytesIn = result.bytesIn, let bytesOut = result.bytesOut {
+                            StatTile(
+                                value: "\(bytesIn - bytesOut) B",
+                                caption: "Size delta", tint: .blue)
+                        }
+                    }
+                }
+                if !result.removedLabels.isEmpty {
+                    FlowText(items: result.removedLabels.map { "\($0.0) ×\($0.1)" })
+                }
+                if !result.actions.isEmpty {
+                    VStack(alignment: .leading, spacing: 5) {
+                        ForEach(result.actions, id: \.self) { action in
+                            Label(action, systemImage: "checkmark.circle")
+                                .font(.callout)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                }
+                if result.stillHasC2PA || result.stillHasAIMetadata {
+                    Label(
+                        "The service still sees provenance data after cleaning. "
+                            + "Install exiftool and qpdf for a full strip.",
+                        systemImage: "exclamationmark.triangle"
+                    )
+                    .foregroundStyle(.orange)
+                    .font(.callout)
+                }
+                if let outputURL {
+                    HStack {
+                        Text(outputURL.lastPathComponent)
+                            .font(.callout)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        Spacer()
+                        Button("Reveal") { model.reveal(outputURL) }
+                            .buttonStyle(.borderless)
+                    }
+                }
+                RawReportView(title: "Show the clean report", value: result.raw)
+            }
+        }
+    }
+}
+
+/// Wrapping row of small labels. `Layout` keeps it to one pass and avoids the
+/// nested-GeometryReader tricks these usually need.
+struct FlowText: View {
+    let items: [String]
+
+    var body: some View {
+        FlowLayout(spacing: 6) {
+            ForEach(items, id: \.self) { item in
+                Chip(text: item)
+            }
+        }
+    }
+}
+
+struct FlowLayout: Layout {
+    var spacing: CGFloat = 6
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let width = proposal.width ?? 400
+        var rowWidth: CGFloat = 0
+        var rowHeight: CGFloat = 0
+        var total: CGFloat = 0
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if rowWidth > 0, rowWidth + spacing + size.width > width {
+                total += rowHeight + spacing
+                rowWidth = size.width
+                rowHeight = size.height
+            } else {
+                rowWidth += (rowWidth > 0 ? spacing : 0) + size.width
+                rowHeight = max(rowHeight, size.height)
+            }
+        }
+        return CGSize(width: width, height: total + rowHeight)
+    }
+
+    func placeSubviews(
+        in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()
+    ) {
+        var x = bounds.minX
+        var y = bounds.minY
+        var rowHeight: CGFloat = 0
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if x > bounds.minX, x + size.width > bounds.maxX {
+                x = bounds.minX
+                y += rowHeight + spacing
+                rowHeight = 0
+            }
+            subview.place(at: CGPoint(x: x, y: y), proposal: ProposedViewSize(size))
+            x += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+        }
+    }
+}

--- a/app/macos/Sources/WatermarksRemover/Views/OptionsPopover.swift
+++ b/app/macos/Sources/WatermarksRemover/Views/OptionsPopover.swift
@@ -1,0 +1,88 @@
+import AppKit
+import SwiftUI
+
+/// The clean-options popover hanging off the toolbar.
+struct OptionsPopover: View {
+    @EnvironmentObject private var model: AppModel
+    @ObservedObject var settings: AppSettings
+    let capabilities: Capabilities?
+
+    var body: some View {
+        Form {
+            Section("Text") {
+                Toggle("Unicode NFKC normalization", isOn: $model.options.nfkc)
+                    .help("Folds compatibility forms. Changes more than invisible characters.")
+                Toggle("Fold look-alike letters", isOn: $model.options.aggressiveHomoglyphs)
+                    .help("Aggressive homoglyph mapping — can alter legitimate non-Latin text.")
+                Toggle("Scrub text bodies inside documents", isOn: $model.options.alsoLayerAText)
+                    .help("Runs the Layer A pass on Markdown and HTML bodies too.")
+            }
+
+            Section("Metadata") {
+                Toggle("Keep non-AI metadata", isOn: $model.options.keepNonAIMetadata)
+                    .help("Preserves camera and authoring metadata; strips only AI provenance.")
+            }
+
+            Section("Images") {
+                Picker("Pixel watermark removal", selection: $model.options.pixelRemover) {
+                    ForEach(PixelRemover.allCases) { remover in
+                        Text(remover.label).tag(remover)
+                    }
+                }
+                .disabled(capabilities?.pixelBackendAvailable != true)
+                if capabilities?.pixelBackendAvailable != true {
+                    Text("No pixel backend configured. See the repo's Docker profiles.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Section("Detectors") {
+                Toggle("Run detectors when inspecting", isOn: $settings.runDetectorsOnInspect)
+                Toggle("Detect before cleaning", isOn: $model.options.detectBefore)
+                Toggle("Detect after cleaning", isOn: $model.options.detectAfter)
+                Text(
+                    "Detectors are opt-in because some of them send your text to a vendor API."
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+
+            Section("Output") {
+                Picker("Write cleaned files", selection: $settings.outputMode) {
+                    ForEach(OutputMode.allCases) { mode in
+                        Text(mode.label).tag(mode)
+                    }
+                }
+                Text(settings.outputMode.detail)
+                    .font(.caption)
+                    .foregroundStyle(settings.outputMode == .inPlace ? .orange : .secondary)
+                if settings.outputMode == .folder {
+                    HStack {
+                        Text(
+                            settings.outputFolderPath.isEmpty
+                                ? "No folder chosen" : settings.outputFolderPath
+                        )
+                        .font(.caption)
+                        .lineLimit(1)
+                        .truncationMode(.head)
+                        Spacer()
+                        Button("Choose…") { chooseFolder() }
+                    }
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .frame(width: 380, height: 480)
+    }
+
+    private func chooseFolder() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.canCreateDirectories = true
+        if panel.runModal() == .OK, let url = panel.url {
+            settings.outputFolderPath = url.path
+        }
+    }
+}

--- a/app/macos/Sources/WatermarksRemover/Views/ScratchpadView.swift
+++ b/app/macos/Sources/WatermarksRemover/Views/ScratchpadView.swift
@@ -1,0 +1,189 @@
+import AppKit
+import SwiftUI
+
+/// Paste-in text, inspected and cleaned entirely in memory.
+struct ScratchpadView: View {
+    @EnvironmentObject private var model: AppModel
+    @State private var input = ""
+    @State private var cleaned = ""
+    @State private var inspection: InspectSummary?
+    @State private var cleanSummary: CleanSummary?
+    @State private var busy = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        HSplitView {
+            editorPane
+            resultPane
+        }
+    }
+
+    private var editorPane: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text("Draft")
+                    .font(.headline)
+                Spacer()
+                Text("\(input.count) characters")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(12)
+
+            TextEditor(text: $input)
+                .font(.system(.body, design: .monospaced))
+                .padding(6)
+
+            Divider()
+
+            HStack(spacing: 10) {
+                Group {
+                    Button {
+                        Task { await inspect() }
+                    } label: {
+                        Label("Inspect", systemImage: "magnifyingglass")
+                    }
+                    Button {
+                        Task { await clean() }
+                    } label: {
+                        Label("Clean", systemImage: "sparkles")
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+                .disabled(busy || input.isEmpty)
+                if busy { ProgressView().controlSize(.small) }
+                Spacer()
+                Button("Paste") { paste() }
+                    .disabled(busy)
+                Button("Clear") { reset() }
+                    .disabled(busy || input.isEmpty)
+            }
+            .padding(12)
+        }
+        .frame(minWidth: 320)
+    }
+
+    private var resultPane: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                if let errorMessage {
+                    Card(title: "Failed", symbol: "exclamationmark.triangle") {
+                        Text(errorMessage).foregroundStyle(.red)
+                    }
+                }
+                if let inspection {
+                    InspectionCards(inspection: inspection)
+                }
+                if let cleanSummary {
+                    Card(title: "Cleaned text", symbol: "text.badge.checkmark",
+                         accessory: cleanSummary.headline) {
+                        VStack(alignment: .leading, spacing: 10) {
+                            HStack(spacing: 10) {
+                                StatTile(
+                                    value: "\(cleanSummary.removedCount)", caption: "Removed",
+                                    tint: .blue)
+                                StatTile(
+                                    value: "\(cleanSummary.replacedCount)", caption: "Replaced",
+                                    tint: .blue)
+                            }
+                            if !cleanSummary.removedLabels.isEmpty {
+                                FlowText(items: cleanSummary.removedLabels.map { "\($0.0) ×\($0.1)" })
+                            }
+                            ScrollView {
+                                Text(cleaned)
+                                    .font(.system(.body, design: .monospaced))
+                                    .textSelection(.enabled)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .padding(8)
+                            }
+                            .frame(maxHeight: 240)
+                            .background(
+                                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                    .fill(Color(nsColor: .textBackgroundColor)))
+                            HStack {
+                                Button {
+                                    copyCleaned()
+                                } label: {
+                                    Label("Copy cleaned text", systemImage: "doc.on.doc")
+                                }
+                                Button("Replace draft") { input = cleaned }
+                            }
+                        }
+                    }
+                }
+                if inspection == nil && cleanSummary == nil && errorMessage == nil {
+                    VStack(spacing: 8) {
+                        Image(systemName: "text.magnifyingglass")
+                            .font(.system(size: 34, weight: .light))
+                            .foregroundStyle(.tint)
+                        Text("Nothing inspected yet")
+                            .font(.headline)
+                        Text("Paste a draft on the left, then Inspect or Clean.")
+                            .foregroundStyle(.secondary)
+                    }
+                    .frame(maxWidth: .infinity, minHeight: 260)
+                }
+            }
+            .padding(18)
+        }
+        .frame(minWidth: 380)
+    }
+
+    // MARK: - Actions
+
+    private func inspect() async {
+        guard let client = model.service.client else {
+            errorMessage = "The service is not running."
+            return
+        }
+        busy = true
+        defer { busy = false }
+        errorMessage = nil
+        do {
+            let result = try await client.inspect(
+                data: Data(input.utf8), name: "scratchpad.txt",
+                detect: model.settings.runDetectorsOnInspect)
+            inspection = InspectSummary(
+                kind: result.kind, suspicious: result.suspicious, report: result.report)
+        } catch {
+            errorMessage = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+        }
+    }
+
+    private func clean() async {
+        guard let client = model.service.client else {
+            errorMessage = "The service is not running."
+            return
+        }
+        busy = true
+        defer { busy = false }
+        errorMessage = nil
+        do {
+            let result = try await client.clean(
+                data: Data(input.utf8), name: "scratchpad.txt", options: model.options)
+            cleaned = String(decoding: result.cleaned, as: UTF8.self)
+            cleanSummary = CleanSummary(kind: result.kind, report: result.report)
+        } catch {
+            errorMessage = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+        }
+    }
+
+    private func paste() {
+        if let text = NSPasteboard.general.string(forType: .string) {
+            input = text
+        }
+    }
+
+    private func copyCleaned() {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(cleaned, forType: .string)
+    }
+
+    private func reset() {
+        input = ""
+        cleaned = ""
+        inspection = nil
+        cleanSummary = nil
+        errorMessage = nil
+    }
+}

--- a/app/macos/Sources/WatermarksRemover/Views/SettingsView.swift
+++ b/app/macos/Sources/WatermarksRemover/Views/SettingsView.swift
@@ -1,0 +1,108 @@
+import AppKit
+import SwiftUI
+
+struct SettingsView: View {
+    @ObservedObject var settings: AppSettings
+    @ObservedObject var service: ServiceController
+    @State private var probeResult: String?
+
+    var body: some View {
+        TabView {
+            general.tabItem { Label("General", systemImage: "gearshape") }
+            serviceTab.tabItem { Label("Service", systemImage: "server.rack") }
+        }
+        .frame(width: 480, height: 380)
+    }
+
+    private var general: some View {
+        Form {
+            Section("Queue") {
+                Toggle("Inspect files as soon as they are added", isOn: $settings.autoInspectOnAdd)
+                Toggle("Run watermark detectors when inspecting", isOn: $settings.runDetectorsOnInspect)
+                Text("Some detectors send text to a vendor API. Leave this off for private drafts.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Section("Output") {
+                Picker("Write cleaned files", selection: $settings.outputMode) {
+                    ForEach(OutputMode.allCases) { mode in
+                        Text(mode.label).tag(mode)
+                    }
+                }
+                Text(settings.outputMode.detail)
+                    .font(.caption)
+                    .foregroundStyle(settings.outputMode == .inPlace ? .orange : .secondary)
+                if settings.outputMode == .folder {
+                    HStack {
+                        Text(settings.outputFolderPath.isEmpty ? "No folder chosen" : settings.outputFolderPath)
+                            .lineLimit(1)
+                            .truncationMode(.head)
+                        Spacer()
+                        Button("Choose…") { chooseFolder() }
+                    }
+                }
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    private var serviceTab: some View {
+        Form {
+            Section("Local service") {
+                HStack {
+                    TextField("Python path", text: $settings.pythonPath, prompt: Text("Auto-detect"))
+                    Button("Test") { probe() }
+                }
+                if let probeResult {
+                    Text(probeResult)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Text(
+                    "The app starts service/scripts/server.py on a private loopback port with a "
+                        + "one-off bearer token. Nothing leaves your Mac unless you enable a "
+                        + "vendor detector."
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+            Section("Use a service I already run") {
+                Toggle("Connect to an existing service", isOn: $settings.useExternalService)
+                TextField("URL", text: $settings.externalServiceURL)
+                    .disabled(!settings.useExternalService)
+                SecureField("API key (optional)", text: $settings.externalAPIKey)
+                    .disabled(!settings.useExternalService)
+            }
+            Section {
+                HStack {
+                    Text(service.state.label)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Button("Restart service") {
+                        Task { await service.restart(settings: settings) }
+                    }
+                }
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    private func probe() {
+        let path = settings.pythonPath.isEmpty ? nil : settings.pythonPath
+        if let interpreter = PythonLocator.discover(preferred: path) {
+            probeResult = "Found Python \(interpreter.version) at \(interpreter.url.path)"
+        } else {
+            probeResult = "No usable Python 3.10+ found. Try `brew install python`."
+        }
+    }
+
+    private func chooseFolder() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.canCreateDirectories = true
+        if panel.runModal() == .OK, let url = panel.url {
+            settings.outputFolderPath = url.path
+        }
+    }
+}

--- a/app/macos/Sources/WatermarksRemover/Views/SidebarView.swift
+++ b/app/macos/Sources/WatermarksRemover/Views/SidebarView.swift
@@ -1,0 +1,184 @@
+import AppKit
+import SwiftUI
+
+struct SidebarView: View {
+    @EnvironmentObject private var model: AppModel
+    @Binding var mode: WorkspaceMode
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Picker("", selection: $mode) {
+                ForEach(WorkspaceMode.allCases) { value in
+                    Text(value.label).tag(value)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .padding(10)
+
+            if mode == .files {
+                fileList
+            } else {
+                scratchpadHint
+            }
+        }
+        .frame(minWidth: 260)
+    }
+
+    @ViewBuilder
+    private var fileList: some View {
+        if model.items.isEmpty {
+            DropZone()
+                .padding(12)
+        } else {
+            List(selection: $model.selection) {
+                ForEach(model.items) { item in
+                    FileRow(item: item)
+                        .tag(item.id)
+                        .contextMenu {
+                            Button("Reveal in Finder") { model.reveal(item.url) }
+                            if let output = item.outputURL {
+                                Button("Reveal Cleaned File") { model.reveal(output) }
+                            }
+                            Divider()
+                            Button("Remove from List") { model.remove(ids: [item.id]) }
+                        }
+                }
+            }
+            .listStyle(.sidebar)
+            .onDeleteCommand { model.remove(ids: model.selection) }
+            .overlay(alignment: .bottom) {
+                DropHintBar()
+            }
+        }
+    }
+
+    private var scratchpadHint: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Text scratchpad")
+                .font(.headline)
+            Text(
+                "Paste anything you are about to publish. The scratchpad runs the "
+                    + "same Layer A pass as the file queue, without touching disk."
+            )
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            Spacer()
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+enum WorkspaceMode: String, CaseIterable, Identifiable {
+    case files
+    case text
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .files: return "Files"
+        case .text: return "Text"
+        }
+    }
+}
+
+struct FileRow: View {
+    let item: FileItem
+
+    var body: some View {
+        HStack(spacing: 9) {
+            StatusDot(item: item)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.name)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Text(item.subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+            Spacer(minLength: 4)
+            if item.status.isBusy {
+                ProgressView()
+                    .controlSize(.small)
+            } else if let inspection = item.inspection {
+                Image(systemName: inspection.kind.symbol)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 3)
+    }
+}
+
+/// The always-available "drop more files here" strip under a populated list.
+private struct DropHintBar: View {
+    @EnvironmentObject private var model: AppModel
+    @State private var targeted = false
+
+    var body: some View {
+        Text(targeted ? "Release to add" : "Drop more files here")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 7)
+            .background(.ultraThinMaterial)
+            .overlay(alignment: .top) { Divider() }
+            .dropDestination(for: URL.self) { urls, _ in
+                model.add(urls: urls)
+                return true
+            } isTargeted: { targeted = $0 }
+    }
+}
+
+/// The empty-state target: the app's front door.
+struct DropZone: View {
+    @EnvironmentObject private var model: AppModel
+    @State private var targeted = false
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "square.and.arrow.down.on.square")
+                .font(.system(size: 34, weight: .light))
+                .foregroundStyle(targeted ? Color.accentColor : .secondary)
+            VStack(spacing: 4) {
+                Text("Drop files or folders")
+                    .font(.headline)
+                Text("Text, images, documents, audio and video")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+            Button("Choose Files…") { chooseFiles() }
+                .buttonStyle(.borderedProminent)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(20)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(Color.accentColor.opacity(targeted ? 0.12 : 0.04))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .strokeBorder(
+                    targeted ? Color.accentColor : Color.secondary.opacity(0.35),
+                    style: StrokeStyle(lineWidth: 1.5, dash: [6, 5]))
+        )
+        .dropDestination(for: URL.self) { urls, _ in
+            model.add(urls: urls)
+            return true
+        } isTargeted: { targeted = $0 }
+    }
+
+    private func chooseFiles() {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = true
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = true
+        panel.message = "Select the files you want to inspect or clean."
+        if panel.runModal() == .OK {
+            model.add(urls: panel.urls)
+        }
+    }
+}

--- a/app/macos/Sources/WatermarksRemover/Views/StatusFooter.swift
+++ b/app/macos/Sources/WatermarksRemover/Views/StatusFooter.swift
@@ -1,0 +1,192 @@
+import SwiftUI
+
+/// The window's bottom bar: service state, capabilities, progress.
+struct StatusFooter: View {
+    @EnvironmentObject private var model: AppModel
+    @ObservedObject var service: ServiceController
+    @State private var showingCapabilities = false
+    @State private var showingLog = false
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Circle()
+                .fill(stateColor)
+                .frame(width: 8, height: 8)
+            Text(statusText)
+                .font(.callout)
+                .lineLimit(1)
+
+            if case .failed(let message) = service.state {
+                Button {
+                    showingLog = true
+                } label: {
+                    Image(systemName: "info.circle")
+                }
+                .buttonStyle(.borderless)
+                .help(message)
+            }
+
+            if let progress = model.progress {
+                ProgressView(value: Double(progress.done), total: Double(progress.total))
+                    .progressViewStyle(.linear)
+                    .frame(width: 130)
+                Text("\(progress.done)/\(progress.total)")
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            if !model.items.isEmpty {
+                Text("\(model.items.count) file\(model.items.count == 1 ? "" : "s")")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                if model.suspiciousCount > 0 {
+                    Chip(text: "\(model.suspiciousCount) with marks", tint: .orange)
+                }
+            }
+
+            Button {
+                showingCapabilities = true
+            } label: {
+                Label("Capabilities", systemImage: "puzzlepiece.extension")
+            }
+            .buttonStyle(.borderless)
+            .popover(isPresented: $showingCapabilities, arrowEdge: .bottom) {
+                CapabilitiesPopover(capabilities: service.capabilities, service: service)
+            }
+
+            switch service.state {
+            case .running:
+                Button("Stop") { service.stop() }
+                    .buttonStyle(.borderless)
+            case .starting:
+                ProgressView().controlSize(.small)
+            default:
+                Button("Start") {
+                    Task { await service.start(settings: model.settings) }
+                }
+                .buttonStyle(.borderless)
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .background(.bar)
+        .overlay(alignment: .top) { Divider() }
+        .sheet(isPresented: $showingLog) {
+            ServiceLogSheet(service: service)
+        }
+    }
+
+    private var statusText: String {
+        switch service.state {
+        case .running:
+            let version = service.capabilities?.version ?? ""
+            let interpreter = service.interpreter.map { "Python \($0.version)" } ?? "external service"
+            return "Service ready" + (version.isEmpty ? "" : " · \(version)") + " · \(interpreter)"
+        case .failed(let message):
+            return message.split(separator: "\n").first.map(String.init) ?? "Service unavailable"
+        default:
+            return service.state.label
+        }
+    }
+
+    private var stateColor: Color {
+        switch service.state {
+        case .running: return .green
+        case .starting: return .yellow
+        case .failed: return .red
+        case .idle: return .secondary
+        }
+    }
+}
+
+struct CapabilitiesPopover: View {
+    let capabilities: Capabilities?
+    @ObservedObject var service: ServiceController
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Service capabilities")
+                .font(.headline)
+            if let capabilities {
+                section("System tools", capabilities.tools)
+                section("Backends and scorers", capabilities.backends)
+                section("Text detectors", capabilities.detectors)
+                Text(
+                    "Missing tools are optional. exiftool and qpdf matter most: without "
+                        + "them PDF cleaning falls back to a partial strip."
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: 320, alignment: .leading)
+            } else {
+                Text("Start the service to see what it can do.")
+                    .foregroundStyle(.secondary)
+            }
+            HStack {
+                Spacer()
+                Button("Refresh") { Task { await service.refreshCapabilities() } }
+                    .disabled(!service.state.isRunning)
+            }
+        }
+        .padding(16)
+        .frame(width: 360)
+    }
+
+    @ViewBuilder
+    private func section(_ title: String, _ items: [Capabilities.Item]) -> some View {
+        if !items.isEmpty {
+            VStack(alignment: .leading, spacing: 5) {
+                Text(title)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                ForEach(items) { item in
+                    HStack(spacing: 7) {
+                        Image(systemName: item.available ? "checkmark.circle.fill" : "circle.dashed")
+                            .foregroundStyle(item.available ? Color.green : Color.secondary)
+                        Text(item.name)
+                        Spacer()
+                        Text(item.hint)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct ServiceLogSheet: View {
+    @ObservedObject var service: ServiceController
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Service log")
+                .font(.headline)
+            if case .failed(let message) = service.state {
+                Text(message)
+                    .foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            ScrollView {
+                Text(service.log.isEmpty ? "No output captured." : service.log.joined(separator: "\n"))
+                    .font(.system(.caption, design: .monospaced))
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .frame(width: 560, height: 260)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(Color(nsColor: .textBackgroundColor)))
+            HStack {
+                Spacer()
+                Button("Done") { dismiss() }
+                    .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(18)
+    }
+}

--- a/app/macos/Sources/WatermarksRemover/WatermarksRemoverApp.swift
+++ b/app/macos/Sources/WatermarksRemover/WatermarksRemoverApp.swift
@@ -1,0 +1,88 @@
+import AppKit
+import SwiftUI
+
+@main
+@MainActor
+struct WatermarksRemoverApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) private var delegate
+    @StateObject private var settings: AppSettings
+    @StateObject private var service: ServiceController
+    @StateObject private var model: AppModel
+
+    init() {
+        let settings = AppSettings()
+        let service = ServiceController()
+        _settings = StateObject(wrappedValue: settings)
+        _service = StateObject(wrappedValue: service)
+        _model = StateObject(wrappedValue: AppModel(settings: settings, service: service))
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView(service: service)
+                .environmentObject(model)
+                .frame(minWidth: 900, minHeight: 560)
+        }
+        .windowToolbarStyle(.unified)
+        .commands { commands }
+
+        Settings {
+            SettingsView(settings: settings, service: service)
+        }
+    }
+
+    @CommandsBuilder
+    private var commands: some Commands {
+        CommandGroup(replacing: .newItem) {}
+        CommandGroup(after: .newItem) {
+            Button("Add Files…") { addFiles() }
+                .keyboardShortcut("o")
+            Divider()
+            Button("Export Report…") { model.exportReport() }
+                .keyboardShortcut("e")
+                .disabled(model.items.isEmpty)
+        }
+        CommandMenu("Service") {
+            Button("Inspect All") { Task { await model.inspectAll() } }
+                .keyboardShortcut("i", modifiers: [.command, .shift])
+            Button("Clean All") { Task { await model.cleanAll() } }
+                .keyboardShortcut("k", modifiers: [.command, .shift])
+            Divider()
+            Button("Restart Service") {
+                Task { await service.restart(settings: settings) }
+            }
+            Button("Stop Service") { service.stop() }
+                .disabled(!service.state.isRunning)
+        }
+        CommandGroup(replacing: .help) {
+            Link(
+                "watermarks-remover on GitHub",
+                destination: URL(string: "https://github.com/guillaumemeyer/watermarks-remover")!)
+            Link(
+                "Responsible use",
+                destination: URL(
+                    string:
+                        "https://github.com/guillaumemeyer/watermarks-remover#responsible-use")!)
+        }
+    }
+
+    private func addFiles() {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = true
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = true
+        if panel.runModal() == .OK {
+            model.add(urls: panel.urls)
+        }
+    }
+}
+
+/// Makes the app quit cleanly: the Python child process is terminated with the
+/// last window, so a crashed or force-quit app never leaves a service listening.
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool { true }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        ProcessRegistry.shared.terminateAll()
+    }
+}

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -1,0 +1,146 @@
+"""Guards on the macOS app wrapper (app/macos).
+
+The Swift front end is a thin client over the same HTTP service the skill
+drives, so the things that can silently break it are contract drifts: an option
+the server stops accepting, an endpoint that moves, a bundled module that stops
+being copied. Swift does not compile here, so these tests read the sources as
+text and check the contract instead.
+"""
+
+from __future__ import annotations
+
+import ast
+import plistlib
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "service" / "scripts"
+APP = ROOT / "app" / "macos"
+sys.path.insert(0, str(SCRIPTS))
+
+import server
+
+pytestmark = pytest.mark.skipif(not APP.exists(), reason="macOS app not present")
+
+
+def _swift_source(*parts: str) -> str:
+    return (APP.joinpath(*parts)).read_text(encoding="utf-8")
+
+
+def test_info_plist_matches_the_swift_product() -> None:
+    with (APP / "Info.plist").open("rb") as handle:
+        info = plistlib.load(handle)
+
+    package = _swift_source("Package.swift")
+    assert 'name: "WatermarksRemover"' in package
+
+    assert info["CFBundleExecutable"] == "WatermarksRemover"
+    assert info["CFBundlePackageType"] == "APPL"
+    assert info["CFBundleIconFile"] == "AppIcon"
+    assert info["LSMinimumSystemVersion"] == "13.0"
+    assert info["CFBundleIdentifier"].startswith("io.github.")
+
+
+def test_clean_options_are_all_accepted_by_the_server() -> None:
+    """Every option key the app sends must be one the server allows."""
+    source = _swift_source("Sources", "WatermarksRemover", "Model", "CleanOptions.swift")
+    body = source.split("var wireOptions:", 1)[1]
+    sent = set(re.findall(r'options\["([a-z_]+)"\]|^\s+"([a-z_]+)":', body, re.MULTILINE))
+    keys = {found for pair in sent for found in pair if found}
+
+    assert keys, "no option keys parsed out of CleanOptions.swift"
+    unknown = keys - set(server.ALLOWED_CLEAN_OPTIONS)
+    assert not unknown, f"app sends options the server rejects: {sorted(unknown)}"
+
+    for key in keys:
+        expected = server.ALLOWED_CLEAN_OPTIONS[key]
+        wire = "string" if expected is str else "bool"
+        assert f'"{key}"' in body
+        # remove_pixel is the only string-valued option; the rest are booleans.
+        assert (key == "remove_pixel") == (wire == "string")
+
+
+def test_pixel_remover_values_match_the_server() -> None:
+    source = _swift_source("Sources", "WatermarksRemover", "Model", "CleanOptions.swift")
+    cases = set(re.findall(r"^\s+case (ctrlregen|diffusion)$", source, re.MULTILINE))
+    assert cases == {"ctrlregen", "diffusion"}
+
+    handler = (SCRIPTS / "server.py").read_text(encoding="utf-8")
+    assert 'remove_pixel not in (None, "ctrlregen", "diffusion")' in handler
+
+
+def test_client_only_calls_endpoints_the_server_routes() -> None:
+    source = _swift_source("Sources", "WatermarksRemover", "Service", "ServiceClient.swift")
+    called = set(re.findall(r'await (?:get|post)\("(/[a-z/]+)"', source))
+    assert called, "no endpoints parsed out of ServiceClient.swift"
+
+    handler = (SCRIPTS / "server.py").read_text(encoding="utf-8")
+    for path in called:
+        assert f'"{path}"' in handler, f"{path} is not routed by server.py"
+
+
+def test_input_cap_matches_the_service() -> None:
+    source = _swift_source("Sources", "WatermarksRemover", "Service", "ServiceClient.swift")
+    match = re.search(r"maxInputBytes = (\d+) << (\d+)", source)
+    assert match, "maxInputBytes not found"
+    app_cap = int(match.group(1)) << int(match.group(2))
+
+    from common import MAX_INPUT_BYTES
+
+    assert app_cap == MAX_INPUT_BYTES
+
+
+def test_api_key_is_passed_through_the_environment_not_argv() -> None:
+    """The server reads WATERMARKS_SERVER_API_KEY, which keeps it out of `ps`."""
+    controller = _swift_source("Sources", "WatermarksRemover", "Service", "ServiceController.swift")
+    assert 'environment["WATERMARKS_SERVER_API_KEY"] = apiKey' in controller
+    assert "--api-key" not in controller
+    assert 'API_KEY = os.environ.get("WATERMARKS_SERVER_API_KEY"' in (
+        SCRIPTS / "server.py"
+    ).read_text(encoding="utf-8")
+
+
+def test_bundle_ships_every_module_the_service_imports() -> None:
+    """build-app.sh copies service/scripts/*.py — check that this is enough."""
+    build = _swift_source("Scripts", "build-app.sh")
+    assert 'cp "$repo"/service/scripts/*.py' in build
+
+    tree = ast.parse((SCRIPTS / "server.py").read_text(encoding="utf-8"))
+    local_modules = {path.stem for path in SCRIPTS.glob("*.py")}
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            imported.add(node.module.split(".")[0])
+        elif isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+
+    for module in imported & local_modules:
+        assert (SCRIPTS / f"{module}.py").exists()
+    # The server's own siblings must be plain modules, not packages, or the
+    # flat *.py copy in build-app.sh would miss them.
+    assert not [path for path in SCRIPTS.iterdir() if path.is_dir() and path.name != "__pycache__"]
+
+
+def test_icon_generator_writes_a_full_iconset(tmp_path: Path) -> None:
+    sys.path.insert(0, str(APP / "Scripts"))
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("make_icon", APP / "Scripts" / "make_icon.py")
+    assert spec and spec.loader
+    make_icon = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(make_icon)
+
+    out = tmp_path / "AppIcon.iconset"
+    out.mkdir()
+    master = make_icon.render(64)
+    for name, size in make_icon.ICONSET_SIZES:
+        if size > 64:
+            continue
+        make_icon.write_png(out / name, make_icon.downsample(master, 64, size), size)
+        written = (out / name).read_bytes()
+        assert written.startswith(b"\x89PNG\r\n\x1a\n")
+        assert len(written) > 100


### PR DESCRIPTION
Adds app/macos: a SwiftUI app (macOS 13+) that wraps the repo's tools instead of reimplementing them. It starts service/scripts/server.py on a kernel-assigned loopback port with a per-launch bearer token and drives the documented /inspect, /clean, /detect and /capabilities endpoints, so it inherits every format and fix from the Python pipeline.

- Queue: drag files or folders in, per-file status, inspect and clean, output next to the original / into a folder / in place (confirmed), JSON export of the whole run.
- Detail: Layer A hits with codepoints and confidence, metadata findings, C2PA / AI-metadata flags, stylometry gauge, detector results, raw report.
- Text scratchpad: inspect and clean pasted drafts in memory.
- Service lifecycle: interpreter discovery (3.10+), API key through the environment rather than argv, PATH extended so Homebrew's exiftool/qpdf are visible, child terminated on quit, unexpected exits surfaced.
- Settings can point the app at a service you already run instead.

Packaging: Scripts/build-app.sh compiles, assembles the bundle, copies service/scripts/*.py into Resources, renders the icon (stdlib-only PNG writer) and ad-hoc signs. make mac-app / mac-app-run wrap it, and CI adds a macos-latest job that builds the bundle and checks its layout.

tests/test_macos_app.py guards the contract from the Python side: clean options, pixel remover values, endpoints, the input cap, the API-key path and the bundled-module set.


Claude-Session: https://claude.ai/code/session_01Nk41GM64UjcWs94ovxuG1i

## What

What does this PR change? One short paragraph, or bullet points if needed.

## Why

The problem this solves, and any related issue.

## Checklist

- [ ] Behaviour matches `SKILL.md` / `references/removal-matrix.md` when relevant
- [ ] Unit tests updated or added under `tests/`
- [ ] `python3 -m pytest -q` passes
- [ ] Docs updated (README and/or skill references) if user-facing behaviour
      changes
- [ ] No drive-by refactors unrelated to the fix or feature

## Notes for the reviewer

Anything unusual: layer involved (A Unicode / B rewrite / Files metadata),
sample files, or redaction you applied. Do not include secrets or material
you do not own.
