### PR TITLE
fix: reject partial ID3v2 frame parsing

### DIFF
--- a/service/scripts/av_meta.py
+++ b/service/scripts/av_meta.py
@@ -217,9 +217,11 @@ def _parse_id3v2_frames(data: bytes) -> tuple[int, int, list[tuple[bytes, bytes]
         frame_start = pos + 10
         frame_end = frame_start + frame_size
         if frame_size < 0 or frame_end > frames_end:
-            break
+            return None
         frames.append((frame_id, data[frame_start:frame_end]))
         pos = frame_end
+    if any(data[pos:frames_end]):
+        return None
     return total, major, frames
 
 

--- a/tests/test_av_meta.py
+++ b/tests/test_av_meta.py
@@ -285,6 +285,50 @@ def test_flac_ignores_truncated_c2pa_geob(tmp_path):
     assert dest.read_bytes() == data
 
 
+def test_flac_keep_mode_preserves_tag_with_truncated_frame(tmp_path):
+    truncated_title = b"TIT2" + struct.pack(">I", 20) + b"\x00\x00partial"
+    data = _flac(
+        _id3v2_frame(b"GEOB", _c2pa_geob()),
+        truncated_title,
+    )
+    src = tmp_path / "voice.flac"
+    src.write_bytes(data)
+    dest = tmp_path / "voice.cleaned.flac"
+
+    clean_av(src, dest, strip_all_metadata=False)
+
+    assert dest.read_bytes() == data
+
+
+def test_flac_keep_mode_preserves_tag_with_nonzero_short_tail(tmp_path):
+    data = _flac(
+        _id3v2_frame(b"GEOB", _c2pa_geob()),
+        b"TIT2bad",
+    )
+    src = tmp_path / "voice.flac"
+    src.write_bytes(data)
+    dest = tmp_path / "voice.cleaned.flac"
+
+    clean_av(src, dest, strip_all_metadata=False)
+
+    assert dest.read_bytes() == data
+
+
+def test_flac_keep_mode_accepts_zero_padding(tmp_path):
+    src = tmp_path / "voice.flac"
+    src.write_bytes(
+        _flac(
+            _id3v2_frame(b"GEOB", _c2pa_geob()),
+            b"\x00" * 7,
+        )
+    )
+    dest = tmp_path / "voice.cleaned.flac"
+
+    clean_av(src, dest, strip_all_metadata=False)
+
+    assert dest.read_bytes() == _flac()
+
+
 # ---------------------------------------------------------------------------
 # MP4 / MOV
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

- Abort ID3v2 frame parsing when a frame payload exceeds the declared tag boundary.
- Reject non-zero trailing bytes that are too short to form a frame header, while continuing to accept zero padding.
- Add FLAC keep-mode regressions proving malformed ID3v2 tags remain byte-identical.

## Why

The shared ID3v2 parser previously returned frames parsed before a malformed
suffix. For an ID3-prefixed FLAC containing a valid C2PA GEOB followed by a
truncated unrelated frame, keep-mode cleaning trusted that partial result,
removed the GEOB, and silently dropped the unparsed remainder.

Around an FFmpeg-generated, decodable FLAC, the old cleaner reduced the file
from 8,398 to 8,299 bytes by dropping the complete ID3 prefix. With this
change, the malformed input is preserved byte-for-byte and still passes
`flac -t`.

Follow-up to the late review on #218.

## Validation

- `tests/test_av_meta.py`: 36 passed
- Full pytest suite except one pre-existing exiftool-dependent PDF failure:
  passed
- The PDF failure reproduces unchanged on `origin/main`
- `python -m ruff check service tests`
- `python -m ruff format --check service tests`
- OpenAPI specification validation
- `git diff --check`
- Real FFmpeg FLAC byte comparison and `flac -t`

The local `pip-audit` command could not complete because temporary-environment
`ensurepip` aborted on this macOS host. This PR has no dependency changes; CI
will run the authoritative audit.

## Checklist

- [x] Behaviour matches the Files metadata preservation contract
- [x] Unit tests updated under `tests/`
- [ ] Full local pytest has one unrelated baseline PDF/exiftool failure
- [x] No documentation change needed
- [x] No drive-by refactors

## Notes for the reviewer

This change is limited to fail-closed ID3v2 frame parsing. It does not address
unsupported ID3v2.5+ tags or WAV report-field consistency.

Malformed ID3-prefixed FLAC currently falls back to the MP3 format label while
remaining byte-identical. Surfacing malformed tags as inconclusive is outside
this data-preservation fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed ID3 metadata in FLAC files.
  * Preserves original tags when truncated frames or nonzero trailing data are detected.
  * Continues removing C2PA metadata when only valid zero-padding follows the parsed frames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->