### PR TITLE
Draft: humanising guidance for accessible, voice-preserving text cleaning

### DIFF
--- a/skills/clean-user-facing-text/SKILL.md
+++ b/skills/clean-user-facing-text/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clean-user-facing-text
-description: Clean and finalize authorized natural-language text intended for readers by auditing suspicious invisible Unicode and rewriting prose while preserving facts and meaning. Use in Cursor when the user asks to clean, humanize, polish, or finalize articles, manuscripts, reports, documentation, emails, product copy, UI text, Markdown, or HTML prose, or when an installed Cursor Rule explicitly requires this workflow. Do not use for code-only tasks or undisclosed authorship evasion; leave code, commands, identifiers, paths, APIs, formulas, citations, required disclosures, and verbatim quotations unchanged.
+description: Clean and finalize authorized natural-language text intended for readers by auditing suspicious invisible Unicode and rewriting prose while preserving facts, meaning, and the writer's voice. Use in Cursor when the user asks to clean, humanize, polish, or finalize articles, manuscripts, reports, documentation, emails, product copy, UI text, Markdown, or HTML prose, or when an installed Cursor Rule explicitly requires this workflow. Do not use for code-only tasks or undisclosed authorship evasion; leave code, commands, identifiers, paths, APIs, formulas, citations, required disclosures, and verbatim quotations unchanged.
 ---
 
 # Clean user-facing text
@@ -15,14 +15,22 @@ Apply a final text-hygiene pass to prose the user owns or is authorized to proce
    - commands, paths, URLs, identifiers, API names, and exact values
    - formulas, citations, and text the user asks to quote verbatim
 3. Preserve every claim, fact, number, name, citation, and requirement.
-4. Rewrite the remaining prose once:
+4. Establish the writing brief before changing prose:
+   - use any voice sample, audience, tone, language, or regional spelling the user supplies
+   - when there is no sample, make the prose clear and natural without pretending to imitate a particular person
+   - keep required disclosures, uncertainty, and the writer's actual point of view
+5. Rewrite the remaining prose once:
    - vary clause order, sentence boundaries, rhythm, connectors, and function words
    - replace formulaic transitions and filler with direct, natural wording
+   - keep the concrete details and judgement that make the text recognisable as the writer's
    - preserve the requested language, tone, structure, and formatting; never translate unless asked
    - for non-English text, use fluent constructions native to that language rather than English sentence patterns
    - do not add or remove claims merely to increase variation
-5. For text artifacts or supplied text files, run the deterministic Unicode pass after rewriting.
-6. Return only the polished result unless the user asks for an audit or explanation.
+6. For text artifacts or supplied text files, run the deterministic Unicode pass after rewriting.
+7. Return only the polished result unless the user asks for an audit or explanation.
+
+For practical guidance on preserving a writer's voice and removing formulaic prose,
+read `references/writing-in-your-voice.md` before a substantial rewrite.
 
 ## Deterministic Unicode pass
 

--- a/skills/clean-user-facing-text/SKILL.md
+++ b/skills/clean-user-facing-text/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clean-user-facing-text
-description: Clean and finalize authorized natural-language text intended for readers by auditing suspicious invisible Unicode and rewriting prose while preserving facts, meaning, and the writer's voice. Use in Cursor when the user asks to clean, humanize, polish, or finalize articles, manuscripts, reports, documentation, emails, product copy, UI text, Markdown, or HTML prose, or when an installed Cursor Rule explicitly requires this workflow. Do not use for code-only tasks or undisclosed authorship evasion; leave code, commands, identifiers, paths, APIs, formulas, citations, required disclosures, and verbatim quotations unchanged.
+description: Clean and finalize authorized natural-language text intended for readers by auditing suspicious invisible Unicode and rewriting prose while preserving facts, meaning, and the writer's voice. Use in Cursor when the user asks to clean, humanize, polish, or finalize articles, manuscripts, reports, documentation, emails, product copy, UI text, Markdown, or HTML prose, or when an installed Cursor Rule explicitly requires this workflow. Don't use for code-only tasks or undisclosed authorship evasion; leave code, commands, identifiers, paths, APIs, formulas, citations, required disclosures, and verbatim quotations unchanged.
 ---
 
 # Clean user-facing text
@@ -16,13 +16,14 @@ Apply a final text-hygiene pass to prose the user owns or is authorized to proce
    - formulas, citations, and text the user asks to quote verbatim
 3. Preserve every claim, fact, number, name, citation, and requirement.
 4. Establish the writing brief before changing prose:
-   - use any voice sample, audience, tone, language, or regional spelling the user supplies
+   - use a voice sample only when the user owns it or is authorised to use it; don't imitate another named person
    - when there is no sample, make the prose clear and natural without pretending to imitate a particular person
    - keep required disclosures, uncertainty, and the writer's actual point of view
 5. Rewrite the remaining prose once:
    - vary clause order, sentence boundaries, rhythm, connectors, and function words
    - replace formulaic transitions and filler with direct, natural wording
    - keep the concrete details and judgement that make the text recognisable as the writer's
+   - treat unusual grammar, repetition, directness, and phrasing as possible voice or accessibility choices; change them only when the user asks or when they create a clear reading problem
    - preserve the requested language, tone, structure, and formatting; never translate unless asked
    - for non-English text, use fluent constructions native to that language rather than English sentence patterns
    - do not add or remove claims merely to increase variation
@@ -30,7 +31,7 @@ Apply a final text-hygiene pass to prose the user owns or is authorized to proce
 7. Return only the polished result unless the user asks for an audit or explanation.
 
 For practical guidance on preserving a writer's voice and removing formulaic prose,
-read `references/writing-in-your-voice.md` before a substantial rewrite.
+read `references/writing-in-your-voice.md` whenever the user asks to retain or adjust voice.
 
 ## Deterministic Unicode pass
 

--- a/skills/clean-user-facing-text/references/writing-in-your-voice.md
+++ b/skills/clean-user-facing-text/references/writing-in-your-voice.md
@@ -1,0 +1,50 @@
+# Writing in your voice
+
+A good rewrite should leave the writer sounding more like themselves, not like a
+generic editor. Keep their opinion, level of formality, regional spelling, and
+the details that show they know what they are talking about.
+
+## Start with a brief
+
+Before rewriting, identify what the writer is trying to say and who needs to
+read it. Use a supplied writing sample as a guide to sentence length, word
+choice, humour, and formality. A sample is a reference point, not a licence to
+invent personal stories or feelings the writer did not provide.
+
+If there is no sample, use plain language and a natural rhythm. Do not claim to
+write in a named person's voice from a guess.
+
+Keep the language and regional spelling the writer used unless they ask for a
+change. For example, retain Australian spelling in an Australian document.
+
+## Make the prose sound lived-in
+
+Prefer the specific subject of the sentence over vague commentary about it. Cut
+filler that does not add information. Let sentence length move around when the
+subject calls for it: a longer explanation can sit beside a short, direct
+sentence.
+
+Keep a writer's useful rough edges. A dry joke, a firm judgement, or an unusual
+turn of phrase may be the part that makes the piece feel like theirs. Clean up
+confusion, repetition, and accidental clutter. Do not sand every opinion down
+until it says nothing.
+
+## Watch for template prose
+
+Remove or rewrite phrases that announce a point without making it, such as
+"In today's fast-paced world", "It is important to note", or "This article
+will explore". Be wary of grand claims about significance, empty conclusions,
+and stock transitions between paragraphs.
+
+Avoid a steady run of identical sentence shapes. Break up mechanical lists of
+adjectives and filler phrases that merely repeat the sentence before them.
+
+## Keep the boundary clear
+
+Do not add facts, citations, experience, emotion, or certainty. Do not remove a
+required disclosure, attribution, warning, or qualification. Preserve quoted
+text, code, names, numbers, and technical identifiers exactly where the main
+skill requires it.
+
+This pass can make authorised prose clearer and more personal. It cannot prove
+who wrote the original text or establish that a detector will reach any result.

--- a/skills/clean-user-facing-text/references/writing-in-your-voice.md
+++ b/skills/clean-user-facing-text/references/writing-in-your-voice.md
@@ -7,11 +7,12 @@ the details that show they know what they are talking about.
 ## Start with a brief
 
 Before rewriting, identify what the writer is trying to say and who needs to
-read it. Use a supplied writing sample as a guide to sentence length, word
-choice, humour, and formality. A sample is a reference point, not a licence to
-invent personal stories or feelings the writer did not provide.
+read it. Use a writing sample only when the user owns it or is authorised to
+use it. Don't imitate another named person. An approved sample can guide sentence
+length, word choice, humour, and formality. It's a reference point, not a
+licence to invent personal stories or feelings the writer didn't provide.
 
-If there is no sample, use plain language and a natural rhythm. Do not claim to
+If there is no sample, use plain language and a natural rhythm. Don't claim to
 write in a named person's voice from a guess.
 
 Keep the language and regional spelling the writer used unless they ask for a
@@ -26,8 +27,12 @@ sentence.
 
 Keep a writer's useful rough edges. A dry joke, a firm judgement, or an unusual
 turn of phrase may be the part that makes the piece feel like theirs. Clean up
-confusion, repetition, and accidental clutter. Do not sand every opinion down
+confusion, repetition, and accidental clutter. Don't sand every opinion down
 until it says nothing.
+
+Treat unusual grammar, repetition, directness, and phrasing as possible voice
+or accessibility choices. Change them only when the writer asks, or when they
+create a clear reading problem.
 
 ## Watch for template prose
 
@@ -41,10 +46,10 @@ adjectives and filler phrases that merely repeat the sentence before them.
 
 ## Keep the boundary clear
 
-Do not add facts, citations, experience, emotion, or certainty. Do not remove a
+Don't add facts, citations, experience, emotion, or certainty. Don't remove a
 required disclosure, attribution, warning, or qualification. Preserve quoted
 text, code, names, numbers, and technical identifiers exactly where the main
 skill requires it.
 
-This pass can make authorised prose clearer and more personal. It cannot prove
+This pass can make authorised prose clearer and more personal. It can't prove
 who wrote the original text or establish that a detector will reach any result.

--- a/tests/test_lightweight_skill.py
+++ b/tests/test_lightweight_skill.py
@@ -81,6 +81,7 @@ def test_lightweight_skill_has_no_template_placeholders():
 
     assert "TODO" not in skill_text
     assert (SKILL / "references" / "watermark-notes.md").is_file()
+    assert (SKILL / "references" / "writing-in-your-voice.md").is_file()
 
 
 def _run_installer(home: Path, *args: str, check: bool = True):

--- a/tests/test_lightweight_skill.py
+++ b/tests/test_lightweight_skill.py
@@ -80,6 +80,9 @@ def test_lightweight_skill_has_no_template_placeholders():
     skill_text = (SKILL / "SKILL.md").read_text(encoding="utf-8")
 
     assert "TODO" not in skill_text
+
+
+def test_lightweight_skill_includes_required_references():
     assert (SKILL / "references" / "watermark-notes.md").is_file()
     assert (SKILL / "references" / "writing-in-your-voice.md").is_file()
 
@@ -100,7 +103,9 @@ def _run_installer(home: Path, *args: str, check: bool = True):
 def test_installer_uses_cursor_skill_location(tmp_path):
     _run_installer(tmp_path)
 
-    assert (tmp_path / ".cursor" / "skills" / SKILL.name / "SKILL.md").is_file()
+    installed_skill = tmp_path / ".cursor" / "skills" / SKILL.name
+    assert (installed_skill / "SKILL.md").is_file()
+    assert (installed_skill / "references" / "writing-in-your-voice.md").is_file()
 
 
 def test_installer_preserves_existing_install_without_force(tmp_path):


### PR DESCRIPTION
## What this starts

This is a small Cursor-skill pilot for the humanising work. The existing
`clean-user-facing-text` skill already cleans suspicious Unicode and asks for a
prose rewrite. It didn't give the agent much help with keeping a writer's actual
voice, point of view, and local spelling intact.

I've kept this small so we can agree on the approach before it spreads through
the rest of the project.

## Changes

- add a writing brief before a rewrite
- use a voice sample only when the user owns it or is authorised to use it
- protect unusual grammar, repetition, directness, and phrasing when they're a
  voice or accessibility choice
- add a guide for keeping tone and useful specifics without making things up
- test that the installed standalone skill includes the new guide

## Why this matters

For someone using AI as writing support for dyslexia, ADHD, disability, dictation,
or language help, a final edit should leave them in control of their own writing.
It shouldn't flatten a non-standard voice just because it looks unfamiliar.

This is for clearer authorised prose. It isn't a promise of detector evasion or
a claim about who wrote the original text.

The accessibility context is in [my article on AI watermarking](https://www.linkedin.com/pulse/ai-watermarking-new-scarlet-letter-vivid-n-savitri-npzpc).

## Scope

This PR only pilots the guidance in the standalone Cursor skill. The shared
Layer B prompt stays unchanged for now. If this direction works, I can bring the
same safeguards to the shared prompt in a separate PR.

## Check run

`python3.11 -m pytest -q`  
612 passed, 2 skipped

## Feedback I'd value

Should this stay inside `clean-user-facing-text`, or become a separate optional
skill once the wording has had a proper workout?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated text-cleaning guidance to better preserve the writer’s voice, regional spelling, distinctive phrasing, accessibility choices, and required facts.
  * Added guidance for authorized voice samples and natural, non-template language.
  * Clarified boundaries around impersonation, invented personal details, unsupported claims, and authorship assurances.

* **Quality Improvements**
  * Expanded validation to ensure the new voice-preservation guidance is included wherever the skill is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->