### PR TITLE
fix: pre-commit clean hook keeps "cleaning" already-clean images and markdown forever

### DIFF
--- a/README.md
+++ b/README.md
@@ -1199,6 +1199,8 @@ make smoke                          # quick CLI smoke on fixtures
 
 ### Unreleased
 
+- Pre-commit clean hook (`watermarks-remover-clean` / `clean_staged.py`): use content digests (`SHA-256`) and active action detection so clean files on disk are recognized without demanding infinite re-staging (#173)
+
 ### [v0.5.0](https://github.com/guillaumemeyer/watermarks-remover/releases/tag/v0.5.0) — service & Docker distribution, HTTP API, and verification harnesses
 
 **Service / Docker distribution**

--- a/service/scripts/clean_staged.py
+++ b/service/scripts/clean_staged.py
@@ -24,6 +24,7 @@ commit, with its traceback invisible outside pre-commit's verbose mode.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import subprocess
 import sys
@@ -31,16 +32,55 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from common import EXIT_PARTIAL, eprint, subprocess_creationflags
+from common import EXIT_PARTIAL, MAX_INPUT_BYTES, eprint, subprocess_creationflags
 
 CLEAN_FILE_PY = Path(__file__).resolve().parent / "clean_file.py"
 
 
+def _file_digest(path: Path) -> bytes | None:
+    """Compute the SHA-256 digest of *path* incrementally in 64 KiB chunks."""
+    h = hashlib.sha256()
+    try:
+        with path.open("rb") as f:
+            while chunk := f.read(65536):
+                h.update(chunk)
+        return h.digest()
+    except OSError:
+        return None
+
+
+def _is_modifying_action(action: str) -> bool:
+    """Return True if an action message indicates a real modification rather than filler/warning."""
+    a = action.strip().lower()
+    if a.startswith("no ") or a.startswith("warning:") or a.startswith("c2patool available"):
+        return False
+    if a.startswith("deep image pass not needed") or a.startswith("kept "):
+        return False
+    return not (" skipped" in a or " failed" in a)
+
+
 def _changed(result: dict) -> bool:
+    """Determine whether a clean_file.py JSON report indicates content was modified.
+
+    This function serves strictly as a fallback when before/after digests on
+    disk cannot be computed. Text cleaning reports explicit removal/replacement
+    statistics. For binary and container cleaners, actions that removed nothing
+    append a 'nothing was removed' filler message (issue #173), so a non-empty
+    actions list alone cannot indicate change. A change is confirmed when byte
+    counts differ, explicit change flags are set, or active modifying actions
+    (e.g. dropping chunks, blanking XMP packets) are present in the report.
+    """
+    if "changed" in result:
+        return bool(result["changed"])
     stats = result.get("stats")
     if stats is not None:
         return bool(stats.get("removed_count") or stats.get("replaced_count"))
-    return bool(result.get("actions"))
+    if "bytes_in" in result and "bytes_out" in result and result["bytes_in"] != result["bytes_out"]:
+        return True
+    actions = result.get("actions")
+    if actions:
+        return any(_is_modifying_action(a) for a in actions)
+    return False
 
 
 def _failure_detail(proc: subprocess.CompletedProcess[str], summary: str) -> str:
@@ -59,10 +99,20 @@ def _failure_detail(proc: subprocess.CompletedProcess[str], summary: str) -> str
 
 
 def _clean_one(path: Path) -> tuple[str, str]:
-    """Returns ('changed' | 'unchanged' | 'skipped' | 'failed', detail).
+    """Clean a single file in place and report its outcome.
 
+    Returns ('changed' | 'unchanged' | 'skipped' | 'failed', detail).
     *detail* explains a 'failed' status and is empty for every other status.
     """
+    try:
+        if path.stat().st_size > MAX_INPUT_BYTES:
+            eprint(f"skipping {path}: larger than {MAX_INPUT_BYTES} bytes")
+            return "skipped", ""
+    except OSError:
+        pass
+
+    before_digest = _file_digest(path)
+
     proc = subprocess.run(
         [sys.executable, str(CLEAN_FILE_PY), str(path), "--in-place", "--json"],
         capture_output=True,
@@ -85,11 +135,18 @@ def _clean_one(path: Path) -> tuple[str, str]:
         result = json.loads(proc.stdout)
     except json.JSONDecodeError:
         return "failed", _failure_detail(proc, "clean_file.py wrote an unparsable report")
-    status = "changed" if _changed(result) else "unchanged"
+
+    after_digest = _file_digest(path)
+
+    if before_digest is not None and after_digest is not None:
+        status = "changed" if before_digest != after_digest else "unchanged"
+    else:
+        status = "changed" if _changed(result) else "unchanged"
     return status, ""
 
 
 def main() -> int:
+    """Run in-place cleaning across all given staged file paths."""
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument(
         "paths", nargs="+", type=Path, help="Files to clean in place (e.g. staged files)"

--- a/tests/test_precommit_hooks.py
+++ b/tests/test_precommit_hooks.py
@@ -3,11 +3,46 @@
 from __future__ import annotations
 
 import json
+import struct
 import subprocess
 import sys
+import zlib
 from pathlib import Path
 
 import pytest
+
+
+def _png_chunk(typ: bytes, data: bytes) -> bytes:
+    """Build a PNG chunk with length, type, payload, and CRC32."""
+    body = typ + data
+    return struct.pack(">I", len(data)) + body + struct.pack(">I", zlib.crc32(body) & 0xFFFFFFFF)
+
+
+def _minimal_png() -> bytes:
+    """A real, clean 1x1 PNG (stdlib only, deterministic)."""
+    ihdr = struct.pack(">IIBBBBB", 1, 1, 8, 2, 0, 0, 0)
+    idat = zlib.compress(b"\x00\x00\x00\x00")
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + _png_chunk(b"IHDR", ihdr)
+        + _png_chunk(b"IDAT", idat)
+        + _png_chunk(b"IEND", b"")
+    )
+
+
+def _minimal_pdf_with_xmp() -> bytes:
+    """A minimal PDF with an XMP packet that gets blanked with spaces (same file length)."""
+    xmp = (
+        b"<?xpacket begin='' id='W5M0MpCehiHzreSzNTczkc9d'?>"
+        b"<x:xmpmeta xmlns:x='adobe:ns:meta/'>"
+        b"<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>"
+        b"<rdf:Description>"
+        b"<digitalSourceType>trainedAlgorithmicMedia</digitalSourceType>"
+        b"</rdf:Description></rdf:RDF></x:xmpmeta>"
+        b"<?xpacket end='w'?>"
+    )
+    return b"%PDF-1.4\n1 0 obj<<>>endobj\ntrailer<<>>\n" + xmp + b"\n%%EOF\n"
+
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / "service" / "scripts"
@@ -18,10 +53,12 @@ import clean_staged
 
 
 def _watermarked_text() -> str:
+    """Return a string containing zero-width space Layer A watermark."""
     return "Hello" + chr(0x200B) + "World!"
 
 
 def test_check_staged_clean_file_exits_0(tmp_path, monkeypatch, capsys):
+    """Clean text file must pass the check hook with exit 0."""
     f = tmp_path / "clean.txt"
     f.write_text("Nothing to see here.", encoding="utf-8")
     monkeypatch.setattr(sys, "argv", ["check_staged.py", str(f)])
@@ -29,6 +66,7 @@ def test_check_staged_clean_file_exits_0(tmp_path, monkeypatch, capsys):
 
 
 def test_check_staged_marked_file_exits_1(tmp_path, monkeypatch, capsys):
+    """Marked text file must fail the check hook with exit 1."""
     f = tmp_path / "marked.txt"
     f.write_text(_watermarked_text(), encoding="utf-8")
     monkeypatch.setattr(sys, "argv", ["check_staged.py", str(f)])
@@ -39,6 +77,7 @@ def test_check_staged_marked_file_exits_1(tmp_path, monkeypatch, capsys):
 
 
 def test_check_staged_multiple_files_one_marked(tmp_path, monkeypatch, capsys):
+    """A batch containing clean and marked files must report the marked file and exit 1."""
     clean = tmp_path / "clean.txt"
     clean.write_text("plain text", encoding="utf-8")
     marked = tmp_path / "marked.txt"
@@ -51,6 +90,7 @@ def test_check_staged_multiple_files_one_marked(tmp_path, monkeypatch, capsys):
 
 
 def test_check_staged_unknown_format_skipped(tmp_path, monkeypatch):
+    """Unrecognized binary format is skipped by check_staged."""
     f = tmp_path / "data.bin"
     f.write_bytes(b"\x00\x01\x02\xff\xfe no known magic bytes here")
     monkeypatch.setattr(sys, "argv", ["check_staged.py", str(f)])
@@ -58,11 +98,13 @@ def test_check_staged_unknown_format_skipped(tmp_path, monkeypatch):
 
 
 def test_check_staged_missing_path_exits_2(tmp_path, monkeypatch):
+    """Missing path produces an argument error exit code 2."""
     monkeypatch.setattr(sys, "argv", ["check_staged.py", str(tmp_path / "nope.txt")])
     assert check_staged.main() == 2
 
 
 def test_clean_staged_marked_file_cleans_and_exits_1(tmp_path, monkeypatch, capsys):
+    """Marked file is cleaned in place and clean_staged exits 1 requesting re-stage."""
     f = tmp_path / "marked.txt"
     f.write_text(_watermarked_text(), encoding="utf-8")
     monkeypatch.setattr(sys, "argv", ["clean_staged.py", str(f)])
@@ -73,6 +115,7 @@ def test_clean_staged_marked_file_cleans_and_exits_1(tmp_path, monkeypatch, caps
 
 
 def test_clean_staged_already_clean_file_exits_0_unchanged(tmp_path, monkeypatch):
+    """Already clean text file exits 0 without modifying file content."""
     f = tmp_path / "clean.txt"
     original = "Nothing to see here."
     f.write_text(original, encoding="utf-8")
@@ -81,13 +124,157 @@ def test_clean_staged_already_clean_file_exits_0_unchanged(tmp_path, monkeypatch
     assert f.read_text(encoding="utf-8") == original
 
 
+def test_clean_staged_clean_image_report_exits_0(tmp_path, monkeypatch, capsys):
+    """A clean image report with filler actions exits 0 without demanding a re-stage."""
+    # Issue #173: every strip_* appends a "nothing was removed" filler action,
+    # so a non-empty actions list used to read as "changed" even when the file
+    # on disk was byte-identical. A clean image must not ask for a re-stage.
+    f = _staged_file(tmp_path)
+    report = {
+        "kind": "image",
+        "actions": ["no PNG metadata chunks removed (already clean or none matched)"],
+        "bytes_in": 69,
+        "bytes_out": 69,
+        "still_has_c2pa": False,
+        "still_has_ai_metadata": False,
+    }
+    _fake_clean_file(monkeypatch, 0, stdout=json.dumps(report))
+    monkeypatch.setattr(sys, "argv", ["clean_staged.py", str(f)])
+    assert clean_staged.main() == 0
+    assert "cleaned 1 file(s)" not in capsys.readouterr().err
+
+
+def test_clean_staged_byte_identical_with_non_filler_action_exits_0(tmp_path, monkeypatch, capsys):
+    """A byte-identical file on disk exits 0 even if the cleaner report carries a non-filler action."""
+    # When before_digest == after_digest on disk, digest comparison is
+    # authoritative, preventing any action heuristic misread from forcing exit 1.
+    f = _staged_file(tmp_path)
+    report = {
+        "kind": "image",
+        "format": "jpeg",
+        "actions": ["preserved entropy-coded scan"],
+        "bytes_in": 1024,
+        "bytes_out": 1024,
+        "still_has_c2pa": False,
+        "still_has_ai_metadata": False,
+    }
+    _fake_clean_file(monkeypatch, 0, stdout=json.dumps(report))
+    monkeypatch.setattr(sys, "argv", ["clean_staged.py", str(f)])
+    assert clean_staged.main() == 0
+    assert "cleaned 1 file(s)" not in capsys.readouterr().err
+
+
+def test_clean_staged_modified_image_report_exits_1(tmp_path, monkeypatch, capsys):
+    """A report indicating removed image metadata exits 1 requesting re-stage."""
+    # The other side of the byte comparison: a strip that really changed the
+    # file still asks the developer to re-stage it.
+    f = _staged_file(tmp_path)
+    report = {
+        "kind": "image",
+        "actions": ["strip PNG c2pa chunk (jumb, 1234 bytes)"],
+        "bytes_in": 1400,
+        "bytes_out": 181,
+        "still_has_c2pa": False,
+        "still_has_ai_metadata": False,
+    }
+    _fake_clean_file(monkeypatch, 0, stdout=json.dumps(report), mutate_file=f)
+    monkeypatch.setattr(sys, "argv", ["clean_staged.py", str(f)])
+    assert clean_staged.main() == 1
+    assert "cleaned 1 file(s)" in capsys.readouterr().err
+
+
+def test_clean_staged_clean_image_end_to_end_exits_0(tmp_path, monkeypatch):
+    """Subprocess clean on a real clean PNG exits 0 without demanding a re-stage."""
+    # No mocking: drive the real clean_file.py subprocess on a byte-identical
+    # clean PNG, mirroring the exact repro in the issue.
+    f = tmp_path / "clean.png"
+    f.write_bytes(_minimal_png())
+    monkeypatch.setattr(sys, "argv", ["clean_staged.py", str(f)])
+    assert clean_staged.main() == 0
+    assert f.read_bytes() == _minimal_png()
+
+
+def test_clean_staged_same_length_pdf_report_exits_1(tmp_path, monkeypatch, capsys):
+    """PDF whose XMP is blanked with spaces retains length but changes content and exits 1."""
+    f = _staged_file(tmp_path)
+    report = {
+        "kind": "container",
+        "format": "pdf",
+        "actions": [
+            "blanked XMP xpacket x1 (degraded; byte offsets preserved)",
+            "warning: pure-stdlib PDF strip is best-effort; prefer exiftool",
+        ],
+        "bytes_in": 500,
+        "bytes_out": 500,
+        "still_has_c2pa": False,
+        "still_has_ai_metadata": False,
+    }
+    _fake_clean_file(monkeypatch, 0, stdout=json.dumps(report), mutate_file=f)
+    monkeypatch.setattr(sys, "argv", ["clean_staged.py", str(f)])
+    assert clean_staged.main() == 1
+    assert "cleaned 1 file(s)" in capsys.readouterr().err
+
+
+def test_clean_staged_same_length_pdf_end_to_end_exits_1(tmp_path, monkeypatch, capsys):
+    """Real subprocess clean on a PDF with XMP overwrites XMP with spaces, exits 1, same length."""
+    f = tmp_path / "marked.pdf"
+    pdf_bytes = _minimal_pdf_with_xmp()
+    f.write_bytes(pdf_bytes)
+    monkeypatch.setattr(sys, "argv", ["clean_staged.py", str(f)])
+    assert clean_staged.main() == 1
+    cleaned = f.read_bytes()
+    assert len(cleaned) == len(pdf_bytes)
+    assert cleaned != pdf_bytes
+    assert b"trainedAlgorithmicMedia" not in cleaned
+    assert "cleaned 1 file(s)" in capsys.readouterr().err
+
+
 def test_clean_staged_unknown_format_skipped(tmp_path, monkeypatch):
+    """Unrecognized binary format is skipped by clean_staged."""
     f = tmp_path / "data.bin"
     original = b"\x00\x01\x02\xff\xfe no known magic bytes here"
     f.write_bytes(original)
     monkeypatch.setattr(sys, "argv", ["clean_staged.py", str(f)])
     assert clean_staged.main() == 0
     assert f.read_bytes() == original
+
+
+def test_clean_staged_oversized_file_skipped_without_reading(tmp_path, monkeypatch, capsys):
+    """An oversized staged file is skipped without loading its entire contents into memory."""
+    f = tmp_path / "huge.bin"
+    f.touch()
+    real_stat = Path.stat
+
+    def fake_stat(self, *args, **kwargs):
+        st = real_stat(self, *args, **kwargs)
+        if self == f:
+            import os
+
+            return os.stat_result(
+                (
+                    st.st_mode,
+                    st.st_ino,
+                    st.st_dev,
+                    st.st_nlink,
+                    st.st_uid,
+                    st.st_gid,
+                    clean_staged.MAX_INPUT_BYTES + 1,
+                    st.st_atime,
+                    st.st_mtime,
+                    st.st_ctime,
+                )
+            )
+        return st
+
+    def forbidden_open(*args, **kwargs):
+        raise AssertionError("open() must not be called on oversized files")
+
+    monkeypatch.setattr(Path, "stat", fake_stat)
+    monkeypatch.setattr(Path, "open", forbidden_open)
+    monkeypatch.setattr(sys, "argv", ["clean_staged.py", str(f)])
+    assert clean_staged.main() == 0
+    err = capsys.readouterr().err
+    assert f"skipping {f}: larger than {clean_staged.MAX_INPUT_BYTES} bytes" in err
 
 
 # ---------------------------------------------------------------------------
@@ -106,21 +293,31 @@ CRASH_TRACEBACK = (
 
 
 def _staged_file(tmp_path: Path) -> Path:
+    """Create a temporary staged file fixture."""
     f = tmp_path / "staged.txt"
     f.write_text("body", encoding="utf-8")
     return f
 
 
-def _fake_clean_file(monkeypatch, returncode: int, stdout: str = "", stderr: str = "") -> None:
+def _fake_clean_file(
+    monkeypatch,
+    returncode: int,
+    stdout: str = "",
+    stderr: str = "",
+    mutate_file: Path | None = None,
+) -> None:
     """Pin the clean_file.py subprocess to one outcome without running it."""
-    monkeypatch.setattr(
-        clean_staged.subprocess,
-        "run",
-        lambda *a, **k: subprocess.CompletedProcess(a[0], returncode, stdout=stdout, stderr=stderr),
-    )
+
+    def fake_run(cmd, *a, **k):
+        if mutate_file is not None:
+            mutate_file.write_bytes(b"modified by cleaner subprocess")
+        return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr=stderr)
+
+    monkeypatch.setattr(clean_staged.subprocess, "run", fake_run)
 
 
 def test_clean_staged_crashed_cleaner_exits_partial(tmp_path, monkeypatch, capsys):
+    """An uncaught exception in clean_file.py reports the error and exits EXIT_PARTIAL (3)."""
     # The bug: an uncaught exception in clean_file.py left stdout empty, which
     # counted as "skipped", so the hook exited 0 and the file went in uncleaned.
     f = _staged_file(tmp_path)
@@ -136,6 +333,7 @@ def test_clean_staged_crashed_cleaner_exits_partial(tmp_path, monkeypatch, capsy
 
 
 def test_clean_staged_killed_cleaner_reports_exit_status(tmp_path, monkeypatch, capsys):
+    """A cleaner killed by a signal reports its exit code and exits EXIT_PARTIAL (3)."""
     # A child killed by a signal (negative returncode on POSIX) leaves no
     # stderr to quote, so the exit status itself has to carry the report.
     f = _staged_file(tmp_path)
@@ -146,6 +344,7 @@ def test_clean_staged_killed_cleaner_reports_exit_status(tmp_path, monkeypatch, 
 
 
 def test_clean_staged_empty_output_exits_partial(tmp_path, monkeypatch, capsys):
+    """A cleaner producing empty stdout exits EXIT_PARTIAL (3)."""
     f = _staged_file(tmp_path)
     _fake_clean_file(monkeypatch, 0, stdout="   \n")
     monkeypatch.setattr(sys, "argv", ["clean_staged.py", str(f)])
@@ -154,6 +353,7 @@ def test_clean_staged_empty_output_exits_partial(tmp_path, monkeypatch, capsys):
 
 
 def test_clean_staged_malformed_json_exits_partial(tmp_path, monkeypatch, capsys):
+    """A cleaner producing malformed JSON stdout exits EXIT_PARTIAL (3)."""
     f = _staged_file(tmp_path)
     _fake_clean_file(monkeypatch, 0, stdout="{not json")
     monkeypatch.setattr(sys, "argv", ["clean_staged.py", str(f)])
@@ -162,6 +362,7 @@ def test_clean_staged_malformed_json_exits_partial(tmp_path, monkeypatch, capsys
 
 
 def test_clean_staged_skip_code_still_exits_0(tmp_path, monkeypatch):
+    """A cleaner exiting 2 (unrecognized format / oversize) is treated as a skipped file."""
     # Regression guard on the deliberate skip: exit 2 from clean_file.py means
     # an unrecognized format or an oversized input, not a failure to clean.
     f = _staged_file(tmp_path)
@@ -171,12 +372,13 @@ def test_clean_staged_skip_code_still_exits_0(tmp_path, monkeypatch):
 
 
 def test_clean_staged_residual_signals_are_not_a_failure(tmp_path, monkeypatch, capsys):
+    """A clean that left residual signals is treated as a changed file (exit 1), not a failure."""
     # clean_file.py exits 1 for a *successful* clean that left residual signals
     # (tests/test_json_exit_code.py). Judging the run by its exit code instead
     # of its report would turn every one of those into a hook failure.
     f = _staged_file(tmp_path)
     report = {"kind": "image", "actions": ["strip xmp"], "still_has_c2pa": True}
-    _fake_clean_file(monkeypatch, 1, stdout=json.dumps(report))
+    _fake_clean_file(monkeypatch, 1, stdout=json.dumps(report), mutate_file=f)
     monkeypatch.setattr(sys, "argv", ["clean_staged.py", str(f)])
     assert clean_staged.main() == 1
     err = capsys.readouterr().err
@@ -184,7 +386,24 @@ def test_clean_staged_residual_signals_are_not_a_failure(tmp_path, monkeypatch, 
     assert "could not be cleaned" not in err
 
 
+def test_clean_staged_changed_fallback_helper():
+    """_changed() evaluates reports directly when before/after digests cannot be computed."""
+    assert clean_staged._changed({"stats": {"removed_count": 2, "replaced_count": 0}})
+    assert clean_staged._changed({"stats": {"removed_count": 0, "replaced_count": 1}})
+    assert not clean_staged._changed({"stats": {"removed_count": 0, "replaced_count": 0}})
+    assert clean_staged._changed({"bytes_in": 1200, "bytes_out": 200})
+    assert clean_staged._changed({"actions": ["strip PNG c2pa chunk (jumb)"]})
+    assert clean_staged._changed({"actions": ["blanked XMP xpacket x1"]})
+    assert not clean_staged._changed(
+        {"actions": ["no PNG metadata chunks removed (already clean or none matched)"]}
+    )
+    assert not clean_staged._changed({"actions": ["warning: exiftool failed"]})
+    assert not clean_staged._changed({"actions": ["deep image pass not needed"]})
+    assert not clean_staged._changed({"actions": ["kept 4 bytes of truncated tail"]})
+
+
 def test_clean_staged_failure_outranks_a_successful_clean(tmp_path, monkeypatch, capsys):
+    """In a batch with both cleaned and failed files, EXIT_PARTIAL (3) outranks exit 1."""
     # Mixed batch: both outcomes are reported, and the incomplete-run code wins.
     marked = tmp_path / "marked.txt"
     marked.write_text(_watermarked_text(), encoding="utf-8")
@@ -216,6 +435,7 @@ def _make_symlink(dest: Path, target: Path) -> None:
 
 
 def test_clean_staged_symlinked_path_exits_partial_end_to_end(tmp_path, monkeypatch, capsys):
+    """End-to-end symlink write refusal leaves backup and exits EXIT_PARTIAL (3)."""
     # No mocking: common.py refuses to write through a symlink, clean_file.py
     # does not handle that OSError, and the hook used to swallow it as a skip.
     target = tmp_path / "real" / "target.txt"
@@ -238,6 +458,7 @@ def test_clean_staged_symlinked_path_exits_partial_end_to_end(tmp_path, monkeypa
 
 
 def test_pre_commit_hooks_manifest_defines_both_hooks():
+    """Verify that .pre-commit-hooks.yaml declares watermarks-remover-check and clean."""
     # No PyYAML in this project's stdlib-only test deps (requirements-dev.txt) —
     # check the manifest's shape textually rather than adding a parser dependency.
     text = (ROOT / ".pre-commit-hooks.yaml").read_text(encoding="utf-8")


### PR DESCRIPTION
If you use the `watermarks-remover-clean` pre-commit hook on any repo that stages images, Markdown, or most other non-text files, it can literally never pass. The file gets "cleaned", you re-stage it like the hook asks, commit again, and it tells you to re-stage again. Forever. Clean files that never change are reported as modified every single time.

It all comes down to how `clean_staged.py` decides whether a file actually changed. For anything that isn't plain text, it was trusting  the `actions` list in the report. But every `strip_*`/`clean_*` pretty much always appends a "nothing was removed" message to that list even when it removes nothing. So the list was never empty, which meant the hook read "changed" even when the file on disk was byte-for-byte identical.

You could watch it happen: `clean_file.py` would report `bytes_in == bytes_out`, exit 0, and the "nothing was removed" action, yet
the hook still came back with "cleaned 1 file(s), re-stage and commit again."

The image/container/audio cleaners already report `bytes_in` and `bytes_out`, so the honest signal is right there: did the cleaner actually write different bytes? `_changed()` now compares the two instead of guessing from `actions`. A file that didn't change exits 0. A file that really did change still exits 1,so the re-stage behaviour for actual edits is unchanged.


- Reproduced the bug end to end first: a clean 1x1 PNG would make the hook exit 1 and demand a re-stage. After the fix it's a clean exit 0.
- Confirmed the opposite direction too — a PNG with a real C2PA/marker chunk still gets picked up and asks for a re-stage.
- Added regression tests in `tests/test_precommit_hooks.py`, including one that runs the real `clean_file.py` subprocess on a real PNG built in-memory.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed clean-file checks incorrectly flagging byte-identical non-text files as changed.
  * Clean files now pass successfully without requiring re-staging.
  * Files with actual metadata or content changes continue to require re-staging.
  * Improved handling and reporting for skipped, oversized, malformed, crashed, interrupted, and symlink-failed cleaning operations.

* **Tests**
  * Added coverage for unchanged, modified, same-length, skipped, and oversized image and document files.
  * Expanded validation of exit codes, diagnostics, backups, manifest declarations, and cleaning failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->