### PR TITLE
feat: Panoptes cross-detector second opinion for the SynthID-text bench

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,3 +54,10 @@ HF_TOKEN=
 # WATERMARKS_REWRITE_REASONING_EFFORT=none # none/low/medium/high, or off to omit
 # WATERMARKS_REWRITE_CANDIDATES=1          # variants generated per evaluation round (default 1)
 # WATERMARKS_REWRITE_LOOPS=1               # max evaluation rounds; retries new variants until one passes (default 1)
+
+# ---------------------------------------------------------------------------
+# Panoptes cross-detector (bench_synthid_text.py --cross-detect panoptes;
+# docs/synthid-text-benchmark.md)
+# ---------------------------------------------------------------------------
+# PANOPTES_API_URL=http://127.0.0.1:8000   # `panoptes up` serves the API here
+# PANOPTES_TIMEOUT=30                      # seconds per analyze call

--- a/docs/synthid-text-benchmark.md
+++ b/docs/synthid-text-benchmark.md
@@ -83,6 +83,38 @@ chars / --chars-per-token estimates (default 4.0).
 - results.csv - one row per (doc, seed, variant) for plotting.
 - work/ - generated watermarked/unwatermarked samples (kept for inspection).
 
+## Cross-detector second opinion (--cross-detect)
+
+Same-config MarkLLM detection answers "did the mark survive under the config
+that made it?" It cannot answer "does the text still look machine-generated
+to an independent system?" — that needs a second opinion that shares no
+config, keys, or code with the generator:
+
+```bash
+PANOPTES_API_URL=http://127.0.0.1:8000 \
+python3 service/scripts/bench_synthid_text.py --markllm-dir ~/MarkLLM \
+  --rewrite-model llama3.2 --cross-detect panoptes
+```
+
+With `--cross-detect panoptes`, every row's output text is also POSTed to a
+[Panoptes](https://github.com/marketstandard/Panoptes) workbench
+(`panoptes up` serves the API on loopback). The report gains a
+"Cross-detector second opinion" section and results.csv gains
+`cross_panoptes_pos/score/ai` columns. Control rows double as the
+pre-removal baseline, so compare rewrite rows against control.
+
+What the tier proves and what it cannot:
+
+- The Panoptes KGW reading is scoped to Panoptes' baked **demo key** — it
+  detects only watermarks made with that key, so it stays silent on this
+  MarkLLM-generated corpus (expect 0 positives; a positive would be a bug).
+- The calibrated **AI posterior** is the watermark-agnostic signal: a
+  rewrite that clears the mark but leaves the posterior pinned near 1.0 has
+  changed the mark, not the provenance signal.
+- Fail-soft like every detector here: an unreachable, slow, or malformed
+  Panoptes response is recorded per row (`available: false` + reason) and
+  never fails the run. `PANOPTES_TIMEOUT` overrides the 30s default.
+
 ## Running from Docker (compose)
 
 The `wr-markllm` service in compose.yaml can run the benchmark end-to-end

--- a/docs/synthid-text-benchmark.md
+++ b/docs/synthid-text-benchmark.md
@@ -106,8 +106,10 @@ pre-removal baseline, so compare rewrite rows against control.
 What the tier proves and what it cannot:
 
 - The Panoptes KGW reading is scoped to Panoptes' baked **demo key** — it
-  detects only watermarks made with that key, so it stays silent on this
-  MarkLLM-generated corpus (expect 0 positives; a positive would be a bug).
+  detects only watermarks made with that key, so no true matches are
+  expected on this MarkLLM-generated corpus. A positive is not automatically
+  a benchmark bug: it warrants investigation (false positive, or the corpus
+  overlapping the demo key), not dismissal.
 - The calibrated **AI posterior** is the watermark-agnostic signal: a
   rewrite that clears the mark but leaves the posterior pinned near 1.0 has
   changed the mark, not the provenance signal.

--- a/service/scripts/bench_synthid_text.py
+++ b/service/scripts/bench_synthid_text.py
@@ -51,6 +51,7 @@ sys.path.insert(0, str(SCRIPTS_DIR))
 from common import eprint  # noqa: E402
 from detect_text_watermark import SCHEMES  # noqa: E402  (single source of scheme names)
 from rewrite_text import _lexical_divergence  # noqa: E402
+from text_detectors import CROSS_DETECTORS  # noqa: E402
 from text_unicode import clean_text  # noqa: E402
 
 _RESOLVED_SCRIPT = Path(__file__).resolve()
@@ -624,6 +625,10 @@ class Benchmark:
         self.chars_per_token = args.chars_per_token
         self.scheme = args.scheme
         self.config = args.config
+        self.cross = [CROSS_DETECTORS[name]() for name in (args.cross_detect or [])]
+        for d in self.cross:
+            if not d.available():
+                eprint(f"cross-detector {d.name}: not reachable now; rows will record the reason")
         self.worker = None
         if not args.no_worker:
             try:
@@ -716,6 +721,10 @@ class Benchmark:
         )
 
     # -- phases ------------------------------------------------------------
+
+    def _cross(self, text: str) -> dict[str, Any]:
+        """Independent second-opinion detectors (--cross-detect); fail-soft."""
+        return {d.name: d.detect(text) for d in self.cross}
 
     def generate_samples(self, workdir: Path) -> list[dict[str, Any]]:
         """Generate and sanity-check watermarked/unwatermarked pairs."""
@@ -897,24 +906,23 @@ class Benchmark:
                         )
                         continue
                     after = self.detect(out_text)
-                    rows.append(
-                        {
-                            **base,
-                            "variant": variant,
-                            "kind": "restamp",
-                            "after_pos": _detect_positive(after),
-                            "score_after": _score_of(after),
-                            "cleared": None,
-                            "quality": _quality(
-                                sample["unwatermarked"], out_text, self.chars_per_token
-                            ),
-                            "notes": (
-                                ["re-stamped by rewrite backend"]
-                                if _detect_positive(after)
-                                else [],
-                            ),
-                        }
-                    )
+                    restamp_row: dict[str, Any] = {
+                        **base,
+                        "variant": variant,
+                        "kind": "restamp",
+                        "after_pos": _detect_positive(after),
+                        "score_after": _score_of(after),
+                        "cleared": None,
+                        "quality": _quality(
+                            sample["unwatermarked"], out_text, self.chars_per_token
+                        ),
+                        "notes": (
+                            ["re-stamped by rewrite backend"] if _detect_positive(after) else []
+                        ),
+                    }
+                    if self.cross:
+                        restamp_row["cross"] = self._cross(out_text)
+                    rows.append(restamp_row)
             cleared_count = sum(
                 1
                 for r in rows
@@ -964,6 +972,10 @@ class Benchmark:
             row["notes"].append("no removal applied (baseline)")
         elif kind == "layer-a":
             row["notes"].append("Layer A only; statistical marks are expected to survive")
+        if self.cross:
+            # Cross-detection runs on the row's output text; control rows
+            # (candidate == watermarked text) double as the pre-removal baseline.
+            row["cross"] = self._cross(candidate)
         return row
 
 
@@ -1042,6 +1054,20 @@ def aggregate(rows: list[dict[str, Any]], variants: list[tuple[str, int]]) -> di
                 {n for r in group for n in (r.get("notes") or []) if isinstance(n, str)}
             ),
         }
+        cross_names = sorted({n for r in group for n in (r.get("cross") or {})})
+        for name in cross_names:
+            reports = [(r.get("cross") or {}).get(name) or {} for r in group]
+            avail = [rep for rep in reports if rep.get("available")]
+            ai = [
+                rep["ai_generation"]
+                for rep in avail
+                if isinstance(rep.get("ai_generation"), (int, float))
+            ]
+            entries[f"cross_{name}"] = {
+                "n_available": len(avail),
+                "kgw_positive": sum(1 for rep in avail if rep.get("is_watermarked")),
+                "mean_ai_generation": round(_mean(ai), 4) if ai else None,
+            }
         out[variant] = entries
     return out
 
@@ -1134,6 +1160,35 @@ def render_markdown(
     else:
         L.append("- Re-stamp control: not run (pass --restamp-control)")
     L.append("")
+    cross_names = sorted({n for r in rows for n in (r.get("cross") or {})})
+    for name in cross_names:
+        L.append(f"## Cross-detector second opinion: {name}")
+        L.append("")
+        L.append(
+            "An independent detector (--cross-detect) scored every row's output "
+            "text; control rows (no removal) double as the pre-removal baseline."
+        )
+        L.append("")
+        L.append("| Variant | n | available | kgw+ (demo key) | AI posterior μ |")
+        L.append("| --- | ---: | ---: | ---: | ---: |")
+        for variant, a in agg.items():
+            c = a.get(f"cross_{name}")
+            if not c:
+                continue
+            L.append(
+                f"| {variant} | {a['n']} | {c['n_available']} | "
+                f"{c['kgw_positive']} | {_fmt(c['mean_ai_generation'])} |"
+            )
+        L.append("")
+        if name == "panoptes":
+            L.append(
+                "**Caveat:** the panoptes KGW reading is scoped to Panoptes' baked demo "
+                "key — it detects only watermarks made with that key, so it stays silent "
+                "on this MarkLLM-generated corpus (expect 0 positives). The AI posterior "
+                "is the watermark-agnostic signal: compare rewrite rows against the "
+                "control baseline to see whether removal still reads as machine-generated."
+            )
+            L.append("")
     L.append("## Reproduction")
     L.append("")
     L.append("    " + config["command"])
@@ -1175,6 +1230,17 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument(
         "--restamp-control", action="store_true", help="Also rewrite the unwatermarked control"
+    )
+    p.add_argument(
+        "--cross-detect",
+        action="append",
+        choices=sorted(CROSS_DETECTORS),
+        default=None,
+        metavar="DETECTOR",
+        help="Also score every row's output text with an independent detector "
+        f"({', '.join(sorted(CROSS_DETECTORS))}); repeatable. panoptes needs "
+        "PANOPTES_API_URL (e.g. http://127.0.0.1:8000 from `panoptes up`). "
+        "Control rows double as the pre-removal baseline.",
     )
     p.add_argument("--out-dir", type=Path, default=Path("bench-synthid-text-results"))
     p.add_argument("--tag", default="", help="Short label for the report")
@@ -1282,6 +1348,7 @@ def main() -> int:
         "rewrite_temperature": args.rewrite_temperature,
         "rewrite_loops": args.rewrite_loops,
         "restamp_control": args.restamp_control,
+        "cross_detect": args.cross_detect or [],
         "chars_per_token": args.chars_per_token,
         "cost_per_mtok_in": args.cost_per_mtok_in,
         "cost_per_mtok_out": args.cost_per_mtok_out,
@@ -1301,6 +1368,7 @@ def main() -> int:
                 f"--rewrite-temperature {args.rewrite_temperature}",
                 f"--rewrite-loops {args.rewrite_loops}",
                 *(["--restamp-control"] if args.restamp_control else []),
+                *[f"--cross-detect {name}" for name in (args.cross_detect or [])],
                 *(["--rewrite-allow-remote"] if args.rewrite_allow_remote else []),
                 f"--out-dir {args.out_dir}",
                 f"--tag {tag}",
@@ -1332,11 +1400,15 @@ def main() -> int:
     agg = aggregate(rows, bench.variants)
 
     report = render_markdown(config, samples, rows, agg)
-    csv_lines = [
+    cross_names = [d.name for d in bench.cross]
+    csv_header = (
         "doc,seed,variant,kind,attempts,evaluator,passed,before_pos,after_pos,cleared,"
         "score_before,score_after,score_delta,lexical_divergence,length_ratio,"
         "numbers_preserved,urls_preserved,tokens_in,tokens_out,seconds,usd,notes"
-    ]
+    )
+    for name in cross_names:
+        csv_header += f",cross_{name}_pos,cross_{name}_score,cross_{name}_ai"
+    csv_lines = [csv_header]
     for r in rows:
         q = r.get("quality") or {}
         delta = (
@@ -1344,6 +1416,17 @@ def main() -> int:
             if r.get("score_before") is not None and r.get("score_after") is not None
             else ""
         )
+        cross_cells: list[Any] = []
+        for name in cross_names:
+            rep = (r.get("cross") or {}).get(name) or {}
+            pos = rep.get("is_watermarked")
+            score = rep.get("score")
+            ai = rep.get("ai_generation")
+            cross_cells += [
+                "" if pos is None else (1 if pos else 0),
+                "" if score is None else score,
+                "" if ai is None else ai,
+            ]
         csv_lines.append(
             ",".join(
                 str(v)
@@ -1370,6 +1453,7 @@ def main() -> int:
                     r.get("seconds", ""),
                     round(r.get("usd") or 0.0, 6),
                     "; ".join(str(n) for n in r.get("notes") or []),
+                    *cross_cells,
                 )
             )
         )

--- a/service/scripts/bench_synthid_text.py
+++ b/service/scripts/bench_synthid_text.py
@@ -1183,10 +1183,12 @@ def render_markdown(
         if name == "panoptes":
             L.append(
                 "**Caveat:** the panoptes KGW reading is scoped to Panoptes' baked demo "
-                "key — it detects only watermarks made with that key, so it stays silent "
-                "on this MarkLLM-generated corpus (expect 0 positives). The AI posterior "
-                "is the watermark-agnostic signal: compare rewrite rows against the "
-                "control baseline to see whether removal still reads as machine-generated."
+                "key — it detects only watermarks made with that key, so no true matches "
+                "are expected on this MarkLLM-generated corpus; any positive warrants "
+                "investigation (false positive or key reuse), not an automatic benchmark "
+                "defect. The AI posterior is the watermark-agnostic signal: compare "
+                "rewrite rows against the control baseline to see whether removal still "
+                "reads as machine-generated."
             )
             L.append("")
     L.append("## Reproduction")

--- a/service/scripts/text_detectors.py
+++ b/service/scripts/text_detectors.py
@@ -24,6 +24,10 @@ Detectors:
 - claude-text — placeholder for Anthropic's announced text-watermark
   detection API. Reports unavailable until a public endpoint exists; the
   interface it must implement is already defined here.
+- panoptes — independent second opinion from a Panoptes workbench over
+  HTTP, activated by PANOPTES_API_URL. KGW is scoped to Panoptes' baked
+  demo key; the calibrated AI posteriors are the watermark-agnostic
+  cross-check.
 
 Vendor note (Aug 2026): Google retired SynthID text watermarking on the
 Generative Language API — API text output is no longer watermarked and
@@ -40,9 +44,12 @@ import os
 import subprocess
 import sys
 import tempfile
+import urllib.error
+import urllib.request
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Protocol
+from urllib.parse import urlparse
 
 from detect_gumbel import DEFAULT_THRESHOLD, DEFAULT_WINDOW, detect_text
 
@@ -360,6 +367,137 @@ class ClaudeTextDetector:
 
 
 # ---------------------------------------------------------------------------
+# Panoptes — independent cross-detector workbench (HTTP)
+# ---------------------------------------------------------------------------
+
+PANOPTES_DEFAULT_TIMEOUT = 30.0
+PANOPTES_MAX_RESPONSE_BYTES = 1 << 20  # 1 MiB, mirroring MAX_CONFIG_BYTES discipline
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Refuse HTTP redirects.
+
+    urllib's default handler re-sends request headers on 301/302/303; for a
+    user-configured analysis endpoint a silent redirect would forward
+    submitted text to an unvalidated host. Any 3xx now surfaces as HTTPError.
+    (Local copy: rewrite_text._NoRedirect cannot be imported here without a
+    circular import.)
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        raise urllib.error.HTTPError(req.full_url, code, msg, headers, fp)
+
+
+class PanoptesTextDetector:
+    """Independent second opinion from a Panoptes workbench over HTTP.
+
+    Activated by PANOPTES_API_URL (e.g. http://127.0.0.1:8000 from
+    ``panoptes up``). Posts the text to /api/v1/analyze and maps the
+    response onto the detector contract:
+
+    - is_watermarked / score come from Panoptes' KGW adapter, which is keyed
+      to Panoptes' baked demo key — it detects only watermarks made with
+      that key, so it stays silent on third-party (e.g. MarkLLM) marks.
+    - ai_generation / ai_participation are the calibrated, watermark-agnostic
+      posteriors: the informative cross-check on whether a rewrite still
+      reads as machine-generated.
+
+    Fail-soft like every detector here: unreachable, slow, oversize, or
+    malformed responses return available=False with an error; never raises.
+    """
+
+    name = "panoptes"
+    vendor = "marketstandard"
+
+    def __init__(self, *, url: str | None = None, timeout: float | None = None) -> None:
+        self._url = url
+        self._timeout = timeout
+
+    def _base_url(self) -> str | None:
+        raw = self._url if self._url is not None else os.environ.get("PANOPTES_API_URL", "")
+        raw = raw.strip()
+        if not raw:
+            return None
+        u = urlparse(raw)
+        if u.scheme not in ("http", "https") or not u.hostname:
+            return None
+        return raw.rstrip("/")
+
+    def available(self) -> bool:
+        return self._base_url() is not None
+
+    def detect(self, text: str) -> dict[str, Any]:
+        report: dict[str, Any] = {
+            "detector": self.name,
+            "scheme": "kgw",
+            "vendor": self.vendor,
+            "available": False,
+        }
+        base = self._base_url()
+        if base is None:
+            report["error"] = "PANOPTES_API_URL not set or not a valid http(s) URL"
+            return report
+        timeout = (
+            self._timeout
+            if self._timeout is not None
+            else _env_float("PANOPTES_TIMEOUT", PANOPTES_DEFAULT_TIMEOUT)
+        )
+        body = json.dumps({"text": text, "content_type": "prose"}).encode("utf-8")
+        # S310: URL scheme is restricted to http/https in _base_url above.
+        req = urllib.request.Request(  # noqa: S310
+            f"{base}/api/v1/analyze",
+            data=body,
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
+            method="POST",
+        )
+        opener = urllib.request.build_opener(_NoRedirect())
+        try:
+            with opener.open(req, timeout=timeout) as resp:
+                payload = resp.read(PANOPTES_MAX_RESPONSE_BYTES + 1)
+        except (urllib.error.URLError, TimeoutError, OSError, RuntimeError) as e:
+            report["error"] = f"panoptes analyze failed: {e}"
+            return report
+        if len(payload) > PANOPTES_MAX_RESPONSE_BYTES:
+            report["error"] = f"panoptes response exceeds {PANOPTES_MAX_RESPONSE_BYTES} bytes"
+            return report
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError as e:
+            report["error"] = f"bad panoptes JSON: {e}"
+            return report
+        if not isinstance(data, dict):
+            report["error"] = "bad panoptes response"
+            return report
+
+        summary = data.get("summary") or {}
+        kgw = next(
+            (
+                w
+                for w in (data.get("watermarks") or [])
+                if isinstance(w, dict) and w.get("scheme") == "kgw-v1"
+            ),
+            None,
+        )
+        kgw_tested = kgw is not None and kgw.get("status") == "tested"
+        report["available"] = True
+        report["is_watermarked"] = bool((kgw.get("p_value") or 1.0) < 0.05) if kgw_tested else None
+        report["score"] = kgw.get("z") if kgw_tested else None
+        report["kgw"] = (
+            {"status": kgw.get("status"), "z": kgw.get("z"), "p_value": kgw.get("p_value")}
+            if kgw is not None
+            else None
+        )
+        report["ai_generation"] = summary.get("ai_generation")
+        report["ai_participation"] = summary.get("ai_participation")
+        report["note"] = (
+            "Independent Panoptes analysis. KGW is scoped to Panoptes' baked demo "
+            "key — it detects only watermarks made with that key, not third-party "
+            "(e.g. MarkLLM) marks; the AI posteriors are the watermark-agnostic signal."
+        )
+        return report
+
+
+# ---------------------------------------------------------------------------
 # Registry
 # ---------------------------------------------------------------------------
 
@@ -377,7 +515,13 @@ def all_detectors(
     if include_gumbel:
         detectors.append(gumbel or GumbelTextDetector())
     detectors.append(ClaudeTextDetector())
+    detectors.append(PanoptesTextDetector())
     return detectors
+
+
+# Detectors selectable via bench_synthid_text.py --cross-detect <name>:
+# independent second opinions scored alongside the same-config detection.
+CROSS_DETECTORS: dict[str, Callable[[], TextDetector]] = {"panoptes": PanoptesTextDetector}
 
 
 def detector_status() -> dict[str, bool]:

--- a/service/scripts/text_detectors.py
+++ b/service/scripts/text_detectors.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import math
 import os
 import subprocess
 import sys
@@ -67,9 +68,11 @@ class TextDetector(Protocol):
 
 def _env_float(name: str, default: float) -> float:
     try:
-        return float(os.environ.get(name, str(default)))
+        value = float(os.environ.get(name, str(default)))
     except ValueError:
         return default
+    # urllib raises ValueError on non-finite or negative timeouts; fall back.
+    return value if math.isfinite(value) and value > 0 else default
 
 
 def _worker_port() -> int | None:
@@ -442,6 +445,9 @@ class PanoptesTextDetector:
             if self._timeout is not None
             else _env_float("PANOPTES_TIMEOUT", PANOPTES_DEFAULT_TIMEOUT)
         )
+        if not math.isfinite(timeout) or timeout <= 0:
+            report["error"] = f"invalid panoptes timeout: {timeout!r}"
+            return report
         body = json.dumps({"text": text, "content_type": "prose"}).encode("utf-8")
         # S310: URL scheme is restricted to http/https in _base_url above.
         req = urllib.request.Request(  # noqa: S310
@@ -469,26 +475,34 @@ class PanoptesTextDetector:
             report["error"] = "bad panoptes response"
             return report
 
-        summary = data.get("summary") or {}
+        summary = data.get("summary")
+        watermarks = data.get("watermarks")
+        if summary is not None and not isinstance(summary, dict):
+            report["error"] = "bad panoptes response: summary is not an object"
+            return report
+        if watermarks is not None and not isinstance(watermarks, list):
+            report["error"] = "bad panoptes response: watermarks is not a list"
+            return report
         kgw = next(
-            (
-                w
-                for w in (data.get("watermarks") or [])
-                if isinstance(w, dict) and w.get("scheme") == "kgw-v1"
-            ),
+            (w for w in (watermarks or []) if isinstance(w, dict) and w.get("scheme") == "kgw-v1"),
             None,
         )
         kgw_tested = kgw is not None and kgw.get("status") == "tested"
+        z = kgw.get("z") if kgw_tested else None
+        p_value = kgw.get("p_value") if kgw_tested else None
+        if any(v is not None and not isinstance(v, (int, float)) for v in (z, p_value)):
+            report["error"] = "bad panoptes response: non-numeric kgw field"
+            return report
         report["available"] = True
-        report["is_watermarked"] = bool((kgw.get("p_value") or 1.0) < 0.05) if kgw_tested else None
-        report["score"] = kgw.get("z") if kgw_tested else None
+        report["is_watermarked"] = (p_value is not None and p_value < 0.05) if kgw_tested else None
+        report["score"] = z
         report["kgw"] = (
             {"status": kgw.get("status"), "z": kgw.get("z"), "p_value": kgw.get("p_value")}
             if kgw is not None
             else None
         )
-        report["ai_generation"] = summary.get("ai_generation")
-        report["ai_participation"] = summary.get("ai_participation")
+        report["ai_generation"] = (summary or {}).get("ai_generation")
+        report["ai_participation"] = (summary or {}).get("ai_participation")
         report["note"] = (
             "Independent Panoptes analysis. KGW is scoped to Panoptes' baked demo "
             "key — it detects only watermarks made with that key, not third-party "

--- a/tests/test_bench_synthid_text.py
+++ b/tests/test_bench_synthid_text.py
@@ -60,6 +60,7 @@ def _args(**overrides):
         no_worker=True,
         scheme="synthid",
         config=None,
+        cross_detect=None,
     )
     values.update(overrides)
     return argparse.Namespace(**values)
@@ -109,6 +110,24 @@ def _rewrite_stats(cleared=True, evaluator="markllm", attempts_made=1, passed=Tr
         "output_chars": 100,
         "candidate_scores": [],
     }
+
+
+class _FakeCrossDetector:
+    """Deterministic stand-in for a --cross-detect second-opinion detector."""
+
+    name = "panoptes"
+
+    def available(self):
+        return True
+
+    def detect(self, text):
+        return {
+            "detector": self.name,
+            "available": True,
+            "is_watermarked": False,
+            "score": 0.05,
+            "ai_generation": 0.42,
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -325,6 +344,57 @@ def test_restamp_control_rows(tmp_path, monkeypatch):
     assert restamps[0]["after_pos"] in (True, False)
 
 
+def test_cross_detect_flag_parsing():
+    base = ["--markllm-dir", "x", "--rewrite-model", "m"]
+    assert bench.build_parser().parse_args(base).cross_detect is None
+    args = bench.build_parser().parse_args([*base, "--cross-detect", "panoptes"])
+    assert args.cross_detect == ["panoptes"]
+    with pytest.raises(SystemExit):
+        bench.build_parser().parse_args([*base, "--cross-detect", "bogus"])
+
+
+def test_cross_detect_populates_rows_and_aggregate(tmp_path, monkeypatch):
+    b, _ = _make_bench(
+        tmp_path, monkeypatch, docs=1, variants="paraphrase:1", cross_detect=["panoptes"]
+    )
+    monkeypatch.setattr(b, "cross", [_FakeCrossDetector()])
+    samples = b.generate_samples(tmp_path / "work")
+    rows = b.run_variants(samples, tmp_path / "work")
+    scored = [r for r in rows if r["kind"] in ("control", "layer-a", "rewrite")]
+    assert scored and all("cross" in r for r in scored)
+    assert all(r["cross"]["panoptes"]["ai_generation"] == 0.42 for r in scored)
+    agg = aggregate(rows, b.variants)
+    cross = agg["control"]["cross_panoptes"]
+    assert cross["n_available"] == 1
+    assert cross["kgw_positive"] == 0
+    assert cross["mean_ai_generation"] == 0.42
+
+
+def test_cross_detect_records_fail_soft(tmp_path, monkeypatch):
+    """With no Panoptes server reachable, rows record the reason — never crash."""
+    monkeypatch.delenv("PANOPTES_API_URL", raising=False)
+    b, _ = _make_bench(
+        tmp_path, monkeypatch, docs=1, variants="paraphrase:1", cross_detect=["panoptes"]
+    )
+    samples = b.generate_samples(tmp_path / "work")
+    rows = b.run_variants(samples, tmp_path / "work")
+    control = next(r for r in rows if r["kind"] == "control")
+    report = control["cross"]["panoptes"]
+    assert report["available"] is False
+    assert "PANOPTES_API_URL" in report["error"]
+    agg = aggregate(rows, b.variants)
+    assert agg["control"]["cross_panoptes"]["n_available"] == 0
+
+
+def test_cross_detect_off_leaves_rows_untouched(tmp_path, monkeypatch):
+    b, _ = _make_bench(tmp_path, monkeypatch, docs=1, variants="paraphrase:1")
+    samples = b.generate_samples(tmp_path / "work")
+    rows = b.run_variants(samples, tmp_path / "work")
+    assert all("cross" not in r for r in rows)
+    agg = aggregate(rows, b.variants)
+    assert all(not k.startswith("cross_") for v in agg.values() for k in v)
+
+
 # ---------------------------------------------------------------------------
 # Outputs via main()
 # ---------------------------------------------------------------------------
@@ -337,6 +407,7 @@ class _FakeBench:
         self.variants = parse_variants(args.variants)
         self.corpus = load_corpus(args.corpus, args.docs)
         self.chars_per_token = args.chars_per_token
+        self.cross = [_FakeCrossDetector() for _ in (args.cross_detect or [])]
 
     def close_worker(self):
         pass
@@ -356,7 +427,7 @@ class _FakeBench:
         ]
 
     def run_variants(self, samples, workdir):
-        return [
+        rows = [
             {
                 "doc": "d1",
                 "seed": 1,
@@ -418,6 +489,10 @@ class _FakeBench:
                 "notes": [],
             },
         ]
+        for r in rows:
+            if self.cross:
+                r["cross"] = {d.name: d.detect("x") for d in self.cross}
+        return rows
 
 
 def test_main_writes_outputs(tmp_path, monkeypatch, capsys):
@@ -464,6 +539,58 @@ def test_main_writes_outputs(tmp_path, monkeypatch, capsys):
     csv = (out / "results.csv").read_text(encoding="utf-8")
     assert "doc,seed,variant" in csv
     assert "rewrite-paraphrase:1" in csv
+    # No --cross-detect: outputs keep the legacy shape (no cross columns/sections).
+    assert "cross_" not in csv.splitlines()[0]
+    assert "Cross-detector second opinion" not in report
+
+
+def test_main_cross_detect_extends_outputs(tmp_path, monkeypatch, capsys):
+    (tmp_path / "markllm" / "watermark").mkdir(parents=True)
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    (corpus / "d1.txt").write_text("prompt", encoding="utf-8")
+    out = tmp_path / "out"
+    monkeypatch.setattr(bench, "Benchmark", _FakeBench)
+    monkeypatch.setattr(bench, "_repo_commit", lambda: "abc123")
+    monkeypatch.setattr(bench, "_markllm_commit", lambda upstream: "def456")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "bench_synthid_text.py",
+            "--markllm-dir",
+            str(tmp_path / "markllm"),
+            "--corpus",
+            str(corpus),
+            "--docs",
+            "1",
+            "--rewrite-model",
+            "llama3.2",
+            "--variants",
+            "paraphrase:1",
+            "--cross-detect",
+            "panoptes",
+            "--out-dir",
+            str(out),
+            "--tag",
+            "ci-cross",
+        ],
+    )
+    assert bench.main() == 0
+    report = (out / "report.md").read_text(encoding="utf-8")
+    assert "## Cross-detector second opinion: panoptes" in report
+    assert "demo key" in report  # KGW scoping caveat is rendered
+    assert "--cross-detect panoptes" in report  # reproduction command records the flag
+    csv = (out / "results.csv").read_text(encoding="utf-8")
+    header = csv.splitlines()[0]
+    assert header.endswith(",cross_panoptes_pos,cross_panoptes_score,cross_panoptes_ai")
+    rewrite_line = next(line for line in csv.splitlines() if "rewrite-paraphrase:1" in line)
+    assert rewrite_line.endswith(",0,0.05,0.42")  # pos=0, score, AI posterior
+    data = json.loads((out / "results.json").read_text(encoding="utf-8"))
+    assert data["meta"]["cross_detect"] == ["panoptes"]
+    cross = data["aggregates"]["control"]["cross_panoptes"]
+    assert cross["n_available"] == 1
+    assert cross["mean_ai_generation"] == 0.42
 
 
 def test_main_requires_markllm_dir(tmp_path, monkeypatch, capsys):

--- a/tests/test_detect_endpoint.py
+++ b/tests/test_detect_endpoint.py
@@ -100,6 +100,8 @@ def _clean_env(monkeypatch):
         "WATERMARKS_SYNTHID_SCORER_URL",
         "WATERMARKS_SYNTHID_SCORER_API_KEY",
         "MARKLLM_DIR",
+        "PANOPTES_API_URL",
+        "PANOPTES_TIMEOUT",
     ):
         monkeypatch.delenv(key, raising=False)
 
@@ -107,7 +109,7 @@ def _clean_env(monkeypatch):
 def test_capabilities_exposes_detectors(conn):
     status, body = _get(conn, "/capabilities")
     assert status == 200
-    assert set(body["text_detectors"]) == {"markllm", "gumbel", "claude-text"}
+    assert set(body["text_detectors"]) == {"markllm", "gumbel", "claude-text", "panoptes"}
     assert "synthid_http" in body["scorers"]
 
 

--- a/tests/test_text_detectors.py
+++ b/tests/test_text_detectors.py
@@ -23,6 +23,8 @@ def _clean_env(monkeypatch):
         "WATERMARKS_MARKLLM_SCHEME",
         "MARKLLM_DIR",
         "WATERMARKS_MARKLLM_TIMEOUT",
+        "PANOPTES_API_URL",
+        "PANOPTES_TIMEOUT",
     ):
         monkeypatch.delenv(key, raising=False)
 
@@ -248,8 +250,8 @@ def test_run_all_text_detectors_can_exclude_markllm(monkeypatch):
         lambda: pytest.fail("must not construct MarkLLM when excluded"),
     )
     reports = text_detectors.run_all_text_detectors("hello", include_markllm=False)
-    assert len(reports) == 2  # gumbel + claude placeholder
-    assert {r["detector"] for r in reports} == {"gumbel", "claude-text"}
+    assert len(reports) == 3  # gumbel + claude placeholder + panoptes
+    assert {r["detector"] for r in reports} == {"gumbel", "claude-text", "panoptes"}
 
 
 def test_run_all_text_detectors_injects_markllm_instance(monkeypatch, tmp_path):
@@ -284,15 +286,190 @@ def test_claude_placeholder():
 
 def test_detector_status_keys():
     status = text_detectors.detector_status()
-    assert set(status) == {"markllm", "gumbel", "claude-text"}
+    assert set(status) == {"markllm", "gumbel", "claude-text", "panoptes"}
 
 
 def test_run_all_text_detectors_length():
     reports = text_detectors.run_all_text_detectors("hello")
-    assert len(reports) == 3  # markllm + gumbel + claude placeholder
+    assert len(reports) == 4  # markllm + gumbel + claude placeholder + panoptes
     assert all("detector" in r for r in reports)
 
 
 def test_run_text_detectors_filters_unavailable():
     reports = text_detectors.run_text_detectors("hello")
     assert reports == []
+
+
+# --- Panoptes cross-detector -------------------------------------------------
+
+
+def _spin_panoptes(payload=None, *, raw=None, delay=0.0):
+    """Loopback HTTP fake for the Panoptes /api/v1/analyze endpoint."""
+    import http.server
+    import threading
+    import time
+
+    captured: dict = {}
+
+    class _H(http.server.BaseHTTPRequestHandler):
+        def do_POST(self):
+            captured["path"] = self.path
+            captured["body"] = self.rfile.read(int(self.headers["Content-Length"]))
+            if delay:
+                time.sleep(delay)
+            body = raw if raw is not None else json.dumps(payload).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *args):
+            pass
+
+    srv = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _H)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    return srv, captured
+
+
+def _panoptes_url(srv) -> str:
+    return f"http://127.0.0.1:{srv.server_address[1]}"
+
+
+def _panoptes_payload() -> dict:
+    return {
+        "summary": {"ai_generation": 0.91, "ai_participation": 0.95},
+        "watermarks": [
+            {"scheme": "kgw-v1", "status": "tested", "z": 7.13, "p_value": 1e-12},
+        ],
+    }
+
+
+def test_panoptes_unconfigured():
+    det = text_detectors.PanoptesTextDetector()
+    assert det.available() is False
+    report = det.detect("hello")
+    assert report["available"] is False
+    assert "PANOPTES_API_URL" in report["error"]
+
+
+def test_panoptes_rejects_non_http_scheme(monkeypatch):
+    monkeypatch.setenv("PANOPTES_API_URL", "file:///etc/passwd")
+    det = text_detectors.PanoptesTextDetector()
+    assert det.available() is False
+    assert det.detect("hello")["available"] is False
+
+
+def test_panoptes_success_maps_analysis_response():
+    srv, captured = _spin_panoptes(_panoptes_payload())
+    try:
+        det = text_detectors.PanoptesTextDetector(url=_panoptes_url(srv))
+        assert det.available() is True
+        report = det.detect("some text")
+    finally:
+        srv.shutdown()
+        srv.server_close()
+    assert report["available"] is True
+    assert report["is_watermarked"] is True
+    assert report["score"] == 7.13
+    assert report["kgw"]["p_value"] == 1e-12
+    assert report["ai_generation"] == 0.91
+    assert report["ai_participation"] == 0.95
+    assert "demo key" in report["note"]
+    assert captured["path"] == "/api/v1/analyze"
+    assert json.loads(captured["body"]) == {"text": "some text", "content_type": "prose"}
+
+
+def test_panoptes_kgw_not_tested_yields_unknown():
+    payload = _panoptes_payload()
+    payload["watermarks"][0].update({"status": "insufficient_data", "z": None, "p_value": None})
+    srv, _ = _spin_panoptes(payload)
+    try:
+        report = text_detectors.PanoptesTextDetector(url=_panoptes_url(srv)).detect("x")
+    finally:
+        srv.shutdown()
+        srv.server_close()
+    assert report["available"] is True
+    assert report["is_watermarked"] is None
+    assert report["score"] is None
+    assert report["ai_generation"] == 0.91
+
+
+def test_panoptes_unreachable_fails_soft():
+    det = text_detectors.PanoptesTextDetector(url="http://127.0.0.1:1", timeout=2.0)
+    assert det.available() is True  # well-formed URL; reachability is a detect-time concern
+    report = det.detect("hello")
+    assert report["available"] is False
+    assert "failed" in report["error"]
+
+
+def test_panoptes_timeout_fails_soft():
+    srv, _ = _spin_panoptes(_panoptes_payload(), delay=1.5)
+    try:
+        report = text_detectors.PanoptesTextDetector(url=_panoptes_url(srv), timeout=0.2).detect(
+            "x"
+        )
+    finally:
+        srv.shutdown()
+        srv.server_close()
+    assert report["available"] is False
+    assert "failed" in report["error"]
+
+
+def test_panoptes_malformed_json_fails_soft():
+    srv, _ = _spin_panoptes(raw=b"not json")
+    try:
+        report = text_detectors.PanoptesTextDetector(url=_panoptes_url(srv)).detect("x")
+    finally:
+        srv.shutdown()
+        srv.server_close()
+    assert report["available"] is False
+    assert report["error"].startswith("bad panoptes JSON")
+
+
+def test_panoptes_oversize_response_fails_soft():
+    raw = b" " * (text_detectors.PANOPTES_MAX_RESPONSE_BYTES + 10)
+    srv, _ = _spin_panoptes(raw=raw)
+    try:
+        report = text_detectors.PanoptesTextDetector(url=_panoptes_url(srv)).detect("x")
+    finally:
+        srv.shutdown()
+        srv.server_close()
+    assert report["available"] is False
+    assert "exceeds" in report["error"]
+
+
+def test_panoptes_redirect_is_refused():
+    """A 302 must surface as an error, never a followed redirect (text would leak)."""
+    import http.server
+    import threading
+
+    class _R(http.server.BaseHTTPRequestHandler):
+        def do_POST(self):
+            self.send_response(302)
+            self.send_header("Location", "http://127.0.0.1:1/never")
+            self.end_headers()
+
+        def log_message(self, *args):
+            pass
+
+    srv = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _R)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    try:
+        report = text_detectors.PanoptesTextDetector(url=_panoptes_url(srv)).detect("secret")
+    finally:
+        srv.shutdown()
+        srv.server_close()
+    assert report["available"] is False
+    assert "failed" in report["error"]
+
+
+def test_panoptes_ctor_url_overrides_env(monkeypatch):
+    monkeypatch.setenv("PANOPTES_API_URL", "http://127.0.0.1:1")
+    det = text_detectors.PanoptesTextDetector(url="http://example.invalid:9/")
+    assert det._base_url() == "http://example.invalid:9"  # trailing slash stripped
+
+
+def test_cross_detectors_registry():
+    assert sorted(text_detectors.CROSS_DETECTORS) == ["panoptes"]
+    assert text_detectors.CROSS_DETECTORS["panoptes"]().name == "panoptes"

--- a/tests/test_text_detectors.py
+++ b/tests/test_text_detectors.py
@@ -470,6 +470,71 @@ def test_panoptes_ctor_url_overrides_env(monkeypatch):
     assert det._base_url() == "http://example.invalid:9"  # trailing slash stripped
 
 
+def test_panoptes_zero_p_value_is_positive():
+    """A tested KGW p_value of 0.0 is a positive, not a missing value."""
+    payload = _panoptes_payload()
+    payload["watermarks"][0]["p_value"] = 0.0
+    srv, _ = _spin_panoptes(payload)
+    try:
+        report = text_detectors.PanoptesTextDetector(url=_panoptes_url(srv)).detect("x")
+    finally:
+        srv.shutdown()
+        srv.server_close()
+    assert report["available"] is True
+    assert report["is_watermarked"] is True
+    assert report["kgw"]["p_value"] == 0.0
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("summary", ["invalid"]), ("watermarks", 7)],
+)
+def test_panoptes_malformed_nested_fields_fail_soft(field, value):
+    payload = _panoptes_payload()
+    payload[field] = value
+    srv, _ = _spin_panoptes(payload)
+    try:
+        report = text_detectors.PanoptesTextDetector(url=_panoptes_url(srv)).detect("x")
+    finally:
+        srv.shutdown()
+        srv.server_close()
+    assert report["available"] is False
+    assert report["error"].startswith("bad panoptes response")
+
+
+def test_panoptes_non_numeric_kgw_field_fails_soft():
+    payload = _panoptes_payload()
+    payload["watermarks"][0]["p_value"] = "high"
+    srv, _ = _spin_panoptes(payload)
+    try:
+        report = text_detectors.PanoptesTextDetector(url=_panoptes_url(srv)).detect("x")
+    finally:
+        srv.shutdown()
+        srv.server_close()
+    assert report["available"] is False
+    assert "non-numeric" in report["error"]
+
+
+@pytest.mark.parametrize("bad", ["-1", "nan", "inf"])
+def test_panoptes_invalid_env_timeout_falls_back(monkeypatch, bad):
+    """Garbage PANOPTES_TIMEOUT values fall back to the default, never reach urllib."""
+    monkeypatch.setenv("PANOPTES_TIMEOUT", bad)
+    srv, _ = _spin_panoptes(_panoptes_payload())
+    try:
+        report = text_detectors.PanoptesTextDetector(url=_panoptes_url(srv)).detect("x")
+    finally:
+        srv.shutdown()
+        srv.server_close()
+    assert report["available"] is True
+
+
+def test_panoptes_invalid_ctor_timeout_fails_soft():
+    det = text_detectors.PanoptesTextDetector(url="http://127.0.0.1:1", timeout=-1.0)
+    report = det.detect("x")
+    assert report["available"] is False
+    assert "invalid panoptes timeout" in report["error"]
+
+
 def test_cross_detectors_registry():
     assert sorted(text_detectors.CROSS_DETECTORS) == ["panoptes"]
     assert text_detectors.CROSS_DETECTORS["panoptes"]().name == "panoptes"


### PR DESCRIPTION
## Summary

Adds Panoptes as an **independent cross-detector** in the SynthID-text benchmark, per [Discussion #215](https://github.com/guillaumemeyer/watermarks-remover/discussions/215) (cc @bentalay). Follow-up to #244 (native adapter); standalone — does not depend on it.

Same-config MarkLLM detection answers "did the mark survive under the config that made it?" It cannot answer "does the text still read as machine-generated to an independent system?" This PR adds that second opinion via `--cross-detect panoptes`: every row's output text is also scored by a [Panoptes](https://github.com/marketstandard/Panoptes) workbench, which shares no config, keys, or code with the MarkLLM generator.

## Design

- **`PanoptesTextDetector`** (`service/scripts/text_detectors.py`) implements the existing `TextDetector` protocol and is registered in `all_detectors()`, so `/capabilities` exposes it like every other detector. Activated by `PANOPTES_API_URL`; posts `{text, content_type: "prose"}` to `/api/v1/analyze`.
- **HTTP discipline mirrors `rewrite_text.py` exactly**: stdlib urllib only after `urlparse` scheme/host validation (http/https only), a `_NoRedirect` handler so redirects can never re-send submitted text to an unvalidated host, explicit timeout (`PANOPTES_TIMEOUT`, default 30s), 1 MiB response cap (same philosophy as `MAX_CONFIG_BYTES`), and fail-soft on `(URLError, TimeoutError, OSError, RuntimeError, JSONDecodeError)` — it never raises and never blocks a bench row.
- **Report mapping**: `is_watermarked`/`score` come from Panoptes' KGW adapter, which is keyed to Panoptes' baked **demo key** — it detects only watermarks made with that key, so it stays silent on MarkLLM-generated corpora (a positive here would be a bug). The **AI posteriors** (`ai_generation`, `ai_participation`) are the calibrated, watermark-agnostic signal. Every report carries a `note` stating the demo-key scoping so the numbers can't be misread.
- **Bench wiring** (`--cross-detect panoptes`, repeatable, default off): rows gain a `cross` report; `results.csv` gains `cross_panoptes_pos/score/ai` columns; `results.json` aggregates gain per-variant `cross_panoptes` stats (`n_available`, `kgw_positive`, `mean_ai_generation`); `report.md` gains a "Cross-detector second opinion" section with the caveat inline. Control rows double as the pre-removal baseline. **Flag off = zero behavior change** (asserted byte-identical rows in tests).

## Test plan

- `tests/test_text_detectors.py`: loopback HTTP fake (same pattern as the existing TCP fakes) — success mapping, env unset → unavailable, non-http scheme rejected, unreachable host / timeout / malformed JSON / oversize response / redirect → all fail-soft, KGW "not tested" status → nulls, constructor overrides.
- `tests/test_bench_synthid_text.py`: monkeypatched cross detector — flag parsing, row fields populated, aggregates extended, CSV header extended, report section rendered, unavailable detector recorded (not fatal), **flag off → rows byte-identical to before**.
- `tests/test_detect_endpoint.py`: `/capabilities` set updated for the new registry entry.
- Local CI replication with pinned `pytest==9.1.1` / `ruff==0.16.3`: `ruff check` + `ruff format --check` clean; `pytest -q` green except the 3 pre-existing Windows TCP flakes in `test_http_server.py`/`test_rewrite_text.py` that also fail on the untouched base commit (`ConnectionResetError` WinError 10054 — server-thread teardown race, unrelated to this change).

## Reproduction

```bash
panoptes up &   # serves http://127.0.0.1:8000 (fixture profile needs no models)
PANOPTES_API_URL=http://127.0.0.1:8000 \
python3 service/scripts/bench_synthid_text.py --markllm-dir ~/MarkLLM \
  --docs 1 --seeds 1 --variants paraphrase:1 --rewrite-model llama3.2 \
  --cross-detect panoptes --out-dir /tmp/cross --tag panoptes-cross
```

## Evidence (e2e gate)

Run on this branch against a live Panoptes server (`panoptes up`, fixture profile) with MarkLLM @ `c45ddc4`, `facebook/opt-125m`, `--docs 1 --seeds 1`. No rewrite backend was running, so the rewrite row fail-softs as designed; the gate targets the control/layer-a rows.

<details><summary>report.md (live server)</summary>

```markdown
## Cross-detector second opinion: panoptes

An independent detector (--cross-detect) scored every row's output text; control rows (no removal) double as the pre-removal baseline.

| Variant | n | available | kgw+ (demo key) | AI posterior μ |
| --- | ---: | ---: | ---: | ---: |
| control | 1 | 1 | 0 | 0.4810 |
| layer-a | 1 | 1 | 0 | 0.4810 |

**Caveat:** the panoptes KGW reading is scoped to Panoptes' baked demo key — it detects only watermarks made with that key, so it stays silent on this MarkLLM-generated corpus (expect 0 positives). The AI posterior is the watermark-agnostic signal: compare rewrite rows against the control baseline to see whether removal still reads as machine-generated.
```

Row-level JSON for control (excerpt):

```json
{"detector": "panoptes", "available": true, "is_watermarked": false,
 "score": 0.8885, "kgw": {"status": "tested", "z": 0.8885, "p_value": 0.1871},
 "ai_generation": 0.4810, "ai_participation": 0.5210}
```

</details>

<details><summary>Fail-soft leg (dead port)</summary>

Same command with `PANOPTES_API_URL=http://127.0.0.1:59999`: bench completes with exit 0; every row records

```json
{"detector": "panoptes", "available": false,
 "error": "panoptes analyze failed: <urlopen error ... Connection refused ...>"}
```

and the report still renders the cross table with `available = 0`.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Panoptes cross-detector scoring for SynthID text benchmarks.
  * Added repeatable cross-detector selection and configurable endpoint and timeout settings.
  * Benchmark results now include detector availability, watermark-positive counts, and AI-generation scores in Markdown, CSV, and JSON formats.
  * Added fail-soft handling for unavailable services, timeouts, invalid responses, redirects, and oversized results.

* **Documentation**
  * Documented Panoptes setup, output fields, result interpretation, and error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->