### PR TITLE
feat: native Panoptes adapter for external evaluation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,3 +54,13 @@ HF_TOKEN=
 # WATERMARKS_REWRITE_REASONING_EFFORT=none # none/low/medium/high, or off to omit
 # WATERMARKS_REWRITE_CANDIDATES=1          # variants generated per evaluation round (default 1)
 # WATERMARKS_REWRITE_LOOPS=1               # max evaluation rounds; retries new variants until one passes (default 1)
+
+# ---------------------------------------------------------------------------
+# Panoptes adapter (panoptes_adapter.py — only used when this repo is
+# evaluated by the Panoptes workbench; see docs/panoptes-adapter.md)
+# ---------------------------------------------------------------------------
+# WATERMARKS_REMOVER_ADAPTER_LAYER_B=1     # follow Layer A with the Layer B rewrite
+# Layer B reads the WATERMARKS_REWRITE_* vars above. Note: Panoptes
+# evaluate-repo scrubs env vars containing API_KEY/TOKEN before running an
+# adapter, so under evaluate-repo Layer B is limited to loopback backends
+# that need no key.

--- a/.env.example
+++ b/.env.example
@@ -60,7 +60,10 @@ HF_TOKEN=
 # evaluated by the Panoptes workbench; see docs/panoptes-adapter.md)
 # ---------------------------------------------------------------------------
 # WATERMARKS_REMOVER_ADAPTER_LAYER_B=1     # follow Layer A with the Layer B rewrite
-# Layer B reads the WATERMARKS_REWRITE_* vars above. Note: Panoptes
-# evaluate-repo scrubs env vars containing API_KEY/TOKEN before running an
-# adapter, so under evaluate-repo Layer B is limited to loopback backends
-# that need no key.
+# Layer B reads the WATERMARKS_REWRITE_* vars above and defaults to a
+# loopback backend. Note: Panoptes evaluate-repo scrubs env vars containing
+# API_KEY/TOKEN before running an adapter, so keyed remote backends cannot
+# authenticate there — but WATERMARKS_REWRITE_ALLOW_REMOTE=1 is not a
+# credential var and survives scrubbing, so a keyless remote backend can
+# still receive evaluated text. evaluate-repo disables networking only with
+# --docker.

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@
 !/CONTRIBUTING.md
 !/LICENSE
 !/Makefile
+# Panoptes adapter contract (docs/panoptes-adapter.md)
+!/panoptes.adapter.json
+!/panoptes_adapter.py
 !/pytest.ini
 !/README.md
 !/requirements-dev.txt

--- a/README.md
+++ b/README.md
@@ -680,6 +680,24 @@ Use a **non-origin model** for rewriting (do not rewrite with the same
 watermarked model that generated the text) or the rewrite can re-stamp the
 output; `--restamp-control` measures this.
 
+## Optional Panoptes evaluation
+
+This repository ships a native
+[Panoptes](https://github.com/marketstandard/Panoptes) adapter
+(`panoptes.adapter.json` + `panoptes_adapter.py` at the root), so the
+Panoptes workbench can evaluate watermark removal here directly and emit a
+signed before/after card — no injected adapter needed:
+
+```bash
+python -m bench evaluate-repo \
+  https://github.com/guillaumemeyer/watermarks-remover --kind watermark-remover
+```
+
+The card quantifies the family split: Unicode carriers go from 100% present
+to 0%, while the statistical KGW watermark stays 100% detected under Layer A
+alone. Details and the Layer B opt-in:
+[`docs/panoptes-adapter.md`](docs/panoptes-adapter.md).
+
 ## Optional MarkDiffusion image-watermark harness
 
 For **controlled experiments on images**, an optional external harness wraps

--- a/docs/panoptes-adapter.md
+++ b/docs/panoptes-adapter.md
@@ -1,0 +1,61 @@
+# Panoptes adapter
+
+This repository ships a native adapter for the
+[Panoptes](https://github.com/marketstandard/Panoptes) workbench, so anyone
+can evaluate watermark removal here directly and get a signed before/after
+card — no injected adapter, no glue code:
+
+```bash
+python -m bench evaluate-repo \
+  https://github.com/guillaumemeyer/watermarks-remover \
+  --kind watermark-remover
+```
+
+Panoptes discovers `panoptes.adapter.json` at the repo root, runs
+`panoptes_adapter.transform` over its watermarked generations and
+Unicode-embedded controls in a scrubbed subprocess, and measures detection
+before vs. after.
+
+## What the card means
+
+The removal-retention evaluation covers two watermark families:
+
+| Family | Before | After | Reading |
+| --- | --- | --- | --- |
+| Unicode (zero-width carriers) | 100% present | 0% present | Layer A scrubs the full family |
+| KGW statistical (z-score) | 100% detected | 100% detected | Layer A does not touch statistical marks |
+
+That asymmetry is the point: Unicode hygiene is complete for the family it
+targets and a no-op for statistical watermarks. Removal claims should always
+name the family they cover.
+
+## Layer B opt-in
+
+The adapter defaults to the deterministic Layer A scrub
+(`service/scripts/text_unicode.clean_text`). To evaluate the statistical
+rewrite as well, opt in:
+
+```bash
+WATERMARKS_REMOVER_ADAPTER_LAYER_B=1 \
+WATERMARKS_REWRITE_BACKEND=ollama \
+WATERMARKS_REWRITE_MODEL=llama3.2 \
+python -m bench evaluate-repo ... --kind watermark-remover
+```
+
+Layer B reads the same `WATERMARKS_REWRITE_*` variables as
+`rewrite_text.py` (see `.env.example`). The CLI's `print-prompt` backend is
+rejected in the adapter — it returns a prompt, not cleaned text.
+
+**Sandbox caveat:** `evaluate-repo` scrubs env vars containing
+`API_KEY`/`TOKEN`/etc. before running an adapter, so
+`WATERMARKS_REWRITE_API_KEY` never reaches the adapter subprocess. Under
+`evaluate-repo`, Layer B is limited to loopback backends that need no key
+(e.g. a local Ollama). For keyed remote backends, run the SynthID-text
+benchmark (`docs/synthid-text-benchmark.md`) instead.
+
+## Security
+
+Evaluating a repository clones and executes its code. Panoptes runs the
+adapter in a subprocess with a scrubbed environment and a wall-clock limit;
+pass `--docker` for a network-disabled container. See Panoptes'
+`docs/testing-external-repos.md` for the full contract and threat model.

--- a/docs/panoptes-adapter.md
+++ b/docs/panoptes-adapter.md
@@ -46,12 +46,15 @@ Layer B reads the same `WATERMARKS_REWRITE_*` variables as
 `rewrite_text.py` (see `.env.example`). The CLI's `print-prompt` backend is
 rejected in the adapter — it returns a prompt, not cleaned text.
 
-**Sandbox caveat:** `evaluate-repo` scrubs env vars containing
-`API_KEY`/`TOKEN`/etc. before running an adapter, so
-`WATERMARKS_REWRITE_API_KEY` never reaches the adapter subprocess. Under
-`evaluate-repo`, Layer B is limited to loopback backends that need no key
-(e.g. a local Ollama). For keyed remote backends, run the SynthID-text
-benchmark (`docs/synthid-text-benchmark.md`) instead.
+**Sandbox caveat:** Layer B defaults to a loopback backend (a local
+Ollama). `evaluate-repo` scrubs env vars containing `API_KEY`/`TOKEN`/etc.
+before running an adapter, so `WATERMARKS_REWRITE_API_KEY` never reaches the
+adapter subprocess and keyed remote backends cannot authenticate there.
+However, `WATERMARKS_REWRITE_ALLOW_REMOTE=1` is not a credential variable
+and survives scrubbing — a *keyless* non-loopback backend can still receive
+evaluated text under `evaluate-repo`. Networking is only disabled entirely
+when the caller passes `--docker`. For keyed remote backends, run the
+SynthID-text benchmark (`docs/synthid-text-benchmark.md`) instead.
 
 ## Security
 

--- a/panoptes.adapter.json
+++ b/panoptes.adapter.json
@@ -8,5 +8,5 @@
     "callable": "transform"
   },
   "requires_network": false,
-  "notes": "Native Panoptes adapter (see docs/panoptes-adapter.md). Default: deterministic Layer A Unicode hygiene — no network, model, or API key. Opt-in Layer B statistical rewrite via WATERMARKS_REMOVER_ADAPTER_LAYER_B=1, configured through the WATERMARKS_REWRITE_* env vars; note that Panoptes evaluate-repo scrubs env vars containing API_KEY/TOKEN before running an adapter, so Layer B there is limited to loopback backends that need no key."
+  "notes": "Native Panoptes adapter (see docs/panoptes-adapter.md). Default: deterministic Layer A Unicode hygiene — no network, model, or API key. Opt-in Layer B statistical rewrite via WATERMARKS_REMOVER_ADAPTER_LAYER_B=1, configured through the WATERMARKS_REWRITE_* env vars. Layer B defaults to a loopback backend (local Ollama). Under Panoptes evaluate-repo, env vars containing API_KEY/TOKEN are scrubbed before the adapter runs, so keyed remote backends cannot authenticate there — but WATERMARKS_REWRITE_ALLOW_REMOTE=1 is not a credential variable and survives scrubbing, so a keyless remote backend can still receive evaluated text. evaluate-repo does not disable networking unless the caller passes --docker."
 }

--- a/panoptes.adapter.json
+++ b/panoptes.adapter.json
@@ -1,0 +1,12 @@
+{
+  "kind": "watermark-remover",
+  "name": "watermarks-remover",
+  "version": "1.0",
+  "entry": {
+    "type": "python-function",
+    "module": "panoptes_adapter",
+    "callable": "transform"
+  },
+  "requires_network": false,
+  "notes": "Native Panoptes adapter (see docs/panoptes-adapter.md). Default: deterministic Layer A Unicode hygiene — no network, model, or API key. Opt-in Layer B statistical rewrite via WATERMARKS_REMOVER_ADAPTER_LAYER_B=1, configured through the WATERMARKS_REWRITE_* env vars; note that Panoptes evaluate-repo scrubs env vars containing API_KEY/TOKEN before running an adapter, so Layer B there is limited to loopback backends that need no key."
+}

--- a/panoptes_adapter.py
+++ b/panoptes_adapter.py
@@ -1,0 +1,98 @@
+"""Panoptes adapter — expose watermarks-remover to the Panoptes workbench.
+
+Implements the Panoptes watermark-remover adapter contract
+(https://github.com/marketstandard/Panoptes — docs/testing-external-repos.md):
+
+    watermark-remover contract:  transform(text: str) -> str
+
+Default path: the deterministic Layer A Unicode-hygiene scrub
+(service/scripts/text_unicode.clean_text) — strips invisible/format Unicode
+(zero-width spaces, tag characters, private-use carriers) and normalizes
+space homoglyphs. No model, no network, no API key.
+
+Opt-in Layer B: set WATERMARKS_REMOVER_ADAPTER_LAYER_B=1 to follow Layer A
+with the statistical-rewrite pass (service/scripts/rewrite_text.rewrite),
+configured through the same WATERMARKS_REWRITE_* env vars as
+rewrite_text.py. Layer B needs a real rewrite backend (default: ollama on
+loopback); the CLI's print-prompt backend is rejected here because it
+returns a rewrite prompt, not cleaned text.
+
+Sandbox note: Panoptes evaluate-repo scrubs env vars containing API_KEY /
+TOKEN / etc. before running an adapter, so WATERMARKS_REWRITE_API_KEY never
+reaches this process there — under evaluate-repo, Layer B is limited to
+loopback backends that need no key (e.g. a local Ollama).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent
+_SCRIPTS = _REPO_ROOT / "service" / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from text_unicode import clean_text  # noqa: E402
+
+_LAYER_B_ENV = "WATERMARKS_REMOVER_ADAPTER_LAYER_B"
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+# Conservative general-purpose rewrite strength; the CLI default.
+_LAYER_B_STRENGTH = "paraphrase"
+
+
+def _flag(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in _TRUTHY
+
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, ""))
+    except ValueError:
+        return default
+
+
+def _layer_b(text: str) -> str:
+    """Run the Layer B statistical rewrite, configured via WATERMARKS_REWRITE_*."""
+    from rewrite_text import rewrite  # lazy: keep `import panoptes_adapter` side-effect-light
+
+    backend = os.environ.get("WATERMARKS_REWRITE_BACKEND", "").strip() or "ollama"
+    if backend == "print-prompt":
+        raise RuntimeError(
+            "WATERMARKS_REWRITE_BACKEND=print-prompt cannot drive the Panoptes adapter: "
+            "it returns a rewrite prompt, not cleaned text. Use ollama or openai-compatible."
+        )
+    model = os.environ.get("WATERMARKS_REWRITE_MODEL") or None
+    if model is None:
+        raise RuntimeError(
+            f"Layer B requested ({_LAYER_B_ENV}=1) but WATERMARKS_REWRITE_MODEL is unset"
+        )
+    effort = os.environ.get("WATERMARKS_REWRITE_REASONING_EFFORT", "none")
+    rewritten, _info = rewrite(
+        text,
+        backend=backend,
+        model=model,
+        base_url=os.environ.get("WATERMARKS_REWRITE_BASE_URL", "http://127.0.0.1:11434"),
+        api_key=os.environ.get("WATERMARKS_REWRITE_API_KEY"),
+        strength=_LAYER_B_STRENGTH,
+        lang="French",
+        original_lang="English",
+        timeout=120.0,
+        layer_a_after=True,  # scrub any invisibles the rewrite model emits
+        temperature=0.9,
+        candidates=_int_env("WATERMARKS_REWRITE_CANDIDATES", 1),
+        max_loops=_int_env("WATERMARKS_REWRITE_LOOPS", 1),
+        allow_remote=_flag("WATERMARKS_REWRITE_ALLOW_REMOTE"),
+        reasoning_effort=None if effort == "off" else effort,
+    )
+    return rewritten
+
+
+def transform(text: str) -> str:
+    """Return ``text`` with watermarks removed (Layer A; opt-in Layer B)."""
+    cleaned, _stats = clean_text(text)
+    if _flag(_LAYER_B_ENV):
+        return _layer_b(cleaned)
+    return cleaned

--- a/panoptes_adapter.py
+++ b/panoptes_adapter.py
@@ -19,8 +19,12 @@ returns a rewrite prompt, not cleaned text.
 
 Sandbox note: Panoptes evaluate-repo scrubs env vars containing API_KEY /
 TOKEN / etc. before running an adapter, so WATERMARKS_REWRITE_API_KEY never
-reaches this process there — under evaluate-repo, Layer B is limited to
-loopback backends that need no key (e.g. a local Ollama).
+reaches this process there and keyed remote backends cannot authenticate.
+Layer B defaults to a loopback backend (local Ollama); setting
+WATERMARKS_REWRITE_ALLOW_REMOTE=1 permits a keyless non-loopback backend to
+receive evaluated text even under evaluate-repo — that variable is not a
+credential and is not scrubbed. evaluate-repo only disables networking
+entirely when the caller passes --docker.
 """
 
 from __future__ import annotations

--- a/tests/test_panoptes_adapter.py
+++ b/tests/test_panoptes_adapter.py
@@ -1,0 +1,186 @@
+"""Tests for the Panoptes adapter contract (panoptes_adapter.py + manifest)."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "service" / "scripts"
+for _p in (str(ROOT), str(SCRIPTS)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from text_unicode import clean_text
+
+import panoptes_adapter
+
+_ADAPTER_ENV = (
+    "WATERMARKS_REMOVER_ADAPTER_LAYER_B",
+    "WATERMARKS_REWRITE_BACKEND",
+    "WATERMARKS_REWRITE_MODEL",
+    "WATERMARKS_REWRITE_BASE_URL",
+    "WATERMARKS_REWRITE_API_KEY",
+    "WATERMARKS_REWRITE_ALLOW_REMOTE",
+    "WATERMARKS_REWRITE_REASONING_EFFORT",
+    "WATERMARKS_REWRITE_CANDIDATES",
+    "WATERMARKS_REWRITE_LOOPS",
+)
+
+# Invisible carriers, kept as explicit escapes so they stay visible to reviewers.
+ZWSP = chr(0x200B)
+SOFT_HYPHEN = chr(0x00AD)
+EM_SPACE = chr(0x2003)
+IDEOGRAPHIC_SPACE = chr(0x3000)
+TAG_LATIN_A = chr(0xE0041)  # TAG LATIN CAPITAL LETTER A
+RLO = chr(0x202E)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in _ADAPTER_ENV:
+        monkeypatch.delenv(name, raising=False)
+
+
+# Cases mirror tests/test_clean_text.py.
+PARITY_CASES = [
+    f"Hello{ZWSP}World{SOFT_HYPHEN}!",
+    f"a{EM_SPACE}b{IDEOGRAPHIC_SPACE}c",
+    f"hi{TAG_LATIN_A}there",
+    f"ab{RLO}ef",  # override: stripped by default
+    # Legitimate bidi marks (LRI U+2066, PDI U+2069, RLM U+200F): preserved by default.
+    "السعر " + chr(0x2066) + "123 USD" + chr(0x2069) + chr(0x200F),
+    "plain ASCII stays put",
+    (
+        f"The committee{ZWSP}approved the{SOFT_HYPHEN}budget at{EM_SPACE}14:00.\n"
+        f"Minutes{ZWSP}were{TAG_LATIN_A}circulated."
+    ),
+]
+
+
+def test_manifest_is_valid_and_resolves() -> None:
+    data = json.loads((ROOT / "panoptes.adapter.json").read_text(encoding="utf-8"))
+    assert data["kind"] == "watermark-remover"
+    assert data["requires_network"] is False
+    entry = data["entry"]
+    assert entry["module"] == "panoptes_adapter"
+    module = importlib.import_module(entry["module"])
+    assert callable(getattr(module, entry["callable"]))
+
+
+@pytest.mark.parametrize("raw", PARITY_CASES)
+def test_transform_matches_clean_text(raw: str) -> None:
+    expected, _stats = clean_text(raw)
+    assert panoptes_adapter.transform(raw) == expected
+
+
+def test_transform_strips_invisible_watermark_carriers() -> None:
+    raw = f"hi{TAG_LATIN_A} the{ZWSP}re"
+    assert panoptes_adapter.transform(raw) == "hi there"
+
+
+def test_transform_idempotent() -> None:
+    for raw in PARITY_CASES:
+        once = panoptes_adapter.transform(raw)
+        assert panoptes_adapter.transform(once) == once
+
+
+def test_transform_preserves_legitimate_bidi_marks() -> None:
+    raw = "السعر " + chr(0x2066) + "123 USD" + chr(0x2069) + chr(0x200F)
+    assert panoptes_adapter.transform(raw) == raw
+
+
+def test_transform_empty_string() -> None:
+    assert panoptes_adapter.transform("") == ""
+
+
+def test_transform_large_input() -> None:
+    base = "The quick brown fox jumps over the lazy dog. "
+    raw = base * 24_000 + ZWSP * 100  # ~1 MiB with trailing zero-width marks
+    expected, _stats = clean_text(raw)
+    out = panoptes_adapter.transform(raw)
+    assert out == expected
+    assert ZWSP not in out
+
+
+def test_layer_b_off_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WATERMARKS_REWRITE_BACKEND", "ollama")
+    monkeypatch.setenv("WATERMARKS_REWRITE_MODEL", "llama3.2")
+
+    def _boom(text: str, **kwargs: object) -> tuple[str, dict]:
+        raise AssertionError("rewrite must not run unless Layer B is opted in")
+
+    monkeypatch.setitem(sys.modules, "rewrite_text", SimpleNamespace(rewrite=_boom))
+    assert panoptes_adapter.transform(f"a{ZWSP}b") == "ab"
+
+
+def _install_fake_rewrite(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
+    calls: list[dict] = []
+
+    def _fake(text: str, **kwargs: object) -> tuple[str, dict]:
+        calls.append({"text": text, **kwargs})
+        return "REWRITTEN", {}
+
+    monkeypatch.setitem(sys.modules, "rewrite_text", SimpleNamespace(rewrite=_fake))
+    return calls
+
+
+def test_layer_b_opt_in_routes_to_rewrite(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WATERMARKS_REMOVER_ADAPTER_LAYER_B", "1")
+    monkeypatch.setenv("WATERMARKS_REWRITE_MODEL", "llama3.2")
+    calls = _install_fake_rewrite(monkeypatch)
+
+    assert panoptes_adapter.transform(f"a{ZWSP}b") == "REWRITTEN"
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["text"] == "ab"  # Layer A runs first
+    assert call["backend"] == "ollama"
+    assert call["model"] == "llama3.2"
+    assert call["layer_a_after"] is True
+    assert call["allow_remote"] is False
+    assert call["candidates"] == 1
+    assert call["max_loops"] == 1
+    assert call["reasoning_effort"] == "none"
+    assert call["api_key"] is None
+
+
+def test_layer_b_maps_env_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WATERMARKS_REMOVER_ADAPTER_LAYER_B", "true")
+    monkeypatch.setenv("WATERMARKS_REWRITE_BACKEND", "openai-compatible")
+    monkeypatch.setenv("WATERMARKS_REWRITE_MODEL", "deepseek-v4-flash")
+    monkeypatch.setenv("WATERMARKS_REWRITE_BASE_URL", "https://api.deepseek.com")
+    monkeypatch.setenv("WATERMARKS_REWRITE_API_KEY", "sk-test")
+    monkeypatch.setenv("WATERMARKS_REWRITE_ALLOW_REMOTE", "1")
+    monkeypatch.setenv("WATERMARKS_REWRITE_REASONING_EFFORT", "off")
+    monkeypatch.setenv("WATERMARKS_REWRITE_CANDIDATES", "3")
+    monkeypatch.setenv("WATERMARKS_REWRITE_LOOPS", "2")
+    calls = _install_fake_rewrite(monkeypatch)
+
+    panoptes_adapter.transform("x")
+    call = calls[0]
+    assert call["backend"] == "openai-compatible"
+    assert call["model"] == "deepseek-v4-flash"
+    assert call["base_url"] == "https://api.deepseek.com"
+    assert call["api_key"] == "sk-test"
+    assert call["allow_remote"] is True
+    assert call["reasoning_effort"] is None  # "off" omits the parameter
+    assert call["candidates"] == 3
+    assert call["max_loops"] == 2
+
+
+def test_layer_b_rejects_print_prompt_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WATERMARKS_REMOVER_ADAPTER_LAYER_B", "1")
+    monkeypatch.setenv("WATERMARKS_REWRITE_BACKEND", "print-prompt")
+    with pytest.raises(RuntimeError, match="print-prompt"):
+        panoptes_adapter.transform("x")
+
+
+def test_layer_b_requires_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WATERMARKS_REMOVER_ADAPTER_LAYER_B", "1")
+    with pytest.raises(RuntimeError, match="WATERMARKS_REWRITE_MODEL"):
+        panoptes_adapter.transform("x")


### PR DESCRIPTION
## Summary

From [Discussion #215](https://github.com/guillaumemeyer/watermarks-remover/discussions/215): removers are family-specific, so make the family split measurable by anyone. This PR ships a native [Panoptes](https://github.com/marketstandard/Panoptes) adapter — `panoptes.adapter.json` + `panoptes_adapter.py` at the repo root — so the Panoptes workbench can evaluate this repo's watermark removal directly and emit a signed before/after card, with no injected adapter:

```bash
python -m bench evaluate-repo \
  https://github.com/guillaumemeyer/watermarks-remover --kind watermark-remover
```

cc @bentalay

## What the evaluation shows

Signed card from running the command above against this branch (`--ref feat/panoptes-adapter` on my fork):

| Family | Before | After |
| --- | --- | --- |
| Unicode (zero-width carriers, n=96) | 100% present | **0% present** |
| KGW statistical (z-score, n=96) | 100% detected | **100% detected** (mean z 7.127 unchanged) |

Layer A is complete for the family it targets and a no-op for statistical marks — the card makes that asymmetry a reproducible artifact instead of an anecdote.

## Design

- `transform(text) -> str` wraps `service/scripts/text_unicode.clean_text` with Layer A defaults: deterministic, no network, no model, no key.
- Opt-in Layer B via `WATERMARKS_REMOVER_ADAPTER_LAYER_B=1`, reusing the `WATERMARKS_REWRITE_*` configuration from `rewrite_text.py`. The `print-prompt` backend is rejected in the adapter — it returns a prompt, not cleaned text.
- Documented caveat: Panoptes' evaluate-repo sandbox scrubs env vars containing `API_KEY`/`TOKEN`, so `WATERMARKS_REWRITE_API_KEY` never reaches the adapter subprocess — under evaluate-repo, Layer B is limited to loopback backends. Keyed remote backends should use the SynthID-text benchmark instead.
- `.gitignore`: the repo is deny-by-default, so the two adapter files get explicit allowlist entries.
- Purely additive: 4 new files, 3 small doc/config edits, no changes to existing code paths.

## Test plan

- 18 new tests in `tests/test_panoptes_adapter.py`: `clean_text` parity across the Unicode carrier families, idempotence, empty/large (~1 MiB) inputs, manifest contract (kind, entry resolution, `requires_network: false`), Layer B routing + env mapping + misconfiguration errors, legitimate bidi-mark preservation.
- Local CI replication with the pinned dev deps (pytest 9.1.1, ruff 0.16.3): `pytest -q` — 632 tests, only the 4 pre-existing Windows TCP failures that also fail on the untouched baseline (`test_http_server` ×3, `test_rewrite_text` ×1, all `WinError 10054`); `ruff check` and `ruff format --check` clean.
- E2E: `python -m bench evaluate-repo <fork> --ref feat/panoptes-adapter --kind watermark-remover` (no `--adapter-path`) reproduces the signed card exactly:

```json
{
  "kgw": {"detection_rate_before": 1.0, "detection_rate_after": 1.0,
          "mean_z_before": 7.126828784477168, "mean_z_after": 7.126828784477168, "n": 96},
  "unicode": {"present_rate_before": 1.0, "present_rate_after": 0.0, "n": 96}
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Panoptes adapter for deterministic Unicode cleanup and invisible watermark removal.
  - Added optional Layer B statistical rewriting with configurable backend and model settings.
  - Added repository evaluation with signed before-and-after result cards and watermark-family metrics.

- **Documentation**
  - Documented setup, configuration, evaluation commands, security restrictions, credential handling, and sandbox limitations.

- **Tests**
  - Added coverage for text cleaning, watermark handling, idempotence, large inputs, manifest validation, and Layer B configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->