### PR TITLE
Detect zip container formats by magic in audit_website.guess_kind (#191)

### DIFF
--- a/service/scripts/audit_website.py
+++ b/service/scripts/audit_website.py
@@ -30,6 +30,7 @@ import contextlib
 
 from audit_lib import aggregate, print_human_report, scan_file
 from common import EXIT_PARTIAL, emit_json, eprint
+from container_meta import detect_container_format
 
 DEFAULT_MAX_BYTES = 4 << 20
 DEFAULT_TIMEOUT = 15
@@ -210,6 +211,10 @@ def guess_kind(url: str, data: bytes, content_type: str | None = None) -> str:
         return "svg"
     if b"<html" in data[:2000].lower() or data[:100].lstrip().lower().startswith(b"<"):
         return "html"
+    if data[:2] == b"PK":
+        container_kind = detect_container_format(Path(path), data)
+        if container_kind != "unknown":
+            return container_kind
     return "text"
 
 

--- a/tests/test_website_format_routing.py
+++ b/tests/test_website_format_routing.py
@@ -77,3 +77,29 @@ def test_webp_marker_reaches_image_scanner_not_text():
 def test_html_still_text_friendly():
     assert audit_website.guess_kind("/x", b"<html><body>hi</body></html>", "text/html") == "html"
     assert audit_website.guess_kind("/page.htm", b"<html>", None) == "html"
+
+
+def _make_dummy_zip_container(files: list[str]) -> bytes:
+    import io
+    import zipfile
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for f in files:
+            zf.writestr(f, b"<dummy/>")
+    return buf.getvalue()
+
+
+def test_zip_containers_classified_by_magic_when_extensionless():
+    for internal_files, expected_kind in [
+        (["word/document.xml"], "docx"),
+        (["xl/workbook.xml"], "xlsx"),
+        (["ppt/presentation.xml"], "pptx"),
+        (["content.xml", "meta.xml"], "odt"),
+        (["META-INF/container.xml", "content.opf"], "epub"),
+    ]:
+        data = _make_dummy_zip_container(internal_files)
+        # Suffix-less URL with generic or missing content type
+        assert audit_website.guess_kind("/export?id=123", data, None) == expected_kind
+        assert audit_website.guess_kind("/download", data, "application/octet-stream") == expected_kind
+        assert audit_website.guess_kind("/download", data, "application/zip") == expected_kind


### PR DESCRIPTION
## Summary
Fixes #191

In `audit_website.py:guess_kind()`, URLs serving ZIP-based container files (DOCX, XLSX, PPTX, EPUB, ODT) without an explicit file extension in the URL path or with generic content types like `application/octet-stream` or `application/zip` had no magic-byte sniffers and fell through to `"text"`. This caused binary ZIP data to be written as `.txt` and scanned as plain text, skipping all container metadata and embedded C2PA/AI provenance inspections.

## Changes
- In `service/scripts/audit_website.py:guess_kind()`, check `if data[:2] == b"PK":` and call `detect_container_format(Path(path), data)` to recognize ZIP-based container documents.
- Added test coverage in `tests/test_website_format_routing.py` verifying extensionless and generic-MIME ZIP container routing for `docx`, `xlsx`, `pptx`, `odt`, and `epub`.

## Validation
- `pytest tests/test_website_format_routing.py` -> 6 passed.