### PR TITLE
Update LICENSE copyright to Guillaume Meyer and contributors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 watermarks-remover contributors
+Copyright (c) 2026 Guillaume Meyer and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Update the LICENSE file's copyright notice to attribute the work to **Guillaume Meyer and contributors**.

```diff
- Copyright (c) 2026 watermarks-remover contributors
+ Copyright (c) 2026 Guillaume Meyer and contributors
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the MIT license copyright attribution to reflect the current copyright holder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->