### PR TITLE
docs: add ClaudeWatermarks to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1110,6 +1110,10 @@ Third-party projects that wrap or complement this repository, listed for discove
 
 [unmark-web](https://github.com/ivanusto/unmark-web) is an independent, MIT-licensed static web client. It removes invisible Unicode marks from text and strips provenance metadata from images entirely in the browser, and can optionally call this repository's HTTP service for the formats it does not handle locally. It is a separate codebase and is not affiliated with this project; see its README for scope and limits.
 
+### ClaudeWatermarks — browser-local text inspector
+
+[ClaudeWatermarks](https://claudewatermarks.com) is an independent, free web tool that inspects pasted text for invisible Unicode carriers entirely in the browser — nothing is uploaded — and lists every finding with its code point, position and surrounding context so the reader decides what to remove. Its inspector engine is published separately as [claude-text-inspector](https://github.com/little-pp395/claude-text-inspector) (MIT, TypeScript); its code-point tables and in-context preservation rules (emoji glue, script joiners, flag tags) follow this repository's Layer A engine. The site also reads C2PA Content Credentials from supported files locally. It does not call this repository's service, and it states plainly that it cannot detect or remove Claude's statistical text mark. It is a separate codebase and is not affiliated with this project; see its README for scope and limits.
+
 ### Adding a project
 
 To register a project here, open a PR adding a short entry — project name, what it wraps or adds, and a link to its own repository. Keep entries brief and factual; do not claim compatibility with, or endorsement by, this project. Please avoid names that start with or closely resemble `watermarks-remover` — look-alike names make it hard to tell which project is which.


### PR DESCRIPTION
## What

Adds a short entry for [ClaudeWatermarks](https://claudewatermarks.com) to the Ecosystem chapter, following the format of the existing MetaClean and unmark-web entries (factual, no endorsement or compatibility claim). README only, no code changes.

## Why

ClaudeWatermarks is an independent, free, browser-local inspector for invisible Unicode carriers in pasted text (plus a local C2PA Content Credentials reader for files). Its inspector engine is published separately as [claude-text-inspector](https://github.com/little-pp395/claude-text-inspector) (MIT, TypeScript, tests included); its code-point tables and in-context preservation rules — emoji glue, script joiners, flag tag sequences, same-script fillers — are adapted from this repository's Layer A engine (`text_unicode.py`), with attribution in its `THIRD_PARTY_NOTICES.md`. It does not call this repository's service, and it states on every page that it cannot detect or remove Claude's statistical text mark.

The name does not start with or resemble `watermarks-remover`, per the guidance added in #108.

## Checklist

- [x] Behaviour matches `SKILL.md` / `references/removal-matrix.md` when relevant — n/a, docs only
- [x] Unit tests updated or added under `tests/` — n/a, docs only
- [x] `python3 -m pytest -q` passes — unchanged (818 passed, 16 skipped locally)
- [x] Docs updated (README and/or skill references) if user-facing behaviour changes
- [x] No drive-by refactors unrelated to the fix or feature

## Notes for the reviewer

Separate codebase, not affiliated; happy to shorten or reword the entry to match whatever house style you prefer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information about ClaudeWatermarks, an independent browser-local tool for inspecting invisible Unicode markers and reading C2PA metadata.
  * Clarified that the tool does not use this project’s service, cannot detect or remove Claude’s statistical text watermark, and is unaffiliated with the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->