### PR TITLE
feat(bench): semantic divergence, minimal level, margin objective + chunk rewrite

### DIFF
--- a/benchmarks/benchmark-full.sh
+++ b/benchmarks/benchmark-full.sh
@@ -1,15 +1,28 @@
 #!/usr/bin/env bash
-# Full SynthID-text benchmark: 8 docs x 3 seeds, three rewrite variants,
-# re-stamp control. Results land in out/bench-full/ (override with OUT_DIR).
+# Full SynthID-text benchmark: 10 docs x 3 seeds, three rewrite variants,
+# re-stamp control, plus the minimal-rewrite-level scan. Variants land in
+# out/bench-full/, minimal in out/bench-minimal/ (override with OUT_DIR).
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 set -a; [ -f "$ROOT/.env" ] && . "$ROOT/.env"; set +a
 export MARKLLM_DIR="${MARKLLM_DIR:-$HOME/MarkLLM}"
 export HF_HOME="${HF_HOME:-$ROOT/.hf-cache}"
-exec python3 "$ROOT/service/scripts/bench_synthid_text.py" \
+
+# Named-strength variants: does each rewrite remove the mark?
+python3 "$ROOT/service/scripts/bench_synthid_text.py" \
   --markllm-dir "$MARKLLM_DIR" \
   --docs 10 --seeds 3 \
   --variants "paraphrase:1,paraphrase:3,backtranslate:1" \
   --restamp-control \
   --out-dir "${OUT_DIR:-$ROOT/out/bench-full}" \
   --tag full
+
+# Minimal-rewrite-level scan: what is the smallest rewrite that removes the mark?
+python3 "$ROOT/service/scripts/bench_synthid_text.py" \
+  --markllm-dir "$MARKLLM_DIR" \
+  --docs 10 --seeds 3 \
+  --mode minimal \
+  --rewrite-level-start 0.1 --rewrite-level-step 0.1 --rewrite-level-max 1.0 \
+  --level-attempts 3 \
+  --out-dir "${OUT_DIR:-$ROOT/out/bench-minimal}" \
+  --tag minimal

--- a/docs/synthid-text-benchmark.md
+++ b/docs/synthid-text-benchmark.md
@@ -71,13 +71,13 @@ exposes detection again (e.g. via Vertex AI).
 the Layer B rewrite with candidates as the **variants per evaluation round**;
 `--rewrite-loops` (default 1, mirrors `--max-loops` /
 `WATERMARKS_REWRITE_LOOPS`) sets how many rounds run before the best-effort
-variant is returned. The rewrite is iterative: it generates a variant, runs
-MarkLLM detection (same-config) on it, and stops as soon as an attempt is not
-watermarked — so a variant usually costs fewer rewrites than its candidate
-count, and paraphrase:3 means "try up to 3 variants, stop on the first pass"
-(raise `--rewrite-loops` to keep retrying new variants until one passes).
-The report's att column (and mean_attempts in results.json / attempts in
-results.csv) records the actual attempts per document.
+variant is returned. The rewrite is iterative: it generates a round's
+candidates, scores each one, and selects by the margin-aware policy below —
+there is no "first pass wins" early stop, so a variant evaluates every
+candidate in a round and costs at most its candidate count per round (raise
+`--rewrite-loops` to run more rounds). The report's att column (and
+mean_attempts in results.json / attempts in results.csv) records the actual
+attempts per document.
 
 **Selection is margin-aware, not first-pass.** The rewrite evaluates every
 candidate in a round (no early stop on the first "not watermarked"), treats a
@@ -88,6 +88,18 @@ min-divergence`, content-preserving) or the one with the largest margin
 (`--select max-margin`, robustness-first). Raising `--target-margin` is how you
 ask for a removal that survives a stricter/vendor detector rather than a
 hair-thin threshold crossing.
+
+**Strengths:** `paraphrase` (same language, rephrase), `backtranslate` (via
+another language), `structural`, `humanize`, `code`, and `chunk`. `chunk`
+splits the document into sentence/paragraph fragments, rewrites each with a
+fresh context (new per-token watermark keys), and reassembles them. It is the
+strongest removal at a given rewrite cost because every fragment re-keys
+independently; use `--strength chunk` for that, optionally with
+`--chunk-shuffle` to also shuffle the rewritten fragments (which breaks
+paragraph/line order). Without `--chunk-shuffle`, `chunk` keeps the original
+separators so layout is preserved. `chunk` is accepted wherever a variant
+strength is expected, including `parse_variants` (e.g. `--variants
+"chunk:2,paraphrase:3"`).
 
 ## Minimal-rewrite-level mode (`--mode minimal`)
 

--- a/docs/synthid-text-benchmark.md
+++ b/docs/synthid-text-benchmark.md
@@ -11,11 +11,23 @@ removal variants, and emits a shareable report.
 | --- | --- |
 | Clear rate | % of watermarked samples that flip to not-watermarked after removal (MarkLLM same-config detection) |
 | Score suppression | mean/median drop in detector score (before - after) |
-| Quality | lexical divergence (bigram Jaccard distance), length drift, number/URL survival |
+| Quality | lexical divergence (bigram Jaccard distance), semantic divergence (1 - cosine similarity via sentence-transformers), length drift, number/URL survival |
 | Cost | estimated tokens in/out, wall time per document, optional USD at your prices |
 | Efficiency | clears per million output tokens - removal rate per unit of rewrite cost |
 | Attempts | mean rewrite attempts per document (the Layer B loop stops early on pass) |
 | Controls | Layer A only (expect ~0% - Unicode scrub must not clear a statistical mark), sanity-gate exclusions, optional re-stamp check |
+
+**Semantic divergence** is `1 - cosine(embed(original), embed(candidate))`
+using a SentenceTransformer (default `sentence-transformers/all-MiniLM-L6-v2`).
+It is opt-in: if `sentence-transformers` is not installed the metric is
+`None` and renders as `—` in the report/CSV. Install it into the MarkLLM venv
+to enable the column:
+
+    ~/MarkLLM/.venv/bin/pip install -r service/scripts/requirements-semantic.txt
+
+It is `1 - cosine`, so it measures meaning drift independently of surface
+wording: lexical divergence can be high (many different words) while semantic
+divergence is low (same meaning), and vice versa.
 
 ## How to run
 
@@ -65,6 +77,44 @@ count, and paraphrase:3 means "try up to 3 variants, stop on the first pass"
 (raise `--rewrite-loops` to keep retrying new variants until one passes).
 The report's att column (and mean_attempts in results.json / attempts in
 results.csv) records the actual attempts per document.
+
+## Minimal-rewrite-level mode (`--mode minimal`)
+
+The named-strength variants above answer "does this rewrite remove the mark?"
+The minimal mode answers **"what is the smallest rewrite that removes the
+mark?"** for a given sample, then aggregates that minimum across samples.
+
+- It uses a **numeric rewrite level** instead of a named strength. The level is
+  a request in `(0, 1]`: 0 (the unchanged original) is excluded, 1 means
+  "rewrite everything". The actual lexical/semantic divergence of the output is
+  *measured*, not guaranteed — the level is a prompt, not a contract.
+- For each watermarked sample it starts at `--rewrite-level-start` (0.1),
+  tries up to `--level-attempts` (3) rewrites at that level, and if none
+  clears the mark it raises the level by `--rewrite-level-step` (0.1) and
+  repeats, up to `--rewrite-level-max` (1.0).
+- At the first level where at least one rewrite clears (same-config MarkLLM
+  detection), it keeps the rewrite with the **smallest semantic divergence**
+  and records that level. One row per sample records the chosen level, its
+  lexical/semantic divergence, and the attempts spent.
+- `aggregate_minimal` reports across samples: clear rate, mean/median minimal
+  level, mean/median minimal semantic divergence, mean minimal lexical
+  divergence, and a level-usage histogram.
+
+    python3 service/scripts/bench_synthid_text.py \
+      --markllm-dir ~/MarkLLM \
+      --mode minimal \
+      --docs 10 --seeds 3 \
+      --rewrite-level-start 0.1 --rewrite-level-step 0.1 --rewrite-level-max 1.0 \
+      --level-attempts 3 \
+      --rewrite-backend ollama --rewrite-model llama3.2 \
+      --out-dir out/bench-minimal --tag minimal
+
+**Verdict semantics per sample:** a row is `cleared` (True) when a rewrite at
+some level is no longer detected watermarked; `cleared=False` when no level up
+to the max cleared it (the sample counts in the clear-rate denominator but is
+excluded from the divergence averages); `cleared=None` when the rewrite failed
+or MarkLLM verification was unavailable (also excluded from averages). Only
+cleared samples contribute to the mean/median minimal level and divergence.
 
 Cost warning: with MarkLLM as the evaluator, each attempt also costs one
 MarkLLM detection — up to (candidates x loops) detections per input. The

--- a/docs/synthid-text-benchmark.md
+++ b/docs/synthid-text-benchmark.md
@@ -10,6 +10,7 @@ removal variants, and emits a shareable report.
 | Metric | Meaning |
 | --- | --- |
 | Clear rate | % of watermarked samples that flip to not-watermarked after removal (MarkLLM same-config detection) |
+| Removal margin | mean (threshold - score) after removal. The robust objective: a "clear" that crosses the threshold by a hair (margin ≈ 0) is not a real removal |
 | Score suppression | mean/median drop in detector score (before - after) |
 | Quality | lexical divergence (bigram Jaccard distance), semantic divergence (1 - cosine similarity via sentence-transformers), length drift, number/URL survival |
 | Cost | estimated tokens in/out, wall time per document, optional USD at your prices |
@@ -78,6 +79,16 @@ count, and paraphrase:3 means "try up to 3 variants, stop on the first pass"
 The report's att column (and mean_attempts in results.json / attempts in
 results.csv) records the actual attempts per document.
 
+**Selection is margin-aware, not first-pass.** The rewrite evaluates every
+candidate in a round (no early stop on the first "not watermarked"), treats a
+candidate as a pass only when its after-score sits at least `--target-margin`
+below the threshold (default 0.0 = any not-watermarked verdict), and then picks
+the passing candidate that changed the least by default (`--select
+min-divergence`, content-preserving) or the one with the largest margin
+(`--select max-margin`, robustness-first). Raising `--target-margin` is how you
+ask for a removal that survives a stricter/vendor detector rather than a
+hair-thin threshold crossing.
+
 ## Minimal-rewrite-level mode (`--mode minimal`)
 
 The named-strength variants above answer "does this rewrite remove the mark?"
@@ -95,7 +106,11 @@ mark?"** for a given sample, then aggregates that minimum across samples.
 - At the first level where at least one rewrite clears (same-config MarkLLM
   detection), it keeps the rewrite with the **smallest semantic divergence**
   and records that level. One row per sample records the chosen level, its
-  lexical/semantic divergence, and the attempts spent.
+  lexical/semantic divergence, its removal margin, and the attempts spent.
+- Pass `--target-margin` (e.g. 0.5) to require a rewrite to sit at least that
+  far below the threshold before a level counts as cleared. Without it a level
+  that crosses the threshold by a hair — the failing "100% clear, Δ≈0.03" case
+  — is reported as cleared even though it is not a robust removal.
 - `aggregate_minimal` reports across samples: clear rate, mean/median minimal
   level, mean/median minimal semantic divergence, mean minimal lexical
   divergence, and a level-usage histogram.
@@ -167,6 +182,23 @@ are not a constraint inside the container either.
   and Google retired text watermark detection on its API (Aug 2026), so no
   vendor tier exists to verify against. Rewriting with a watermarked model
   can also re-stamp the text - run --restamp-control to check.
+
+## Humanizer and cross-model hygiene
+
+Two things are easy to mistake for removal but are not, or can silently undo it:
+
+- **The humanizer is style polish, not removal.** It targets deterministic
+  writing tells (em dashes, rule of three, AI vocabulary, passive voice) and
+  intentionally preserves facts, numbers, and names — the opposite of what a
+  watermark attack wants. It changes few tokens per pass and optimizes "sounds
+  like a human", which is a different objective from "green-list bias gone".
+  Keep it as an optional final style polish, but measure removal with the
+  detector score (and `--target-margin`), not with how natural the text reads.
+  In the variant table it is a mid-strength pass, not the removal step.
+- **Cross-model hygiene (correctness).** Rewriting with a model that is the
+  generator or is itself watermarked re-stamps the text you just removed. Use a
+  rewrite backend that is neither, and run `--restamp-control` to detect when
+  the backend re-stamps the unwatermarked control (after-positive > 0).
 
 ## Sharing a run
 

--- a/service/scripts/bench_synthid_text.py
+++ b/service/scripts/bench_synthid_text.py
@@ -334,6 +334,7 @@ def run_rewrite(
     markllm_model: str,
     markllm_timeout: float,
     markllm_scheme: str,
+    rewrite_level: float | None = None,
 ) -> tuple[str, dict[str, Any]]:
     """Run the Layer B rewrite on *text* via rewrite_text.py (real product path).
 
@@ -383,6 +384,8 @@ def run_rewrite(
         str(markllm_timeout),
         "--json-stats",
     ]
+    if rewrite_level is not None:
+        cmd += ["--rewrite-level", str(rewrite_level)]
     if allow_remote:
         cmd.append("--allow-remote")
     try:
@@ -452,9 +455,58 @@ def _detect_positive(d: dict[str, Any] | None) -> bool:
     return bool(d and d.get("available") and d.get("is_watermarked"))
 
 
-def _quality(original: str, candidate: str, chars_per_token: float) -> dict[str, Any]:
+class SemanticEmbedder:
+    """Optional sentence-embedding semantic divergence (1 - cosine similarity).
+
+    Lazily loads a SentenceTransformer the first time it is used. Any failure —
+    package missing (sentence-transformers not installed), model download error,
+    encode error — makes ``available()`` return False and ``score()`` return None,
+    so the benchmark degrades gracefully to lexical-only output instead of failing.
+    """
+
+    def __init__(self, model_name: str) -> None:
+        self._model_name = model_name
+        self._model = None
+        self._util = None
+        self._failed: str | None = None
+
+    def _load(self):
+        if self._model is not None:
+            return self._model
+        if self._failed is not None:
+            return None
+        try:
+            from sentence_transformers import SentenceTransformer, util
+
+            self._util = util
+            self._model = SentenceTransformer(self._model_name)
+        except Exception as e:  # fail-soft: optional dependency
+            self._failed = f"sentence-transformers unavailable: {e}"
+            return None
+        return self._model
+
+    def available(self) -> bool:
+        return self._load() is not None
+
+    def score(self, original: str, candidate: str) -> float | None:
+        model = self._load()
+        if model is None:
+            return None
+        try:
+            emb = model.encode([original, candidate], normalize_embeddings=True)
+            return round(float(1.0 - self._util.cos_sim(emb[0], emb[1]).item()), 4)
+        except Exception as e:
+            self._failed = f"embedding failed: {e}"
+            return None
+
+
+def _quality(
+    original: str, candidate: str, chars_per_token: float, semantic: SemanticEmbedder | None = None
+) -> dict[str, Any]:
+    sem = semantic.score(original, candidate) if semantic is not None else None
     return {
         "lexical_divergence": round(_lexical_divergence(original, candidate), 4),
+        "semantic_divergence": sem,
         "length_ratio": round(len(candidate) / max(len(original), 1), 4),
         "numbers_preserved": round(_numbers_preserved(original, candidate), 4),
         "urls_preserved": round(_urls_preserved(original, candidate), 4),
@@ -626,6 +678,7 @@ class Benchmark:
         self.variants = parse_variants(args.variants)
         self.corpus = load_corpus(args.corpus, args.docs)
         self.chars_per_token = args.chars_per_token
+        self.semantic = SemanticEmbedder(args.semantic_model)
         self.scheme = args.scheme
         self.config = args.config
         self.worker = None
@@ -696,7 +749,12 @@ class Benchmark:
         )
 
     def rewrite(
-        self, text: str, strength: str, candidates: int, max_loops: int = 1
+        self,
+        text: str,
+        strength: str,
+        candidates: int,
+        max_loops: int = 1,
+        rewrite_level: float | None = None,
     ) -> tuple[str, dict[str, Any]]:
         a = self.args
         return run_rewrite(
@@ -717,6 +775,7 @@ class Benchmark:
             markllm_model=a.markllm_model,
             markllm_timeout=a.markllm_timeout,
             markllm_scheme=self.scheme,
+            rewrite_level=rewrite_level,
         )
 
     # -- phases ------------------------------------------------------------
@@ -910,7 +969,10 @@ class Benchmark:
                             "score_after": _score_of(after),
                             "cleared": None,
                             "quality": _quality(
-                                sample["unwatermarked"], out_text, self.chars_per_token
+                                sample["unwatermarked"],
+                                out_text,
+                                self.chars_per_token,
+                                self.semantic,
                             ),
                             "notes": (
                                 ["re-stamped by rewrite backend"]
@@ -959,7 +1021,7 @@ class Benchmark:
             "cleared": cleared,
             "after_pos": _detect_positive(after),
             "score_after": _score_of(after),
-            "quality": _quality(original, candidate, self.chars_per_token),
+            "quality": _quality(original, candidate, self.chars_per_token, self.semantic),
             "seconds": seconds,
             "usd": 0.0,
             "notes": [],
@@ -969,6 +1031,141 @@ class Benchmark:
         elif kind == "layer-a":
             row["notes"].append("Layer A only; statistical marks are expected to survive")
         return row
+
+    def _rewrite_cleared(self, stats: dict[str, Any], out_text: str) -> bool:
+        """Did the rewrite's own MarkLLM verification say the mark is gone?
+
+        Prefer the rewrite's --json-stats (already paid for, no extra model
+        load); fall back to a direct detection if the stats verdict is missing.
+        """
+        mk = (stats.get("markllm") or {}).get("after")
+        if mk and mk.get("available"):
+            return not bool(mk.get("is_watermarked"))
+        after = self.detect(out_text)
+        return bool(after.get("available")) and not bool(after.get("is_watermarked"))
+
+    def minimal_search(self, samples: list[dict[str, Any]], workdir: Path) -> list[dict[str, Any]]:
+        """For each watermarked sample, raise the rewrite level until it clears.
+
+        Starts at ``--rewrite-level-start`` and increments by
+        ``--rewrite-level-step`` per loop (capped at ``--rewrite-level-max``).
+        At each level it tries up to ``--level-attempts`` rewrites and, if any
+        clears, keeps the one with the smallest semantic divergence and stops
+        raising the level. One row per sample records that minimal level and the
+        lexical/semantic divergence of the chosen rewrite.
+        """
+        a = self.args
+        levels: list[float] = []
+        lvl = a.rewrite_level_start
+        while lvl <= a.rewrite_level_max + 1e-9:
+            levels.append(round(lvl, 6))
+            lvl += a.rewrite_level_step
+        if not levels:
+            raise SystemExit("error: --rewrite-level-max must be >= --rewrite-level-start")
+
+        rows: list[dict[str, Any]] = []
+        for sample in samples:
+            if sample.get("excluded"):
+                rows.append(
+                    {
+                        "doc": sample["doc"],
+                        "seed": sample["seed"],
+                        "variant": "minimal",
+                        "kind": "minimal",
+                        "cleared": None,
+                        "before_pos": _detect_positive(sample["before"]),
+                        "score_before": _score_of(sample["before"]),
+                        "level": None,
+                        "lexical_divergence": None,
+                        "semantic_divergence": None,
+                        "attempts": 0,
+                        "seconds": 0.0,
+                        "notes": [sample.get("excluded_reason", "excluded")],
+                    }
+                )
+                continue
+
+            wm_text = sample["watermarked"]
+            base = {
+                "doc": sample["doc"],
+                "seed": sample["seed"],
+                "score_before": _score_of(sample["before"]),
+                "before_pos": _detect_positive(sample["before"]),
+            }
+            attempts = 0
+            started = time.monotonic()
+            chosen: dict[str, Any] | None = None
+            level_used: float | None = None
+            failed: str | None = None
+            for lvl in levels:
+                clears: list[dict[str, Any]] = []
+                for _ in range(max(1, a.level_attempts)):
+                    attempts += 1
+                    try:
+                        out_text, stats = self.rewrite(wm_text, "paraphrase", 1, rewrite_level=lvl)
+                    except RuntimeError as e:
+                        failed = str(e)
+                        break
+                    if not self._rewrite_cleared(stats, out_text):
+                        continue
+                    clears.append(
+                        {
+                            "out": out_text,
+                            "lex": _lexical_divergence(wm_text, out_text),
+                            "sem": self.semantic.score(wm_text, out_text)
+                            if self.semantic
+                            else None,
+                        }
+                    )
+                if failed is not None:
+                    break
+                if clears:
+                    chosen = min(
+                        clears,
+                        key=lambda c: c["sem"] if c["sem"] is not None else float("inf"),
+                    )
+                    level_used = lvl
+                    break
+
+            row = {
+                **base,
+                "variant": "minimal",
+                "kind": "minimal",
+                "attempts": attempts,
+                "seconds": round(time.monotonic() - started, 3),
+            }
+            if failed is not None:
+                row.update(
+                    {
+                        "cleared": None,
+                        "level": lvl,
+                        "lexical_divergence": None,
+                        "semantic_divergence": None,
+                        "notes": [f"rewrite failed: {failed}"],
+                    }
+                )
+            elif chosen is None:
+                row.update(
+                    {
+                        "cleared": False,
+                        "level": levels[-1],
+                        "lexical_divergence": None,
+                        "semantic_divergence": None,
+                        "notes": ["not cleared at any level"],
+                    }
+                )
+            else:
+                row.update(
+                    {
+                        "cleared": True,
+                        "level": level_used,
+                        "lexical_divergence": chosen["lex"],
+                        "semantic_divergence": chosen["sem"],
+                        "notes": [],
+                    }
+                )
+            rows.append(row)
+        return rows
 
 
 # ---------------------------------------------------------------------------
@@ -1026,6 +1223,21 @@ def aggregate(rows: list[dict[str, Any]], variants: list[tuple[str, int]]) -> di
             "mean_lexical_divergence": round(_mean([q["lexical_divergence"] for q in quals]), 4)
             if quals
             else None,
+            "semantic_n": sum(1 for q in quals if q.get("semantic_divergence") is not None),
+            "mean_semantic_divergence": (
+                round(
+                    _mean(
+                        [
+                            q["semantic_divergence"]
+                            for q in quals
+                            if q.get("semantic_divergence") is not None
+                        ]
+                    ),
+                    4,
+                )
+                if any(q.get("semantic_divergence") is not None for q in quals)
+                else None
+            ),
             "mean_length_ratio": round(_mean([q["length_ratio"] for q in quals]), 4)
             if quals
             else None,
@@ -1048,6 +1260,31 @@ def aggregate(rows: list[dict[str, Any]], variants: list[tuple[str, int]]) -> di
         }
         out[variant] = entries
     return out
+
+
+def aggregate_minimal(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate the minimal-rewrite-level search rows across samples."""
+    evaluated = [r for r in rows if r.get("cleared") is not None]
+    cleared = [r for r in evaluated if r["cleared"] is True]
+    levels = [r["level"] for r in cleared if r.get("level") is not None]
+    sems = [r["semantic_divergence"] for r in cleared if r.get("semantic_divergence") is not None]
+    lexes = [r["lexical_divergence"] for r in cleared if r.get("lexical_divergence") is not None]
+    usage: dict[float, int] = {}
+    for r in cleared:
+        if r.get("level") is not None:
+            usage[r["level"]] = usage.get(r["level"], 0) + 1
+    n = len(evaluated)
+    return {
+        "n_samples": n,
+        "n_cleared": len(cleared),
+        "clear_rate": round(len(cleared) / n, 4) if n else None,
+        "mean_min_level": round(_mean(levels), 4) if levels else None,
+        "median_min_level": round(sorted(levels)[len(levels) // 2], 4) if levels else None,
+        "mean_min_semantic_divergence": round(_mean(sems), 4) if sems else None,
+        "median_min_semantic_divergence": round(sorted(sems)[len(sems) // 2], 4) if sems else None,
+        "mean_min_lexical_divergence": round(_mean(lexes), 4) if lexes else None,
+        "level_usage": list(usage.items()),
+    }
 
 
 def _fmt(value: Any, default: str = "—") -> str:
@@ -1093,20 +1330,28 @@ def render_markdown(
         "text."
     )
     L.append("")
+    L.append(
+        "**Semantic divergence:** `1 - cosine(embed(original), embed(candidate))` "
+        f"via sentence-transformers (model: {config.get('semantic_model') or 'not configured'}). "
+        "Optional: when the package/model is unavailable the metric is None and the "
+        "column renders '—'."
+    )
+    L.append("")
     L.append("## Results (per variant)")
     L.append("")
     L.append(
-        "| Variant | n | clear % | Δscore μ | lex div | len ratio | nums keep | tok out | att | s/doc | clears/MTok |"
+        "| Variant | n | clear % | Δscore μ | lex div | sem div | len ratio | nums keep | tok out | att | s/doc | clears/MTok |"
     )
-    L.append("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |")
+    L.append("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |")
     for variant, a in agg.items():
         L.append(
-            "| {v} | {n} | {cr} | {d} | {ld} | {lr} | {np} | {to} | {att} | {s} | {eff} |".format(
+            "| {v} | {n} | {cr} | {d} | {ld} | {sd} | {lr} | {np} | {to} | {att} | {s} | {eff} |".format(
                 v=variant,
                 n=a["n"],
                 cr=_fmt(a["clear_rate"]),
                 d=_fmt(a["mean_score_delta"]),
                 ld=_fmt(a["mean_lexical_divergence"]),
+                sd=_fmt(a.get("mean_semantic_divergence")),
                 lr=_fmt(a["mean_length_ratio"]),
                 np=_fmt(a["mean_numbers_preserved"]),
                 to=_fmt(a["mean_tokens_out"]),
@@ -1147,6 +1392,115 @@ def render_markdown(
     return "\n".join(L) + "\n"
 
 
+def render_markdown_minimal(
+    config: dict[str, Any],
+    samples: list[dict[str, Any]],
+    rows: list[dict[str, Any]],
+    agg: dict[str, Any],
+) -> str:
+    L: list[str] = []
+    L.append(f"# SynthID-text minimal-rewrite-level benchmark — {config['tag']}")
+    L.append("")
+    L.append(f"- Date: {config['timestamp']}")
+    L.append(f"- watermarks-remover commit: {config.get('repo_commit') or 'unknown'}")
+    L.append(f"- MarkLLM commit: {config.get('markllm_commit') or 'unknown'}")
+    L.append(f"- Generator/detector model: {config['markllm_model']}")
+    L.append(f"- Corpus: {config['corpus']} ({config['docs']} docs x {config['seeds']} seeds)")
+    L.append(
+        f"- Rewrite level range: {config['rewrite_level_start']} → {config['rewrite_level_max']} "
+        f"by {config['rewrite_level_step']} ({config['level_attempts']} attempts/level)"
+    )
+    L.append(f"- Semantic model: {config.get('semantic_model') or 'not configured'}")
+    L.append("")
+    L.append("## Methodology")
+    L.append("")
+    L.append(
+        "For each watermarked sample the benchmark starts at the lowest rewrite "
+        "level and raises it by 0.1 per loop until a rewrite is no longer "
+        "watermarked (same-config MarkLLM detection). The chosen rewrite is the "
+        "one with the smallest semantic divergence among the clearing attempts at "
+        "that level; that level's value and the resulting lexical/semantic "
+        "divergence are recorded. Samples that never clear are excluded from the "
+        "divergence average but counted in the clear rate."
+    )
+    L.append("")
+    L.append("## Results (across samples)")
+    L.append("")
+    L.append("| Metric | Value |")
+    L.append("| --- | --- |")
+    L.append(f"| Samples evaluated | {agg['n_samples']} |")
+    L.append(f"| Cleared | {agg['n_cleared']} |")
+    L.append(f"| Clear rate | {_fmt(agg['clear_rate'])} |")
+    L.append(f"| Mean minimal level | {_fmt(agg['mean_min_level'])} |")
+    L.append(f"| Median minimal level | {_fmt(agg['median_min_level'])} |")
+    L.append(f"| Mean minimal semantic divergence | {_fmt(agg['mean_min_semantic_divergence'])} |")
+    L.append(
+        f"| Median minimal semantic divergence | {_fmt(agg['median_min_semantic_divergence'])} |"
+    )
+    L.append(f"| Mean minimal lexical divergence | {_fmt(agg['mean_min_lexical_divergence'])} |")
+    L.append("")
+    L.append("### Level usage (minimal level per cleared sample)")
+    L.append("")
+    L.append("| Level | samples |")
+    L.append("| --- | ---: |")
+    for level, count in agg.get("level_usage") or []:
+        L.append(f"| {_fmt(level)} | {count} |")
+    L.append("")
+    L.append("## Per-sample rows")
+    L.append("")
+    L.append("| doc | seed | cleared | level | lex div | sem div | attempts |")
+    L.append("| --- | --- | ---: | ---: | ---: | ---: | ---: |")
+    for r in rows:
+        L.append(
+            "| {doc} | {seed} | {cleared} | {lv} | {ld} | {sd} | {att} |".format(
+                doc=r["doc"],
+                seed=r["seed"],
+                cleared="yes" if r.get("cleared") else ("no" if r.get("cleared") is False else "—"),
+                lv=_fmt(r.get("level")),
+                ld=_fmt(r.get("lexical_divergence")),
+                sd=_fmt(r.get("semantic_divergence")),
+                att=r.get("attempts"),
+            )
+        )
+    L.append("")
+    L.append("## Reproduction")
+    L.append("")
+    L.append("    " + config["command"])
+    L.append("")
+    L.append("Full per-row data: results.json / results.csv in this directory.")
+    L.append("")
+    return "\n".join(L) + "\n"
+
+
+def _minimal_csv(rows: list[dict[str, Any]]) -> list[str]:
+    lines = [
+        "doc,seed,variant,kind,cleared,before_pos,score_before,level,"
+        "lexical_divergence,semantic_divergence,attempts,seconds,notes"
+    ]
+    for r in rows:
+        lines.append(
+            ",".join(
+                str(v)
+                for v in (
+                    r["doc"],
+                    r["seed"],
+                    "minimal",
+                    "minimal",
+                    "" if r.get("cleared") is None else (1 if r["cleared"] else 0),
+                    1 if r.get("before_pos") else 0,
+                    r.get("score_before", ""),
+                    r.get("level", ""),
+                    r.get("lexical_divergence", ""),
+                    r.get("semantic_divergence", ""),
+                    r.get("attempts", ""),
+                    r.get("seconds", ""),
+                    "; ".join(str(n) for n in r.get("notes") or []),
+                )
+            )
+        )
+    return lines
+
+
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--markllm-dir", default=os.environ.get("MARKLLM_DIR"))
@@ -1176,6 +1530,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="Comma list of <strength>:<candidates> (default: paraphrase:3). "
         "candidates = max rewrite attempts per input; the Layer B loop stops "
         "early when an attempt passes evaluation.",
+    )
+    p.add_argument(
+        "--mode",
+        choices=("variants", "minimal"),
+        default="variants",
+        help="variants: run named-strength rewrite variants (default). minimal: "
+        "per sample, raise the numeric rewrite level (--rewrite-level-start, "
+        "+--rewrite-level-step) until a rewrite is no longer watermarked, then "
+        "report the average minimal level.",
     )
     p.add_argument(
         "--restamp-control", action="store_true", help="Also rewrite the unwatermarked control"
@@ -1220,7 +1583,38 @@ def build_parser() -> argparse.ArgumentParser:
         "--candidates variants and stops when one passes (default: 1)",
     )
     p.add_argument(
+        "--rewrite-level-start",
+        type=float,
+        default=0.1,
+        help="minimal mode: first rewrite level tried (default: 0.1)",
+    )
+    p.add_argument(
+        "--rewrite-level-step",
+        type=float,
+        default=0.1,
+        help="minimal mode: level increment per loop (default: 0.1, so 0.1, 0.2, ...)",
+    )
+    p.add_argument(
+        "--rewrite-level-max",
+        type=float,
+        default=1.0,
+        help="minimal mode: highest rewrite level tried (default: 1.0)",
+    )
+    p.add_argument(
+        "--level-attempts",
+        type=int,
+        default=3,
+        help="minimal mode: rewrite attempts per level before escalating (default: 3)",
+    )
+    p.add_argument(
         "--chars-per-token", type=float, default=4.0, help="Cost token estimate (default: 4.0)"
+    )
+    p.add_argument(
+        "--semantic-model",
+        default="sentence-transformers/all-MiniLM-L6-v2",
+        help="SentenceTransformer model for semantic divergence (optional; "
+        "requires sentence-transformers. Unavailable -> semantic_divergence is "
+        "None and the report renders '—').",
     )
     p.add_argument(
         "--cost-per-mtok-in", type=float, default=0.0, help="USD per million input tokens"
@@ -1289,6 +1683,12 @@ def main() -> int:
         "chars_per_token": args.chars_per_token,
         "cost_per_mtok_in": args.cost_per_mtok_in,
         "cost_per_mtok_out": args.cost_per_mtok_out,
+        "mode": args.mode,
+        "rewrite_level_start": args.rewrite_level_start,
+        "rewrite_level_step": args.rewrite_level_step,
+        "rewrite_level_max": args.rewrite_level_max,
+        "level_attempts": args.level_attempts,
+        "semantic_model": args.semantic_model,
         "command": " ".join(
             [
                 "python3 service/scripts/bench_synthid_text.py",
@@ -1298,12 +1698,18 @@ def main() -> int:
                 f"--corpus {args.corpus}",
                 f"--docs {args.docs} --seeds {args.seeds} --seed-base {args.seed_base}",
                 f"--max-new-tokens {args.max_new_tokens}",
+                f"--mode {args.mode}",
                 f"--variants {args.variants}",
                 f"--rewrite-backend {args.rewrite_backend}",
                 f"--rewrite-model {args.rewrite_model}",
                 f"--rewrite-base-url {args.rewrite_base_url}",
                 f"--rewrite-temperature {args.rewrite_temperature}",
                 f"--rewrite-loops {args.rewrite_loops}",
+                f"--rewrite-level-start {args.rewrite_level_start}",
+                f"--rewrite-level-step {args.rewrite_level_step}",
+                f"--rewrite-level-max {args.rewrite_level_max}",
+                f"--level-attempts {args.level_attempts}",
+                f"--semantic-model {args.semantic_model}",
                 *(["--restamp-control"] if args.restamp_control else []),
                 *(["--rewrite-allow-remote"] if args.rewrite_allow_remote else []),
                 f"--out-dir {args.out_dir}",
@@ -1320,63 +1726,72 @@ def main() -> int:
     eprint(f"markllm via: {bench.python}")
     try:
         samples = bench.generate_samples(workdir)
-        rows = bench.run_variants(samples, workdir)
+        if args.mode == "minimal":
+            rows = bench.minimal_search(samples, workdir)
+        else:
+            rows = bench.run_variants(samples, workdir)
     finally:
         bench.close_worker()
 
-    # Attach USD cost using per-doc token estimates.
-    for row in rows:
-        q = row.get("quality") or {}
-        if q:
-            row["usd"] = (
-                q.get("tokens_in", 0) / 1e6 * args.cost_per_mtok_in
-                + q.get("tokens_out", 0) / 1e6 * args.cost_per_mtok_out
+    if args.mode == "minimal":
+        agg = aggregate_minimal(rows)
+        report = render_markdown_minimal(config, samples, rows, agg)
+        csv_lines = _minimal_csv(rows)
+    else:
+        # Attach USD cost using per-doc token estimates.
+        for row in rows:
+            q = row.get("quality") or {}
+            if q:
+                row["usd"] = (
+                    q.get("tokens_in", 0) / 1e6 * args.cost_per_mtok_in
+                    + q.get("tokens_out", 0) / 1e6 * args.cost_per_mtok_out
+                )
+
+        agg = aggregate(rows, bench.variants)
+
+        report = render_markdown(config, samples, rows, agg)
+        csv_lines = [
+            "doc,seed,variant,kind,attempts,evaluator,passed,before_pos,after_pos,cleared,"
+            "score_before,score_after,score_delta,lexical_divergence,semantic_divergence,"
+            "length_ratio,numbers_preserved,urls_preserved,tokens_in,tokens_out,seconds,usd,notes"
+        ]
+        for r in rows:
+            q = r.get("quality") or {}
+            delta = (
+                round(r["score_before"] - r["score_after"], 4)
+                if r.get("score_before") is not None and r.get("score_after") is not None
+                else ""
             )
-
-    agg = aggregate(rows, bench.variants)
-
-    report = render_markdown(config, samples, rows, agg)
-    csv_lines = [
-        "doc,seed,variant,kind,attempts,evaluator,passed,before_pos,after_pos,cleared,"
-        "score_before,score_after,score_delta,lexical_divergence,length_ratio,"
-        "numbers_preserved,urls_preserved,tokens_in,tokens_out,seconds,usd,notes"
-    ]
-    for r in rows:
-        q = r.get("quality") or {}
-        delta = (
-            round(r["score_before"] - r["score_after"], 4)
-            if r.get("score_before") is not None and r.get("score_after") is not None
-            else ""
-        )
-        csv_lines.append(
-            ",".join(
-                str(v)
-                for v in (
-                    r["doc"],
-                    r["seed"],
-                    r["variant"],
-                    r.get("kind", ""),
-                    r.get("attempts", ""),
-                    r.get("evaluator", ""),
-                    "" if r.get("passed") is None else (1 if r["passed"] else 0),
-                    1 if r.get("before_pos") else 0,
-                    1 if r.get("after_pos") else 0,
-                    "" if r.get("cleared") is None else (1 if r["cleared"] else 0),
-                    r.get("score_before", ""),
-                    r.get("score_after", ""),
-                    delta,
-                    q.get("lexical_divergence", ""),
-                    q.get("length_ratio", ""),
-                    q.get("numbers_preserved", ""),
-                    q.get("urls_preserved", ""),
-                    q.get("tokens_in", ""),
-                    q.get("tokens_out", ""),
-                    r.get("seconds", ""),
-                    round(r.get("usd") or 0.0, 6),
-                    "; ".join(str(n) for n in r.get("notes") or []),
+            csv_lines.append(
+                ",".join(
+                    str(v)
+                    for v in (
+                        r["doc"],
+                        r["seed"],
+                        r["variant"],
+                        r.get("kind", ""),
+                        r.get("attempts", ""),
+                        r.get("evaluator", ""),
+                        "" if r.get("passed") is None else (1 if r["passed"] else 0),
+                        1 if r.get("before_pos") else 0,
+                        1 if r.get("after_pos") else 0,
+                        "" if r.get("cleared") is None else (1 if r["cleared"] else 0),
+                        r.get("score_before", ""),
+                        r.get("score_after", ""),
+                        delta,
+                        q.get("lexical_divergence", ""),
+                        q.get("semantic_divergence", ""),
+                        q.get("length_ratio", ""),
+                        q.get("numbers_preserved", ""),
+                        q.get("urls_preserved", ""),
+                        q.get("tokens_in", ""),
+                        q.get("tokens_out", ""),
+                        r.get("seconds", ""),
+                        round(r.get("usd") or 0.0, 6),
+                        "; ".join(str(n) for n in r.get("notes") or []),
+                    )
                 )
             )
-        )
 
     (out_dir / "report.md").write_text(report, encoding="utf-8")
     (out_dir / "results.json").write_text(
@@ -1388,16 +1803,29 @@ def main() -> int:
     eprint("")
     eprint(f"results written to {out_dir}/")
     print("")
-    print("variant          n   clear%  dScore  lexDiv  lenR  nums  tokOut  att  s/doc  eff/MTok")
-    print("-" * 82)
-    for variant, a in agg.items():
+    if args.mode == "minimal":
+        print("minimal rewrite level (across samples)")
+        print("-" * 40)
+        print(f"  samples evaluated : {agg['n_samples']}")
+        print(f"  cleared           : {agg['n_cleared']}")
+        print(f"  clear rate        : {_fmt(agg['clear_rate'])}")
+        print(f"  mean minimal level: {_fmt(agg['mean_min_level'])}")
+        print(f"  mean min sem div  : {_fmt(agg['mean_min_semantic_divergence'])}")
+        print(f"  mean min lex div  : {_fmt(agg['mean_min_lexical_divergence'])}")
+    else:
         print(
-            f"{variant:<16} {a['n']:>3}  {_fmt(a['clear_rate']):>6}  "
-            f"{_fmt(a['mean_score_delta']):>6}  {_fmt(a['mean_lexical_divergence']):>6}  "
-            f"{_fmt(a['mean_length_ratio']):>5}  {_fmt(a['mean_numbers_preserved']):>5}  "
-            f"{_fmt(a['mean_tokens_out']):>6}  {_fmt(a.get('mean_attempts')):>4}  "
-            f"{_fmt(a['mean_seconds']):>5}  {_fmt(a['clears_per_mtok_out']):>7}"
+            "variant          n   clear%  dScore  lexDiv  semDiv  lenR  nums  tokOut  att  s/doc  eff/MTok"
         )
+        print("-" * 92)
+        for variant, a in agg.items():
+            print(
+                f"{variant:<16} {a['n']:>3}  {_fmt(a['clear_rate']):>6}  "
+                f"{_fmt(a['mean_score_delta']):>6}  {_fmt(a['mean_lexical_divergence']):>6}  "
+                f"{_fmt(a.get('mean_semantic_divergence')):>6}  "
+                f"{_fmt(a['mean_length_ratio']):>5}  {_fmt(a['mean_numbers_preserved']):>5}  "
+                f"{_fmt(a['mean_tokens_out']):>6}  {_fmt(a.get('mean_attempts')):>4}  "
+                f"{_fmt(a['mean_seconds']):>5}  {_fmt(a['clears_per_mtok_out']):>7}"
+            )
     return 0
 
 

--- a/service/scripts/bench_synthid_text.py
+++ b/service/scripts/bench_synthid_text.py
@@ -34,6 +34,7 @@ import argparse
 import contextlib
 import csv
 import json
+import math
 import os
 import queue
 import re
@@ -1072,9 +1073,16 @@ class Benchmark:
             return round(float(threshold) - float(score), 4)
         return None
 
-    def _report_cleared(self, report: dict[str, Any]) -> bool:
-        """Did the after-detection report say the mark is gone?"""
-        return bool(report.get("available")) and not bool(report.get("is_watermarked"))
+    def _cleared_verdict(self, report: dict[str, Any] | None) -> bool | None:
+        """Tri-state clearance from an after-detection report.
+
+        True = report available and not watermarked (cleared); False = report
+        available and still watermarked; None = detection unavailable (fail-soft).
+        An unknown verdict is never conflated with a definite "still watermarked".
+        """
+        if not report or not report.get("available"):
+            return None
+        return not bool(report.get("is_watermarked"))
 
     def minimal_search(self, samples: list[dict[str, Any]], workdir: Path) -> list[dict[str, Any]]:
         """For each watermarked sample, raise the rewrite level until it clears.
@@ -1090,8 +1098,8 @@ class Benchmark:
         # Validate against the (0,1] rewrite-level contract before building the
         # list: a non-positive step would loop forever, and a level outside
         # (0,1] would make every rewrite_text.py call fail at runtime.
-        if a.rewrite_level_step <= 0:
-            raise SystemExit("error: --rewrite-level-step must be > 0")
+        if not math.isfinite(a.rewrite_level_step) or a.rewrite_level_step <= 0:
+            raise SystemExit("error: --rewrite-level-step must be a positive finite number")
         if not (0 < a.rewrite_level_start <= 1) or not (0 < a.rewrite_level_max <= 1):
             raise SystemExit(
                 "error: --rewrite-level-start and --rewrite-level-max must be in (0,1]"
@@ -1140,6 +1148,7 @@ class Benchmark:
             chosen: dict[str, Any] | None = None
             level_used: float | None = None
             failed: str | None = None
+            unavailable = False
             for lvl in levels:
                 clears: list[dict[str, Any]] = []
                 for _ in range(max(1, a.level_attempts)):
@@ -1156,7 +1165,11 @@ class Benchmark:
                         failed = str(e)
                         break
                     report = self._rewrite_report(stats, out_text)
-                    if not self._report_cleared(report):
+                    verdict = self._cleared_verdict(report)
+                    if verdict is None:
+                        unavailable = True
+                        continue
+                    if not verdict:
                         continue
                     margin = self._score_margin(report)
                     # A clear by a hair is not a robust removal: require the
@@ -1202,15 +1215,26 @@ class Benchmark:
                     }
                 )
             elif chosen is None:
-                row.update(
-                    {
-                        "cleared": False,
-                        "level": levels[-1],
-                        "lexical_divergence": None,
-                        "semantic_divergence": None,
-                        "notes": ["not cleared at any level"],
-                    }
-                )
+                if unavailable:
+                    row.update(
+                        {
+                            "cleared": None,
+                            "level": levels[-1],
+                            "lexical_divergence": None,
+                            "semantic_divergence": None,
+                            "notes": ["detection unavailable; not verified"],
+                        }
+                    )
+                else:
+                    row.update(
+                        {
+                            "cleared": False,
+                            "level": levels[-1],
+                            "lexical_divergence": None,
+                            "semantic_divergence": None,
+                            "notes": ["not cleared at any level"],
+                        }
+                    )
             else:
                 row.update(
                     {

--- a/service/scripts/bench_synthid_text.py
+++ b/service/scripts/bench_synthid_text.py
@@ -77,9 +77,9 @@ def parse_variants(spec: str) -> list[tuple[str, int]]:
     """Parse a variant spec like 'paraphrase:3,backtranslate:3'.
 
     Each item is <strength>:<candidates>; strengths come from rewrite_text.py
-    (paraphrase, backtranslate, structural, humanize, code). candidates is the
-    max rewrite attempts per input — the Layer B loop stops early as soon as
-    an attempt passes evaluation.
+    (paraphrase, backtranslate, structural, humanize, code, chunk). candidates
+    is the max rewrite attempts per input — the Layer B loop stops early as
+    soon as an attempt passes evaluation.
     """
     variants: list[tuple[str, int]] = []
     for raw_item in spec.split(","):
@@ -335,6 +335,7 @@ def run_rewrite(
     markllm_timeout: float,
     markllm_scheme: str,
     rewrite_level: float | None = None,
+    target_margin: float = 0.0,
 ) -> tuple[str, dict[str, Any]]:
     """Run the Layer B rewrite on *text* via rewrite_text.py (real product path).
 
@@ -386,6 +387,8 @@ def run_rewrite(
     ]
     if rewrite_level is not None:
         cmd += ["--rewrite-level", str(rewrite_level)]
+    if target_margin:
+        cmd += ["--target-margin", str(target_margin)]
     if allow_remote:
         cmd.append("--allow-remote")
     try:
@@ -755,6 +758,7 @@ class Benchmark:
         candidates: int,
         max_loops: int = 1,
         rewrite_level: float | None = None,
+        target_margin: float = 0.0,
     ) -> tuple[str, dict[str, Any]]:
         a = self.args
         return run_rewrite(
@@ -776,6 +780,7 @@ class Benchmark:
             markllm_timeout=a.markllm_timeout,
             markllm_scheme=self.scheme,
             rewrite_level=rewrite_level,
+            target_margin=target_margin,
         )
 
     # -- phases ------------------------------------------------------------
@@ -875,7 +880,9 @@ class Benchmark:
                 variant = f"rewrite-{strength}:{candidates}"
                 started = time.monotonic()
                 try:
-                    out_text, stats = self.rewrite(wm_text, strength, candidates)
+                    out_text, stats = self.rewrite(
+                        wm_text, strength, candidates, target_margin=self.args.target_margin
+                    )
                     rewrite_seconds = round(time.monotonic() - started, 3)
                 except RuntimeError as e:
                     rows.append(
@@ -886,6 +893,7 @@ class Benchmark:
                             "cleared": None,
                             "after_pos": None,
                             "score_after": None,
+                            "margin": None,
                             "notes": [f"rewrite failed: {e}"],
                         }
                     )
@@ -900,6 +908,7 @@ class Benchmark:
                             "cleared": None,
                             "after_pos": None,
                             "score_after": None,
+                            "margin": None,
                             "notes": ["rewrite markllm verification unavailable"],
                         }
                     )
@@ -919,6 +928,7 @@ class Benchmark:
                     row["cleared"] = bool(row["before_pos"] and not _detect_positive(markllm_after))
                 row["after_pos"] = _detect_positive(markllm_after)
                 row["score_after"] = _score_of(markllm_after)
+                row["margin"] = self._score_margin(markllm_after)
                 row["seconds"] = rewrite_seconds
                 row["attempts"] = stats.get("attempts_made")
                 row["evaluator"] = stats.get("evaluator")
@@ -946,7 +956,10 @@ class Benchmark:
                     variant = f"restamp-{strength}:{candidates}"
                     try:
                         out_text, _stats = self.rewrite(
-                            sample["unwatermarked"], strength, candidates
+                            sample["unwatermarked"],
+                            strength,
+                            candidates,
+                            target_margin=self.args.target_margin,
                         )
                     except RuntimeError as e:
                         rows.append(
@@ -967,6 +980,7 @@ class Benchmark:
                             "kind": "restamp",
                             "after_pos": _detect_positive(after),
                             "score_after": _score_of(after),
+                            "margin": self._score_margin(after),
                             "cleared": None,
                             "quality": _quality(
                                 sample["unwatermarked"],
@@ -1021,6 +1035,7 @@ class Benchmark:
             "cleared": cleared,
             "after_pos": _detect_positive(after),
             "score_after": _score_of(after),
+            "margin": self._score_margin(after),
             "quality": _quality(original, candidate, self.chars_per_token, self.semantic),
             "seconds": seconds,
             "usd": 0.0,
@@ -1032,17 +1047,33 @@ class Benchmark:
             row["notes"].append("Layer A only; statistical marks are expected to survive")
         return row
 
-    def _rewrite_cleared(self, stats: dict[str, Any], out_text: str) -> bool:
-        """Did the rewrite's own MarkLLM verification say the mark is gone?
+    def _rewrite_report(self, stats: dict[str, Any], out_text: str) -> dict[str, Any]:
+        """The rewrite's MarkLLM after-detection report (or a fresh detect).
 
         Prefer the rewrite's --json-stats (already paid for, no extra model
         load); fall back to a direct detection if the stats verdict is missing.
         """
         mk = (stats.get("markllm") or {}).get("after")
         if mk and mk.get("available"):
-            return not bool(mk.get("is_watermarked"))
-        after = self.detect(out_text)
-        return bool(after.get("available")) and not bool(after.get("is_watermarked"))
+            return mk
+        return self.detect(out_text)
+
+    def _score_margin(self, report: dict[str, Any]) -> float | None:
+        """margin = threshold - score for an after-detection report (None if N/A)."""
+        if not report or not report.get("available"):
+            return None
+        score = report.get("score")
+        threshold = report.get("threshold")
+        if isinstance(score, (int, float)) and isinstance(threshold, (int, float)):
+            return round(float(threshold) - float(score), 4)
+        return None
+
+    def _rewrite_cleared(self, stats: dict[str, Any], out_text: str) -> bool:
+        """Did the rewrite's own MarkLLM verification say the mark is gone?
+        Delegates to _rewrite_report, which falls back to a direct detection.
+        """
+        report = self._rewrite_report(stats, out_text)
+        return bool(report.get("available")) and not bool(report.get("is_watermarked"))
 
     def minimal_search(self, samples: list[dict[str, Any]], workdir: Path) -> list[dict[str, Any]]:
         """For each watermarked sample, raise the rewrite level until it clears.
@@ -1102,11 +1133,23 @@ class Benchmark:
                 for _ in range(max(1, a.level_attempts)):
                     attempts += 1
                     try:
-                        out_text, stats = self.rewrite(wm_text, "paraphrase", 1, rewrite_level=lvl)
+                        out_text, stats = self.rewrite(
+                            wm_text,
+                            "paraphrase",
+                            1,
+                            rewrite_level=lvl,
+                            target_margin=a.target_margin,
+                        )
                     except RuntimeError as e:
                         failed = str(e)
                         break
                     if not self._rewrite_cleared(stats, out_text):
+                        continue
+                    report = self._rewrite_report(stats, out_text)
+                    margin = self._score_margin(report)
+                    # A clear by a hair is not a robust removal: require the
+                    # configured margin before the level counts as "cleared".
+                    if margin is not None and margin < a.target_margin - 1e-9:
                         continue
                     clears.append(
                         {
@@ -1115,6 +1158,8 @@ class Benchmark:
                             "sem": self.semantic.score(wm_text, out_text)
                             if self.semantic
                             else None,
+                            "margin": margin,
+                            "score_after": _score_of(report),
                         }
                     )
                 if failed is not None:
@@ -1161,6 +1206,8 @@ class Benchmark:
                         "level": level_used,
                         "lexical_divergence": chosen["lex"],
                         "semantic_divergence": chosen["sem"],
+                        "margin": chosen["margin"],
+                        "score_after": chosen["score_after"],
                         "notes": [],
                     }
                 )
@@ -1210,6 +1257,7 @@ def aggregate(rows: list[dict[str, Any]], variants: list[tuple[str, int]]) -> di
         mean_tokens_out = _mean(tokens_out) if tokens_out else None
         scores_before = [r["score_before"] for r in group if r.get("score_before") is not None]
         scores_after = [r["score_after"] for r in group if r.get("score_after") is not None]
+        margins = [r["margin"] for r in group if r.get("margin") is not None]
         entries: dict[str, Any] = {
             "n": len(group),
             "before_positive": before_pos,
@@ -1218,6 +1266,7 @@ def aggregate(rows: list[dict[str, Any]], variants: list[tuple[str, int]]) -> di
             "clear_rate": round(clear_rate, 4) if clear_rate is not None else None,
             "mean_score_before": round(_mean(scores_before), 4) if scores_before else None,
             "mean_score_after": round(_mean(scores_after), 4) if scores_after else None,
+            "mean_margin": round(_mean(margins), 4) if margins else None,
             "mean_score_delta": round(_mean(deltas), 4) if deltas else None,
             "median_score_delta": round(sorted(deltas)[len(deltas) // 2], 4) if deltas else None,
             "mean_lexical_divergence": round(_mean([q["lexical_divergence"] for q in quals]), 4)
@@ -1269,6 +1318,7 @@ def aggregate_minimal(rows: list[dict[str, Any]]) -> dict[str, Any]:
     levels = [r["level"] for r in cleared if r.get("level") is not None]
     sems = [r["semantic_divergence"] for r in cleared if r.get("semantic_divergence") is not None]
     lexes = [r["lexical_divergence"] for r in cleared if r.get("lexical_divergence") is not None]
+    margins = [r["margin"] for r in cleared if r.get("margin") is not None]
     usage: dict[float, int] = {}
     for r in cleared:
         if r.get("level") is not None:
@@ -1283,6 +1333,7 @@ def aggregate_minimal(rows: list[dict[str, Any]]) -> dict[str, Any]:
         "mean_min_semantic_divergence": round(_mean(sems), 4) if sems else None,
         "median_min_semantic_divergence": round(sorted(sems)[len(sems) // 2], 4) if sems else None,
         "mean_min_lexical_divergence": round(_mean(lexes), 4) if lexes else None,
+        "mean_min_margin": round(_mean(margins), 4) if margins else None,
         "level_usage": list(usage.items()),
     }
 
@@ -1340,16 +1391,19 @@ def render_markdown(
     L.append("## Results (per variant)")
     L.append("")
     L.append(
-        "| Variant | n | clear % | Δscore μ | lex div | sem div | len ratio | nums keep | tok out | att | s/doc | clears/MTok |"
+        "| Variant | n | clear % | Δscore μ | margin μ | lex div | sem div | len ratio | nums keep | tok out | att | s/doc | clears/MTok |"
     )
-    L.append("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |")
+    L.append(
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
+    )
     for variant, a in agg.items():
         L.append(
-            "| {v} | {n} | {cr} | {d} | {ld} | {sd} | {lr} | {np} | {to} | {att} | {s} | {eff} |".format(
+            "| {v} | {n} | {cr} | {d} | {m} | {ld} | {sd} | {lr} | {np} | {to} | {att} | {s} | {eff} |".format(
                 v=variant,
                 n=a["n"],
                 cr=_fmt(a["clear_rate"]),
                 d=_fmt(a["mean_score_delta"]),
+                m=_fmt(a.get("mean_margin")),
                 ld=_fmt(a["mean_lexical_divergence"]),
                 sd=_fmt(a.get("mean_semantic_divergence")),
                 lr=_fmt(a["mean_length_ratio"]),
@@ -1438,6 +1492,7 @@ def render_markdown_minimal(
         f"| Median minimal semantic divergence | {_fmt(agg['median_min_semantic_divergence'])} |"
     )
     L.append(f"| Mean minimal lexical divergence | {_fmt(agg['mean_min_lexical_divergence'])} |")
+    L.append(f"| Mean minimal margin (threshold-score) | {_fmt(agg['mean_min_margin'])} |")
     L.append("")
     L.append("### Level usage (minimal level per cleared sample)")
     L.append("")
@@ -1448,15 +1503,16 @@ def render_markdown_minimal(
     L.append("")
     L.append("## Per-sample rows")
     L.append("")
-    L.append("| doc | seed | cleared | level | lex div | sem div | attempts |")
-    L.append("| --- | --- | ---: | ---: | ---: | ---: | ---: |")
+    L.append("| doc | seed | cleared | level | margin | lex div | sem div | attempts |")
+    L.append("| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |")
     for r in rows:
         L.append(
-            "| {doc} | {seed} | {cleared} | {lv} | {ld} | {sd} | {att} |".format(
+            "| {doc} | {seed} | {cleared} | {lv} | {mg} | {ld} | {sd} | {att} |".format(
                 doc=r["doc"],
                 seed=r["seed"],
                 cleared="yes" if r.get("cleared") else ("no" if r.get("cleared") is False else "—"),
                 lv=_fmt(r.get("level")),
+                mg=_fmt(r.get("margin")),
                 ld=_fmt(r.get("lexical_divergence")),
                 sd=_fmt(r.get("semantic_divergence")),
                 att=r.get("attempts"),
@@ -1474,7 +1530,7 @@ def render_markdown_minimal(
 
 def _minimal_csv(rows: list[dict[str, Any]]) -> list[str]:
     lines = [
-        "doc,seed,variant,kind,cleared,before_pos,score_before,level,"
+        "doc,seed,variant,kind,cleared,before_pos,score_before,level,margin,score_after,"
         "lexical_divergence,semantic_divergence,attempts,seconds,notes"
     ]
     for r in rows:
@@ -1490,6 +1546,8 @@ def _minimal_csv(rows: list[dict[str, Any]]) -> list[str]:
                     1 if r.get("before_pos") else 0,
                     r.get("score_before", ""),
                     r.get("level", ""),
+                    r.get("margin", ""),
+                    r.get("score_after", ""),
                     r.get("lexical_divergence", ""),
                     r.get("semantic_divergence", ""),
                     r.get("attempts", ""),
@@ -1607,6 +1665,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="minimal mode: rewrite attempts per level before escalating (default: 3)",
     )
     p.add_argument(
+        "--target-margin",
+        type=float,
+        default=0.0,
+        help="Robust-removal margin: require the after-score to sit at least "
+        "this many points below the detection threshold before a rewrite counts "
+        "as cleared (default: 0.0). Higher is stricter — it survives a "
+        "production detector but costs more content churn.",
+    )
+    p.add_argument(
         "--chars-per-token", type=float, default=4.0, help="Cost token estimate (default: 4.0)"
     )
     p.add_argument(
@@ -1688,6 +1755,7 @@ def main() -> int:
         "rewrite_level_step": args.rewrite_level_step,
         "rewrite_level_max": args.rewrite_level_max,
         "level_attempts": args.level_attempts,
+        "target_margin": args.target_margin,
         "semantic_model": args.semantic_model,
         "command": " ".join(
             [
@@ -1709,6 +1777,7 @@ def main() -> int:
                 f"--rewrite-level-step {args.rewrite_level_step}",
                 f"--rewrite-level-max {args.rewrite_level_max}",
                 f"--level-attempts {args.level_attempts}",
+                *([f"--target-margin {args.target_margin}"] if args.target_margin else []),
                 f"--semantic-model {args.semantic_model}",
                 *(["--restamp-control"] if args.restamp_control else []),
                 *(["--rewrite-allow-remote"] if args.rewrite_allow_remote else []),
@@ -1752,7 +1821,7 @@ def main() -> int:
         report = render_markdown(config, samples, rows, agg)
         csv_lines = [
             "doc,seed,variant,kind,attempts,evaluator,passed,before_pos,after_pos,cleared,"
-            "score_before,score_after,score_delta,lexical_divergence,semantic_divergence,"
+            "score_before,score_after,margin,score_delta,lexical_divergence,semantic_divergence,"
             "length_ratio,numbers_preserved,urls_preserved,tokens_in,tokens_out,seconds,usd,notes"
         ]
         for r in rows:
@@ -1778,6 +1847,7 @@ def main() -> int:
                         "" if r.get("cleared") is None else (1 if r["cleared"] else 0),
                         r.get("score_before", ""),
                         r.get("score_after", ""),
+                        r.get("margin", ""),
                         delta,
                         q.get("lexical_divergence", ""),
                         q.get("semantic_divergence", ""),
@@ -1812,15 +1882,17 @@ def main() -> int:
         print(f"  mean minimal level: {_fmt(agg['mean_min_level'])}")
         print(f"  mean min sem div  : {_fmt(agg['mean_min_semantic_divergence'])}")
         print(f"  mean min lex div  : {_fmt(agg['mean_min_lexical_divergence'])}")
+        print(f"  mean min margin   : {_fmt(agg['mean_min_margin'])}")
     else:
         print(
-            "variant          n   clear%  dScore  lexDiv  semDiv  lenR  nums  tokOut  att  s/doc  eff/MTok"
+            "variant          n   clear%  dScore  margin  lexDiv  semDiv  lenR  nums  tokOut  att  s/doc  eff/MTok"
         )
-        print("-" * 92)
+        print("-" * 100)
         for variant, a in agg.items():
             print(
                 f"{variant:<16} {a['n']:>3}  {_fmt(a['clear_rate']):>6}  "
-                f"{_fmt(a['mean_score_delta']):>6}  {_fmt(a['mean_lexical_divergence']):>6}  "
+                f"{_fmt(a['mean_score_delta']):>6}  {_fmt(a.get('mean_margin')):>6}  "
+                f"{_fmt(a['mean_lexical_divergence']):>6}  "
                 f"{_fmt(a.get('mean_semantic_divergence')):>6}  "
                 f"{_fmt(a['mean_length_ratio']):>5}  {_fmt(a['mean_numbers_preserved']):>5}  "
                 f"{_fmt(a['mean_tokens_out']):>6}  {_fmt(a.get('mean_attempts')):>4}  "

--- a/service/scripts/bench_synthid_text.py
+++ b/service/scripts/bench_synthid_text.py
@@ -1062,7 +1062,7 @@ class Benchmark:
             return mk
         return self.detect(out_text)
 
-    def _score_margin(self, report: dict[str, Any]) -> float | None:
+    def _score_margin(self, report: dict[str, Any] | None) -> float | None:
         """margin = threshold - score for an after-detection report (None if N/A)."""
         if not report or not report.get("available"):
             return None
@@ -1072,11 +1072,8 @@ class Benchmark:
             return round(float(threshold) - float(score), 4)
         return None
 
-    def _rewrite_cleared(self, stats: dict[str, Any], out_text: str) -> bool:
-        """Did the rewrite's own MarkLLM verification say the mark is gone?
-        Delegates to _rewrite_report, which falls back to a direct detection.
-        """
-        report = self._rewrite_report(stats, out_text)
+    def _report_cleared(self, report: dict[str, Any]) -> bool:
+        """Did the after-detection report say the mark is gone?"""
         return bool(report.get("available")) and not bool(report.get("is_watermarked"))
 
     def minimal_search(self, samples: list[dict[str, Any]], workdir: Path) -> list[dict[str, Any]]:
@@ -1158,9 +1155,9 @@ class Benchmark:
                     except RuntimeError as e:
                         failed = str(e)
                         break
-                    if not self._rewrite_cleared(stats, out_text):
-                        continue
                     report = self._rewrite_report(stats, out_text)
+                    if not self._report_cleared(report):
+                        continue
                     margin = self._score_margin(report)
                     # A clear by a hair is not a robust removal: require the
                     # configured margin before the level counts as "cleared".

--- a/service/scripts/bench_synthid_text.py
+++ b/service/scripts/bench_synthid_text.py
@@ -32,10 +32,12 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import csv
 import json
 import os
 import queue
 import re
+import statistics
 import subprocess
 import sys
 import threading
@@ -474,10 +476,12 @@ class SemanticEmbedder:
         self._failed: str | None = None
 
     def _load(self):
-        if self._model is not None:
-            return self._model
+        # Fail-soft: a prior load OR encode failure disables the backend so we
+        # stop retrying a failing model/encode instead of looping on it.
         if self._failed is not None:
             return None
+        if self._model is not None:
+            return self._model
         try:
             from sentence_transformers import SentenceTransformer, util
 
@@ -1086,13 +1090,24 @@ class Benchmark:
         lexical/semantic divergence of the chosen rewrite.
         """
         a = self.args
+        # Validate against the (0,1] rewrite-level contract before building the
+        # list: a non-positive step would loop forever, and a level outside
+        # (0,1] would make every rewrite_text.py call fail at runtime.
+        if a.rewrite_level_step <= 0:
+            raise SystemExit("error: --rewrite-level-step must be > 0")
+        if not (0 < a.rewrite_level_start <= 1) or not (0 < a.rewrite_level_max <= 1):
+            raise SystemExit(
+                "error: --rewrite-level-start and --rewrite-level-max must be in (0,1]"
+            )
         levels: list[float] = []
         lvl = a.rewrite_level_start
         while lvl <= a.rewrite_level_max + 1e-9:
             levels.append(round(lvl, 6))
             lvl += a.rewrite_level_step
-        if not levels:
-            raise SystemExit("error: --rewrite-level-max must be >= --rewrite-level-start")
+        # Always evaluate the configured maximum: a step can land just short of
+        # it (e.g. start .1, step .2, max 1.0 -> .1 ... .9, then 1.1 > max).
+        if levels and levels[-1] < a.rewrite_level_max - 1e-9:
+            levels.append(round(a.rewrite_level_max, 6))
 
         rows: list[dict[str, Any]] = []
         for sample in samples:
@@ -1104,8 +1119,8 @@ class Benchmark:
                         "variant": "minimal",
                         "kind": "minimal",
                         "cleared": None,
-                        "before_pos": _detect_positive(sample["before"]),
-                        "score_before": _score_of(sample["before"]),
+                        "before_pos": _detect_positive(sample.get("before")),
+                        "score_before": _score_of(sample.get("before")),
                         "level": None,
                         "lexical_divergence": None,
                         "semantic_divergence": None,
@@ -1329,9 +1344,9 @@ def aggregate_minimal(rows: list[dict[str, Any]]) -> dict[str, Any]:
         "n_cleared": len(cleared),
         "clear_rate": round(len(cleared) / n, 4) if n else None,
         "mean_min_level": round(_mean(levels), 4) if levels else None,
-        "median_min_level": round(sorted(levels)[len(levels) // 2], 4) if levels else None,
+        "median_min_level": round(statistics.median(levels), 4) if levels else None,
         "mean_min_semantic_divergence": round(_mean(sems), 4) if sems else None,
-        "median_min_semantic_divergence": round(sorted(sems)[len(sems) // 2], 4) if sems else None,
+        "median_min_semantic_divergence": round(statistics.median(sems), 4) if sems else None,
         "mean_min_lexical_divergence": round(_mean(lexes), 4) if lexes else None,
         "mean_min_margin": round(_mean(margins), 4) if margins else None,
         "level_usage": list(usage.items()),
@@ -1470,8 +1485,9 @@ def render_markdown_minimal(
     L.append("")
     L.append(
         "For each watermarked sample the benchmark starts at the lowest rewrite "
-        "level and raises it by 0.1 per loop until a rewrite is no longer "
-        "watermarked (same-config MarkLLM detection). The chosen rewrite is the "
+        f"level and raises it by {config['rewrite_level_step']} per loop until a "
+        "rewrite is no longer watermarked (same-config MarkLLM detection). "
+        "The chosen rewrite is the "
         "one with the smallest semantic divergence among the clearing attempts at "
         "that level; that level's value and the resulting lexical/semantic "
         "divergence are recorded. Samples that never clear are excluded from the "
@@ -1528,35 +1544,66 @@ def render_markdown_minimal(
     return "\n".join(L) + "\n"
 
 
+def _csv_cell(value: Any) -> Any:
+    """Render a CSV cell: None -> empty field, True/False -> 1/0, else as-is.
+
+    Prevents ``str(None)`` (the literal text "None") from leaking into numeric
+    columns and lets ``csv.writer`` escape any commas in the notes field.
+    """
+    if value is None:
+        return ""
+    if value is True:
+        return 1
+    if value is False:
+        return 0
+    return value
+
+
 def _minimal_csv(rows: list[dict[str, Any]]) -> list[str]:
-    lines = [
-        "doc,seed,variant,kind,cleared,before_pos,score_before,level,margin,score_after,"
-        "lexical_divergence,semantic_divergence,attempts,seconds,notes"
-    ]
+    import io
+
+    out = io.StringIO()
+    w = csv.writer(out)
+    w.writerow(
+        [
+            "doc",
+            "seed",
+            "variant",
+            "kind",
+            "cleared",
+            "before_pos",
+            "score_before",
+            "level",
+            "margin",
+            "score_after",
+            "lexical_divergence",
+            "semantic_divergence",
+            "attempts",
+            "seconds",
+            "notes",
+        ]
+    )
     for r in rows:
-        lines.append(
-            ",".join(
-                str(v)
-                for v in (
-                    r["doc"],
-                    r["seed"],
-                    "minimal",
-                    "minimal",
-                    "" if r.get("cleared") is None else (1 if r["cleared"] else 0),
-                    1 if r.get("before_pos") else 0,
-                    r.get("score_before", ""),
-                    r.get("level", ""),
-                    r.get("margin", ""),
-                    r.get("score_after", ""),
-                    r.get("lexical_divergence", ""),
-                    r.get("semantic_divergence", ""),
-                    r.get("attempts", ""),
-                    r.get("seconds", ""),
-                    "; ".join(str(n) for n in r.get("notes") or []),
-                )
-            )
+        w.writerow(
+            [
+                r["doc"],
+                r["seed"],
+                "minimal",
+                "minimal",
+                _csv_cell(r.get("cleared")),
+                1 if r.get("before_pos") else 0,
+                _csv_cell(r.get("score_before")),
+                _csv_cell(r.get("level")),
+                _csv_cell(r.get("margin")),
+                _csv_cell(r.get("score_after")),
+                _csv_cell(r.get("lexical_divergence")),
+                _csv_cell(r.get("semantic_divergence")),
+                _csv_cell(r.get("attempts")),
+                _csv_cell(r.get("seconds")),
+                "; ".join(str(n) for n in r.get("notes") or []),
+            ]
         )
-    return lines
+    return out.getvalue().rstrip("\n").splitlines()
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -1819,11 +1866,38 @@ def main() -> int:
         agg = aggregate(rows, bench.variants)
 
         report = render_markdown(config, samples, rows, agg)
-        csv_lines = [
-            "doc,seed,variant,kind,attempts,evaluator,passed,before_pos,after_pos,cleared,"
-            "score_before,score_after,margin,score_delta,lexical_divergence,semantic_divergence,"
-            "length_ratio,numbers_preserved,urls_preserved,tokens_in,tokens_out,seconds,usd,notes"
-        ]
+        import io
+
+        _csv_buf = io.StringIO()
+        _csv_w = csv.writer(_csv_buf)
+        _csv_w.writerow(
+            [
+                "doc",
+                "seed",
+                "variant",
+                "kind",
+                "attempts",
+                "evaluator",
+                "passed",
+                "before_pos",
+                "after_pos",
+                "cleared",
+                "score_before",
+                "score_after",
+                "margin",
+                "score_delta",
+                "lexical_divergence",
+                "semantic_divergence",
+                "length_ratio",
+                "numbers_preserved",
+                "urls_preserved",
+                "tokens_in",
+                "tokens_out",
+                "seconds",
+                "usd",
+                "notes",
+            ]
+        )
         for r in rows:
             q = r.get("quality") or {}
             delta = (
@@ -1831,37 +1905,35 @@ def main() -> int:
                 if r.get("score_before") is not None and r.get("score_after") is not None
                 else ""
             )
-            csv_lines.append(
-                ",".join(
-                    str(v)
-                    for v in (
-                        r["doc"],
-                        r["seed"],
-                        r["variant"],
-                        r.get("kind", ""),
-                        r.get("attempts", ""),
-                        r.get("evaluator", ""),
-                        "" if r.get("passed") is None else (1 if r["passed"] else 0),
-                        1 if r.get("before_pos") else 0,
-                        1 if r.get("after_pos") else 0,
-                        "" if r.get("cleared") is None else (1 if r["cleared"] else 0),
-                        r.get("score_before", ""),
-                        r.get("score_after", ""),
-                        r.get("margin", ""),
-                        delta,
-                        q.get("lexical_divergence", ""),
-                        q.get("semantic_divergence", ""),
-                        q.get("length_ratio", ""),
-                        q.get("numbers_preserved", ""),
-                        q.get("urls_preserved", ""),
-                        q.get("tokens_in", ""),
-                        q.get("tokens_out", ""),
-                        r.get("seconds", ""),
-                        round(r.get("usd") or 0.0, 6),
-                        "; ".join(str(n) for n in r.get("notes") or []),
-                    )
-                )
+            _csv_w.writerow(
+                [
+                    r["doc"],
+                    r["seed"],
+                    r["variant"],
+                    r.get("kind", ""),
+                    _csv_cell(r.get("attempts")),
+                    r.get("evaluator", ""),
+                    _csv_cell(r.get("passed")),
+                    1 if r.get("before_pos") else 0,
+                    1 if r.get("after_pos") else 0,
+                    _csv_cell(r.get("cleared")),
+                    _csv_cell(r.get("score_before")),
+                    _csv_cell(r.get("score_after")),
+                    _csv_cell(r.get("margin")),
+                    _csv_cell(delta),
+                    _csv_cell(q.get("lexical_divergence")),
+                    _csv_cell(q.get("semantic_divergence")),
+                    _csv_cell(q.get("length_ratio")),
+                    _csv_cell(q.get("numbers_preserved")),
+                    _csv_cell(q.get("urls_preserved")),
+                    _csv_cell(q.get("tokens_in")),
+                    _csv_cell(q.get("tokens_out")),
+                    _csv_cell(r.get("seconds")),
+                    round(r.get("usd") or 0.0, 6),
+                    "; ".join(str(n) for n in r.get("notes") or []),
+                ]
             )
+        csv_lines = _csv_buf.getvalue().rstrip("\n").splitlines()
 
     (out_dir / "report.md").write_text(report, encoding="utf-8")
     (out_dir / "results.json").write_text(

--- a/service/scripts/requirements-semantic.txt
+++ b/service/scripts/requirements-semantic.txt
@@ -1,0 +1,11 @@
+# Optional dependency for the semantic-divergence metric in the SynthID-text
+# benchmark (bench_synthid_text.py). The benchmark degrades gracefully to a
+# '—' semantic column when this package is absent, so installing it is not
+# required to run the benchmark.
+#
+# sentence-transformers 6.0 requires transformers>=5.0,<6.0, which matches the
+# transformers==5.15.0 pin in requirements-markllm.txt. Install it into the
+# same environment that has that pin (the MarkLLM venv) so the two do not
+# drift. It pulls in torch and transformers; install into the MarkLLM venv
+# (setup_markllm.sh) rather than a fresh environment to reuse those wheels.
+sentence-transformers==6.0.0

--- a/service/scripts/rewrite_text.py
+++ b/service/scripts/rewrite_text.py
@@ -46,6 +46,7 @@ import argparse
 import itertools
 import json
 import os
+import random
 import re
 import sys
 import urllib.error
@@ -110,6 +111,14 @@ PROMPTS = {
         "at the token level. Preserve all facts, numbers, names, and technical "
         "identifiers. Do not add or remove claims. Output only the rewritten text."
         "\n\n---\n{TEXT}"
+    ),
+    "chunk_unit": (
+        "Rewrite only this fragment to change a modest fraction of its tokens. "
+        "At low intensity keep the sentence structure, word order, and every "
+        "token that can stay, changing only function words and a few "
+        "non-essential content words. Preserve all facts, numbers, names, and "
+        "technical identifiers. Do not add or remove claims. Output only the "
+        "rewritten fragment.\n\n---\n{TEXT}"
     ),
 }
 
@@ -291,7 +300,20 @@ def build_prompt(
             "prose without omitting any bullet. Output only the final document.\n\n---\n"
             f"{text}"
         )
+    if strength == "chunk":
+        return PROMPTS["chunk_unit"].format(TEXT=text)
     raise ValueError(f"unknown strength: {strength}")
+
+
+def _split_units(text: str) -> list[str]:
+    """Split a document into fragments (sentences / paragraphs).
+
+    Breaks after sentence punctuation or on any blank-line / newline run, so
+    each fragment is rewritten independently (a fresh context per fragment ⇒
+    new per-token watermark keys). Punctuation is kept with its fragment.
+    """
+    parts = re.split(r"(?<=[.!?])\s+|\n+", text)
+    return [p.strip() for p in parts if p.strip()]
 
 
 def _http_json(url: str, payload: dict, headers: dict[str, str], timeout: float) -> dict:
@@ -365,6 +387,46 @@ def call_openai_compatible(
     return str(content).strip()
 
 
+def _candidate_pass(evaluation: dict, target_margin: float) -> tuple[bool | None, float | None]:
+    """Judge a detection report against a score-margin objective.
+
+    Returns (passed, margin). ``passed`` is True when the detector reports the
+    text not-watermarked AND its score sits at least ``target_margin`` below the
+    threshold; False when still watermarked; None when no verdict is available
+    (fail-soft) or when the margin floor is not met. ``margin`` = threshold -
+    score, or None when either field is missing OR the threshold is not a
+    score-scale cutoff.
+
+    Some detectors (keyed-Gumbel) report a *p-value* threshold that does not
+    scale with their ``score``, so ``threshold - score`` is meaningless; a
+    not-watermarked report whose score is above such a threshold is treated as
+    a clear pass rather than a gated margin.
+    """
+    verdict = evaluation.get("is_watermarked")
+    if verdict is None:
+        return None, None
+    score = evaluation.get("score")
+    threshold = evaluation.get("threshold")
+    margin = None
+    if isinstance(score, (int, float)) and isinstance(threshold, (int, float)):
+        margin = round(float(threshold) - float(score), 4)
+    if verdict is True:
+        return False, margin
+    # Not watermarked. If the threshold is not a score-scale cutoff it cannot
+    # express a margin, so fall back to a clean pass (no margin floor).
+    if margin is not None and margin < 0:
+        margin = None
+    met = margin is not None and margin >= target_margin - 1e-9
+    if margin is None or met:
+        return True, margin
+    return None, margin
+
+
+def _margin_of(rec: dict) -> float:
+    m = rec.get("margin")
+    return m if m is not None else -float("inf")
+
+
 def rewrite(
     text: str,
     *,
@@ -388,6 +450,9 @@ def rewrite(
     markllm_timeout: float = 180.0,
     gumbel_key: str | None = None,
     rewrite_level: float | None = None,
+    target_margin: float = 0.0,
+    selection: str = "min-divergence",
+    chunk_shuffle: bool = False,
 ) -> tuple[str, dict]:
     prompt = build_prompt(
         strength, text, lang=lang, original_lang=original_lang, rewrite_level=rewrite_level
@@ -451,19 +516,52 @@ def rewrite(
     evaluator_name, evaluator = _pick_evaluator(markllm_detector, gumbel_detector)
     info["evaluator"] = evaluator_name
 
+    is_chunk = strength == "chunk"
+    info["chunked"] = is_chunk
+    info["chunk_shuffle"] = bool(chunk_shuffle)
+
+    def _generate_candidate() -> str:
+        if is_chunk:
+            units = _split_units(text)
+            if chunk_shuffle:
+                random.shuffle(units)
+            return " ".join(
+                _generate_once(
+                    backend,
+                    base_url,
+                    model,
+                    api_key,
+                    build_prompt(
+                        strength,
+                        unit,
+                        lang=lang,
+                        original_lang=original_lang,
+                        rewrite_level=rewrite_level,
+                    ),
+                    timeout,
+                    temperature,
+                    reasoning_effort,
+                )
+                for unit in units
+            )
+        return _generate_once(
+            backend, base_url, model, api_key, prompt, timeout, temperature, reasoning_effort
+        )
+
     # Iterative rewrite: each loop generates --candidates variants and
-    # evaluates them, stopping as soon as one passes; --max-loops caps how
-    # many evaluation rounds run before the best-effort variant is returned.
-    # When no detector is configured the evaluator is lexical divergence,
-    # which has no pass/fail verdict, so every attempt is generated and the
-    # most diverged one is selected (the original --candidates behavior).
+    # evaluates them ALL (so the best is chosen, not the first to squeak under
+    # the threshold). A variant "passes" when the detector reports it
+    # not-watermarked AND its score sits at least --target-margin below the
+    # threshold; --max-loops caps the evaluation rounds before the best-effort
+    # variant is returned. When no detector is configured the evaluator is
+    # lexical divergence, which has no pass/fail verdict, so every attempt is
+    # generated and the most diverged one is selected (an unguided best-effort).
     attempts: list[tuple[str, dict]] = []
     passed: bool | None = None
     for loop in range(n_loops):
+        loop_passed = False
         for _ in range(n_cands):
-            cand = _generate_once(
-                backend, base_url, model, api_key, prompt, timeout, temperature, reasoning_effort
-            )
+            cand = _generate_candidate()
             cand_stats: dict | None = None
             if layer_a_after:
                 cand, cand_stats = clean_text(cand)
@@ -475,10 +573,9 @@ def rewrite(
                 }
             else:
                 evaluation = _safe_detect(evaluator, cand)
-            verdict = evaluation.get("is_watermarked")
-            passed_i: bool | None = (
-                True if verdict is False else (False if verdict is True else None)
-            )
+            passed_i, margin = _candidate_pass(evaluation, target_margin)
+            score = evaluation.get("score")
+            threshold = evaluation.get("threshold")
             attempts.append(
                 (
                     cand,
@@ -486,6 +583,13 @@ def rewrite(
                         "loop": loop,
                         "lexical_divergence": round(divergence, 4),
                         "selection_score": round(divergence, 4),
+                        "score_after": round(float(score), 4)
+                        if isinstance(score, (int, float))
+                        else None,
+                        "threshold": round(float(threshold), 4)
+                        if isinstance(threshold, (int, float))
+                        else None,
+                        "margin": margin,
                         "selected": False,
                         "passed": passed_i,
                         "evaluation": evaluation,
@@ -494,9 +598,9 @@ def rewrite(
                 )
             )
             if passed_i is True:
-                passed = True
-                break
-        if passed is True:
+                loop_passed = True
+        if loop_passed:
+            passed = True
             break
 
     if evaluator is not None and passed is None:
@@ -504,8 +608,12 @@ def rewrite(
     info["attempts_made"] = len(attempts)
     info["passed"] = passed
 
-    # Best-effort selection when no attempt passed: the lowest watermark score
-    # (detector evaluator) or the most lexically diverged variant (fallback).
+    # Best-effort selection: among the candidates that passed (met the margin
+    # objective) pick the one that changed the least (min-divergence, the
+    # content-preserving default) or the one with the largest margin
+    # (--select max-margin, robustness-first). When none passed, fall back to
+    # the lowest watermark score (detector evaluator) or the most diverged
+    # variant (unguided fallback).
     selected_idx: int
     best_score: float | None = None
     best_score_idx: int | None = None
@@ -520,8 +628,12 @@ def rewrite(
             if isinstance(s, (int, float)) and (best_score is None or s < best_score):
                 best_score = float(s)
                 best_score_idx = i
-    if passed is True:
-        selected_idx = len(attempts) - 1  # the passing attempt is the last one
+    passed_idxs = [i for i, (_c, r) in enumerate(attempts) if r["passed"] is True]
+    if passed_idxs:
+        if selection == "max-margin":
+            selected_idx = max(passed_idxs, key=lambda i: _margin_of(attempts[i][1]))
+        else:
+            selected_idx = min(passed_idxs, key=lambda i: attempts[i][1]["lexical_divergence"])
     elif best_score_idx is not None:
         selected_idx = best_score_idx
     else:
@@ -539,9 +651,16 @@ def rewrite(
         "cannot certify removal against a vendor detector."
     )
     if evaluator is not None and passed is not True:
+        margin_suffix = f" (target margin {target_margin:.2f})" if target_margin else ""
         note += (
             f" Exhausted {len(attempts)} attempt(s) without passing "
-            f"{evaluator_name} evaluation; returned the best-effort variant."
+            f"{evaluator_name} evaluation{margin_suffix}; returned the best-effort variant."
+        )
+    if markllm_scheme:
+        note += (
+            " Cross-model hygiene: rewrite with a model that is neither the "
+            "generator nor itself watermarked, or the rewritten text can be "
+            "re-stamped."
         )
     info["note"] = note
 
@@ -561,6 +680,16 @@ def rewrite(
             )
         else:
             markllm["cleared"] = None
+        a_score = after.get("score")
+        a_thr = after.get("threshold")
+        markllm["score_after"] = (
+            round(float(a_score), 4) if isinstance(a_score, (int, float)) else None
+        )
+        markllm["margin"] = (
+            round(float(a_thr) - float(a_score), 4)
+            if isinstance(a_score, (int, float)) and isinstance(a_thr, (int, float))
+            else None
+        )
         markllm["note"] = (
             "MarkLLM detection is only valid against the SAME scheme config + "
             "keys used at generation; it does not certify a vendor detector."
@@ -628,7 +757,7 @@ def build_parser() -> argparse.ArgumentParser:
     # and shell history. Set WATERMARKS_REWRITE_API_KEY instead.
     p.add_argument(
         "--strength",
-        choices=("paraphrase", "backtranslate", "structural", "humanize", "code"),
+        choices=("paraphrase", "backtranslate", "structural", "humanize", "code", "chunk"),
         default="paraphrase",
     )
     p.add_argument(
@@ -640,6 +769,29 @@ def build_parser() -> argparse.ArgumentParser:
         "that changes a fraction of tokens close to this value. Omit to use "
         "--strength (the benchmark's minimal mode drives this explicitly). "
         "Planned nominal default 0.5, to be tuned from benchmark output.",
+    )
+    p.add_argument(
+        "--target-margin",
+        type=float,
+        default=0.0,
+        help="Require a detection to sit at least this far below the threshold "
+        "to count as a pass (robustness floor; default 0.0 = any not-watermarked "
+        "verdict). Margin = threshold - score.",
+    )
+    p.add_argument(
+        "--select",
+        choices=("min-divergence", "max-margin"),
+        default="min-divergence",
+        help="Among candidates that pass --target-margin, select the one that "
+        "changed the least (min-divergence, the content-preserving default) or "
+        "the one with the largest score margin (max-margin, robustness-first).",
+    )
+    p.add_argument(
+        "--chunk-shuffle",
+        action="store_true",
+        help="With --strength chunk, shuffle the rewritten fragments (breaks "
+        "cross-fragment context ordering; destroys document coherence, so "
+        "opt-in)",
     )
     p.add_argument("--lang", default="French", help="Pivot language for backtranslate")
     p.add_argument("--original-lang", default="English")
@@ -751,6 +903,9 @@ def main() -> int:
             markllm_timeout=args.markllm_timeout,
             gumbel_key=args.gumbel_key,
             rewrite_level=args.rewrite_level,
+            target_margin=args.target_margin,
+            selection=args.select,
+            chunk_shuffle=args.chunk_shuffle,
         )
     except (urllib.error.URLError, TimeoutError, RuntimeError) as e:
         eprint(f"rewrite failed: {e}")

--- a/service/scripts/rewrite_text.py
+++ b/service/scripts/rewrite_text.py
@@ -552,11 +552,13 @@ def rewrite(
     def _generate_candidate() -> str:
         if is_chunk:
             pairs = _split_units(text)
-            units = [unit for unit, _ in pairs]
             if chunk_shuffle:
+                units = [unit for unit, _ in pairs if unit]
                 random.shuffle(units)
                 return " ".join(_rewrite_unit(unit) for unit in units)
-            return "".join(_rewrite_unit(unit) + sep for unit, sep in pairs)
+            # Skip rewriting empty leading units (blank lines at the top) but
+            # keep their separators so the reassembled document keeps the layout.
+            return "".join((_rewrite_unit(unit) if unit else "") + sep for unit, sep in pairs)
         return _generate_once(
             backend, base_url, model, api_key, prompt, timeout, temperature, reasoning_effort
         )

--- a/service/scripts/rewrite_text.py
+++ b/service/scripts/rewrite_text.py
@@ -27,6 +27,12 @@ attempts are generated and the most diverged one is selected). A vendor-detector
 seam (Google's retired SynthID-text detector) is reserved ahead of the
 same-config detectors should a vendor endpoint return.
 
+The rewrite instruction comes from --strength (a named prompt) or, when
+--rewrite-level is set, a numeric rewrite intensity in (0,1] that controls how
+many tokens change (0 — the unchanged original — is excluded; 1 rewrites
+everything). The level is a request: output lexical/semantic divergence is
+measured, not guaranteed.
+
 Security notes:
   - Only http(s) endpoints are accepted; redirects are refused outright so an
     Authorization header (API key) can never be re-sent to an unvalidated host.
@@ -93,6 +99,16 @@ PROMPTS = {
     "structural_write": (
         "Write a complete document from this outline in natural, varied human prose. "
         "Avoid formulaic transitions. Do not omit any bullet. Output only the document."
+        "\n\n---\n{TEXT}"
+    ),
+    "level": (
+        "Rewrite the following text so that a fraction of the tokens close to "
+        "{LEVEL:.2f} changes — 0 would mean the wording is kept unchanged, 1 means "
+        "everything is rewritten. At low values keep the sentence structure, word "
+        "order, and every token that can stay, changing only function words and a "
+        "few non-essential content words. At high values change wording substantially "
+        "at the token level. Preserve all facts, numbers, names, and technical "
+        "identifiers. Do not add or remove claims. Output only the rewritten text."
         "\n\n---\n{TEXT}"
     ),
 }
@@ -245,7 +261,16 @@ def _generate_once(
     raise SystemExit(f"unknown backend: {backend}")
 
 
-def build_prompt(strength: str, text: str, *, lang: str, original_lang: str) -> str:
+def build_prompt(
+    strength: str,
+    text: str,
+    *,
+    lang: str,
+    original_lang: str,
+    rewrite_level: float | None = None,
+) -> str:
+    if rewrite_level is not None:
+        return PROMPTS["level"].format(TEXT=text, LEVEL=rewrite_level)
     if strength == "paraphrase":
         return PROMPTS["paraphrase"].format(TEXT=text)
     if strength == "humanize":
@@ -362,11 +387,15 @@ def rewrite(
     markllm_model: str | None = None,
     markllm_timeout: float = 180.0,
     gumbel_key: str | None = None,
+    rewrite_level: float | None = None,
 ) -> tuple[str, dict]:
-    prompt = build_prompt(strength, text, lang=lang, original_lang=original_lang)
+    prompt = build_prompt(
+        strength, text, lang=lang, original_lang=original_lang, rewrite_level=rewrite_level
+    )
     info: dict = {
         "backend": backend,
         "strength": strength,
+        "rewrite_level": rewrite_level,
         "model": model,
         "base_url": base_url,
         "temperature": temperature,
@@ -602,6 +631,16 @@ def build_parser() -> argparse.ArgumentParser:
         choices=("paraphrase", "backtranslate", "structural", "humanize", "code"),
         default="paraphrase",
     )
+    p.add_argument(
+        "--rewrite-level",
+        type=float,
+        default=None,
+        help="Numeric rewrite intensity in (0,1]; 0 (the unchanged original) is "
+        "excluded. When set, overrides --strength and builds a level-based prompt "
+        "that changes a fraction of tokens close to this value. Omit to use "
+        "--strength (the benchmark's minimal mode drives this explicitly). "
+        "Planned nominal default 0.5, to be tuned from benchmark output.",
+    )
     p.add_argument("--lang", default="French", help="Pivot language for backtranslate")
     p.add_argument("--original-lang", default="English")
     p.add_argument("--timeout", type=float, default=120.0)
@@ -679,6 +718,10 @@ def build_parser() -> argparse.ArgumentParser:
 def main() -> int:
     args = build_parser().parse_args()
 
+    if args.rewrite_level is not None and not (0 < args.rewrite_level <= 1):
+        eprint(f"error: --rewrite-level must be in (0,1], got {args.rewrite_level}")
+        return 2
+
     text = read_text_input(args.path, allow_binary=args.force_text)
     allow_remote = (
         args.allow_remote
@@ -707,6 +750,7 @@ def main() -> int:
             markllm_model=args.markllm_model,
             markllm_timeout=args.markllm_timeout,
             gumbel_key=args.gumbel_key,
+            rewrite_level=args.rewrite_level,
         )
     except (urllib.error.URLError, TimeoutError, RuntimeError) as e:
         eprint(f"rewrite failed: {e}")

--- a/service/scripts/rewrite_text.py
+++ b/service/scripts/rewrite_text.py
@@ -305,15 +305,26 @@ def build_prompt(
     raise ValueError(f"unknown strength: {strength}")
 
 
-def _split_units(text: str) -> list[str]:
-    """Split a document into fragments (sentences / paragraphs).
+def _split_units(text: str) -> list[tuple[str, str]]:
+    """Split a document into (unit, separator) pairs.
 
     Breaks after sentence punctuation or on any blank-line / newline run, so
     each fragment is rewritten independently (a fresh context per fragment ⇒
-    new per-token watermark keys). Punctuation is kept with its fragment.
+    new per-token watermark keys). Punctuation is kept with its fragment. The
+    separator is the whitespace/blank-line run that follows a unit ('' for the
+    last); unshuffled chunk mode reassembles with it so paragraph/line layout
+    is preserved, while shuffled mode drops it.
     """
-    parts = re.split(r"(?<=[.!?])\s+|\n+", text)
-    return [p.strip() for p in parts if p.strip()]
+    parts = re.split(r"((?<=[.!?])\s+|\n+)", text)
+    pairs: list[tuple[str, str]] = []
+    i = 0
+    while i < len(parts):
+        unit = parts[i]
+        sep = parts[i + 1] if i + 1 < len(parts) else ""
+        if unit.strip() or "\n" in sep:
+            pairs.append((unit.strip(), sep))
+        i += 2
+    return pairs
 
 
 def _http_json(url: str, payload: dict, headers: dict[str, str], timeout: float) -> dict:
@@ -520,30 +531,32 @@ def rewrite(
     info["chunked"] = is_chunk
     info["chunk_shuffle"] = bool(chunk_shuffle)
 
+    def _rewrite_unit(unit: str) -> str:
+        return _generate_once(
+            backend,
+            base_url,
+            model,
+            api_key,
+            build_prompt(
+                strength,
+                unit,
+                lang=lang,
+                original_lang=original_lang,
+                rewrite_level=rewrite_level,
+            ),
+            timeout,
+            temperature,
+            reasoning_effort,
+        )
+
     def _generate_candidate() -> str:
         if is_chunk:
-            units = _split_units(text)
+            pairs = _split_units(text)
+            units = [unit for unit, _ in pairs]
             if chunk_shuffle:
                 random.shuffle(units)
-            return " ".join(
-                _generate_once(
-                    backend,
-                    base_url,
-                    model,
-                    api_key,
-                    build_prompt(
-                        strength,
-                        unit,
-                        lang=lang,
-                        original_lang=original_lang,
-                        rewrite_level=rewrite_level,
-                    ),
-                    timeout,
-                    temperature,
-                    reasoning_effort,
-                )
-                for unit in units
-            )
+                return " ".join(_rewrite_unit(unit) for unit in units)
+            return "".join(_rewrite_unit(unit) + sep for unit, sep in pairs)
         return _generate_once(
             backend, base_url, model, api_key, prompt, timeout, temperature, reasoning_effort
         )

--- a/tests/test_bench_synthid_text.py
+++ b/tests/test_bench_synthid_text.py
@@ -66,6 +66,7 @@ def _args(**overrides):
         rewrite_level_step=0.1,
         rewrite_level_max=1.0,
         level_attempts=3,
+        target_margin=0.0,
     )
     values.update(overrides)
     return argparse.Namespace(**values)
@@ -81,7 +82,9 @@ def _make_bench(tmp_path, monkeypatch, patch_steps=True, **args_overrides):
             b, "detect", lambda text: DETECT_POS if text.startswith("watermarked") else DETECT_NEG
         )
         monkeypatch.setattr(
-            b, "rewrite", lambda text, strength, candidates: (text + " rewritten", _rewrite_stats())
+            b,
+            "rewrite",
+            lambda text, strength, candidates, **kw: (text + " rewritten", _rewrite_stats()),
         )
     return b, args
 
@@ -108,7 +111,12 @@ def _rewrite_stats(cleared=True, evaluator="markllm", attempts_made=1, passed=Tr
         "passed": passed,
         "markllm": {
             "before": dict(DETECT_POS),
-            "after": {"available": True, "is_watermarked": not cleared, "score": -0.5},
+            "after": {
+                "available": True,
+                "is_watermarked": not cleared,
+                "score": -0.5,
+                "threshold": 0.5,
+            },
             "cleared": cleared,
             "note": "same-config only",
         },
@@ -177,6 +185,7 @@ def test_aggregate_clear_rate_and_efficiency():
             "cleared": True,
             "score_before": 2.0,
             "score_after": -1.0,
+            "margin": 1.0,
             "quality": {
                 "lexical_divergence": 0.8,
                 "length_ratio": 1.0,
@@ -197,6 +206,7 @@ def test_aggregate_clear_rate_and_efficiency():
             "cleared": False,
             "score_before": 2.0,
             "score_after": 1.5,
+            "margin": -1.5,
             "quality": {
                 "lexical_divergence": 0.6,
                 "length_ratio": 1.0,
@@ -218,6 +228,7 @@ def test_aggregate_clear_rate_and_efficiency():
     assert a["mean_score_delta"] == 1.75  # ((2-(-1)) + (2-1.5)) / 2
     assert a["mean_tokens_out"] == 250
     assert a["mean_attempts"] == 2.0  # (1 + 3) / 2
+    assert a["mean_margin"] == -0.25  # (1.0 + -1.5) / 2
     assert a["clears_per_mtok_out"] == pytest.approx(2000.0)  # 0.5 / (250/1e6)
 
 
@@ -309,7 +320,7 @@ def test_run_variants_rows_and_clear_rate(tmp_path, monkeypatch):
 def test_rewrite_failure_is_recorded_not_fatal(tmp_path, monkeypatch):
     b, _ = _make_bench(tmp_path, monkeypatch, docs=1, variants="paraphrase:1")
 
-    def _boom(text, strength, candidates):
+    def _boom(text, strength, candidates, **kw):
         raise RuntimeError("backend down")
 
     monkeypatch.setattr(b, "rewrite", _boom)
@@ -808,7 +819,7 @@ def test_minimal_search_escalates_until_cleared(tmp_path, monkeypatch):
     samples = b.generate_samples(tmp_path / "work")
     levels_called = []
 
-    def fake_rewrite(text, strength, candidates, rewrite_level=None):
+    def fake_rewrite(text, strength, candidates, rewrite_level=None, **kw):
         levels_called.append(rewrite_level)
         cleared = rewrite_level is not None and rewrite_level >= 0.3
         return f"{text}|{rewrite_level} rewritten", _rewrite_stats(cleared=cleared, attempts_made=1)
@@ -830,7 +841,7 @@ def test_minimal_search_picks_min_semantic_among_clearing(tmp_path, monkeypatch)
     samples = b.generate_samples(tmp_path / "work")
     sems = iter([0.9, 0.3, 0.7])
 
-    def fake_rewrite(text, strength, candidates, rewrite_level=None):
+    def fake_rewrite(text, strength, candidates, rewrite_level=None, **kw):
         return f"{text}|{rewrite_level} rewritten", _rewrite_stats(cleared=True, attempts_made=1)
 
     monkeypatch.setattr(b, "rewrite", fake_rewrite)
@@ -847,7 +858,7 @@ def test_minimal_search_records_not_cleared_when_no_level_clears(tmp_path, monke
     b, _ = _make_bench(tmp_path, monkeypatch, docs=1, mode="minimal", level_attempts=1)
     samples = b.generate_samples(tmp_path / "work")
 
-    def fake_rewrite(text, strength, candidates, rewrite_level=None):
+    def fake_rewrite(text, strength, candidates, rewrite_level=None, **kw):
         return f"{text} rewritten", _rewrite_stats(cleared=False, attempts_made=1)
 
     monkeypatch.setattr(b, "rewrite", fake_rewrite)
@@ -859,10 +870,57 @@ def test_minimal_search_records_not_cleared_when_no_level_clears(tmp_path, monke
     assert "not cleared at any level" in "; ".join(row["notes"])
 
 
+def test_minimal_search_target_margin_gates_tiny_clear(tmp_path, monkeypatch):
+    b, _ = _make_bench(
+        tmp_path, monkeypatch, docs=1, mode="minimal", level_attempts=1, target_margin=2.0
+    )
+    samples = b.generate_samples(tmp_path / "work")
+    levels_called = []
+
+    def fake_rewrite(text, strength, candidates, rewrite_level=None, **kw):
+        levels_called.append(rewrite_level)
+        # "clears" by the detector (is_watermarked False) but the fake margin
+        # is 1.0 < target_margin 2.0, so it is gated out of the clear count.
+        return f"{text}|{rewrite_level} rewritten", _rewrite_stats(cleared=True, attempts_made=1)
+
+    monkeypatch.setattr(b, "rewrite", fake_rewrite)
+    monkeypatch.setattr(b.semantic, "score", lambda o, c: 0.25)
+    rows = b.minimal_search(samples, tmp_path / "work")
+    row = rows[0]
+    # No level can clear against target_margin=2.0 (fake margin is 1.0), so the
+    # search escalates to the max and records a failure, not a hair-thin pass.
+    assert row["cleared"] is False
+    assert row["level"] == b.args.rewrite_level_max
+    assert levels_called == [
+        0.1,
+        0.2,
+        0.3,
+        0.4,
+        0.5,
+        0.6,
+        0.7,
+        0.8,
+        0.9,
+        1.0,
+    ]
+
+
 def test_aggregate_minimal_means_and_usage():
     rows = [
-        {"cleared": True, "level": 0.2, "semantic_divergence": 0.1, "lexical_divergence": 0.3},
-        {"cleared": True, "level": 0.6, "semantic_divergence": 0.4, "lexical_divergence": 0.5},
+        {
+            "cleared": True,
+            "level": 0.2,
+            "semantic_divergence": 0.1,
+            "lexical_divergence": 0.3,
+            "margin": 0.9,
+        },
+        {
+            "cleared": True,
+            "level": 0.6,
+            "semantic_divergence": 0.4,
+            "lexical_divergence": 0.5,
+            "margin": 1.5,
+        },
         {"cleared": False, "level": 1.0, "semantic_divergence": None, "lexical_divergence": None},
     ]
     agg = bench.aggregate_minimal(rows)
@@ -873,4 +931,5 @@ def test_aggregate_minimal_means_and_usage():
     assert agg["median_min_level"] == pytest.approx(0.6, rel=1e-4)
     assert agg["mean_min_semantic_divergence"] == pytest.approx(0.25, rel=1e-4)
     assert agg["mean_min_lexical_divergence"] == pytest.approx(0.4, rel=1e-4)
+    assert agg["mean_min_margin"] == pytest.approx(1.2, rel=1e-4)  # (0.9 + 1.5) / 2
     assert agg["level_usage"] == [(0.2, 1), (0.6, 1)]

--- a/tests/test_bench_synthid_text.py
+++ b/tests/test_bench_synthid_text.py
@@ -889,7 +889,15 @@ def test_minimal_search_always_evaluates_max_level(tmp_path, monkeypatch):
 
 def test_minimal_search_rejects_bad_level_config(tmp_path, monkeypatch):
     for overrides, err in [
-        ({"rewrite_level_step": 0.0}, "--rewrite-level-step must be > 0"),
+        ({"rewrite_level_step": 0.0}, "--rewrite-level-step must be a positive finite number"),
+        (
+            {"rewrite_level_step": float("inf")},
+            "--rewrite-level-step must be a positive finite number",
+        ),
+        (
+            {"rewrite_level_step": float("nan")},
+            "--rewrite-level-step must be a positive finite number",
+        ),
         ({"rewrite_level_start": 0.0}, "must be in (0,1]"),
         ({"rewrite_level_max": 1.5}, "must be in (0,1]"),
     ]:
@@ -967,6 +975,37 @@ def test_minimal_search_target_margin_gates_tiny_clear(tmp_path, monkeypatch):
         0.9,
         1.0,
     ]
+
+
+def test_cleared_verdict_tristate(tmp_path, monkeypatch):
+    b, _ = _make_bench(tmp_path, monkeypatch, docs=1, mode="minimal")
+    assert b._cleared_verdict({"available": True, "is_watermarked": False}) is True
+    assert b._cleared_verdict({"available": True, "is_watermarked": True}) is False
+    # fail-soft: unavailable detection is never a definite "still watermarked"
+    assert b._cleared_verdict({"available": False, "is_watermarked": True}) is None
+    assert b._cleared_verdict(None) is None
+    assert b._cleared_verdict({"available": True, "is_watermarked": None}) is True
+
+
+def test_minimal_search_detection_unavailable_is_excluded(tmp_path, monkeypatch):
+    b, _ = _make_bench(tmp_path, monkeypatch, docs=1, mode="minimal", level_attempts=1)
+    samples = b.generate_samples(tmp_path / "work")
+
+    # Detection is fail-soft unavailable, so the after-report has no verdict.
+    monkeypatch.setattr(
+        b,
+        "_rewrite_report",
+        lambda stats, out_text: {"available": False, "is_watermarked": None},
+    )
+    rows = b.minimal_search(samples, tmp_path / "work")
+    row = rows[0]
+    # An unknown verdict is excluded (cleared=None), not reported as "not cleared".
+    assert row["cleared"] is None
+    assert "detection unavailable" in "; ".join(row["notes"])
+    # aggregate_minimal drops the unknown row from the clear-rate denominator.
+    agg = bench.aggregate_minimal(rows)
+    assert agg["n_samples"] == 0
+    assert agg["clear_rate"] is None
 
 
 def test_aggregate_minimal_means_and_usage():

--- a/tests/test_bench_synthid_text.py
+++ b/tests/test_bench_synthid_text.py
@@ -60,6 +60,12 @@ def _args(**overrides):
         no_worker=True,
         scheme="synthid",
         config=None,
+        mode="variants",
+        semantic_model="sentence-transformers/all-MiniLM-L6-v2",
+        rewrite_level_start=0.1,
+        rewrite_level_step=0.1,
+        rewrite_level_max=1.0,
+        level_attempts=3,
     )
     values.update(overrides)
     return argparse.Namespace(**values)
@@ -337,6 +343,7 @@ class _FakeBench:
         self.variants = parse_variants(args.variants)
         self.corpus = load_corpus(args.corpus, args.docs)
         self.chars_per_token = args.chars_per_token
+        self.semantic = bench.SemanticEmbedder(args.semantic_model)
 
     def close_worker(self):
         pass
@@ -684,3 +691,186 @@ def test_run_cmd_no_rlimit_preexec(monkeypatch):
 
     b._run_cmd(["echo", "hi"], timeout=5)
     assert "preexec_fn" not in calls["kwargs"]
+
+
+# ---------------------------------------------------------------------------
+# Semantic divergence
+# ---------------------------------------------------------------------------
+
+
+def test_semantic_embedder_score_is_one_minus_cosine():
+    class _FakeModel:
+        def encode(self, texts, normalize_embeddings=True):
+            return [[1.0, 0.0], [0.0, 1.0]]  # orthogonal -> cosine 0
+
+    class _FakeUtil:
+        def cos_sim(self, a, b):
+            class _V:
+                def item(self):
+                    return 0.0
+
+            return _V()
+
+    emb = bench.SemanticEmbedder("fake-model")
+    emb._model = _FakeModel()
+    emb._util = _FakeUtil()
+    assert emb.available() is True
+    assert emb.score("original", "candidate") == 1.0
+
+
+def test_semantic_embedder_graceful_when_package_missing(monkeypatch):
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _fake_import(name, *a, **k):
+        if name == "sentence_transformers":
+            raise ImportError("not installed")
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+    emb = bench.SemanticEmbedder("a-model")
+    assert emb.available() is False
+    assert emb.score("a", "b") is None
+    # a second call does not keep retrying the import
+    assert emb.score("a", "b") is None
+
+
+def test_quality_includes_semantic_divergence():
+    class _FakeSem:
+        def score(self, original, candidate):
+            return 0.42
+
+    sem = _FakeSem()
+    q = bench._quality("original text", "rewritten text", 4.0, sem)
+    assert q["semantic_divergence"] == 0.42
+    # no semantic backend -> the metric is present but None
+    q2 = bench._quality("original text", "rewritten text", 4.0)
+    assert q2["semantic_divergence"] is None
+
+
+def test_aggregate_mean_semantic_divergence_skips_none():
+    rows = [
+        {
+            "variant": "rewrite-paraphrase:1",
+            "kind": "rewrite",
+            "before_pos": True,
+            "after_pos": False,
+            "cleared": True,
+            "score_before": 2.0,
+            "score_after": -1.0,
+            "quality": {
+                "lexical_divergence": 0.8,
+                "semantic_divergence": 0.2,
+                "length_ratio": 1.0,
+                "numbers_preserved": 1.0,
+                "tokens_in": 100,
+                "tokens_out": 100,
+            },
+            "seconds": 1.0,
+            "usd": 0.0,
+            "notes": [],
+        },
+        {
+            "variant": "rewrite-paraphrase:1",
+            "kind": "rewrite",
+            "before_pos": True,
+            "after_pos": False,
+            "cleared": True,
+            "score_before": 2.0,
+            "score_after": -1.0,
+            "quality": {
+                "lexical_divergence": 0.6,
+                "semantic_divergence": None,
+                "length_ratio": 1.0,
+                "numbers_preserved": 1.0,
+                "tokens_in": 200,
+                "tokens_out": 200,
+            },
+            "seconds": 1.0,
+            "usd": 0.0,
+            "notes": [],
+        },
+    ]
+    agg = aggregate(rows, [("paraphrase", 1)])
+    a = agg["rewrite-paraphrase:1"]
+    assert a["semantic_n"] == 1
+    assert a["mean_semantic_divergence"] == 0.2
+
+
+# ---------------------------------------------------------------------------
+# Minimal-rewrite-level mode
+# ---------------------------------------------------------------------------
+
+
+def test_minimal_search_escalates_until_cleared(tmp_path, monkeypatch):
+    b, _ = _make_bench(tmp_path, monkeypatch, docs=1, mode="minimal", level_attempts=1)
+    samples = b.generate_samples(tmp_path / "work")
+    levels_called = []
+
+    def fake_rewrite(text, strength, candidates, rewrite_level=None):
+        levels_called.append(rewrite_level)
+        cleared = rewrite_level is not None and rewrite_level >= 0.3
+        return f"{text}|{rewrite_level} rewritten", _rewrite_stats(cleared=cleared, attempts_made=1)
+
+    monkeypatch.setattr(b, "rewrite", fake_rewrite)
+    monkeypatch.setattr(b.semantic, "score", lambda o, c: 0.25)
+    rows = b.minimal_search(samples, tmp_path / "work")
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["cleared"] is True
+    assert row["level"] == 0.3
+    assert row["semantic_divergence"] == 0.25
+    # one attempt per level, escalating 0.1 -> 0.2 -> 0.3
+    assert levels_called == [0.1, 0.2, 0.3]
+
+
+def test_minimal_search_picks_min_semantic_among_clearing(tmp_path, monkeypatch):
+    b, _ = _make_bench(tmp_path, monkeypatch, docs=1, mode="minimal", level_attempts=3)
+    samples = b.generate_samples(tmp_path / "work")
+    sems = iter([0.9, 0.3, 0.7])
+
+    def fake_rewrite(text, strength, candidates, rewrite_level=None):
+        return f"{text}|{rewrite_level} rewritten", _rewrite_stats(cleared=True, attempts_made=1)
+
+    monkeypatch.setattr(b, "rewrite", fake_rewrite)
+    monkeypatch.setattr(b.semantic, "score", lambda o, c: next(sems))
+    rows = b.minimal_search(samples, tmp_path / "work")
+    row = rows[0]
+    assert row["cleared"] is True
+    # all attempts clear at the first level; the smallest semantic wins
+    assert row["level"] == 0.1
+    assert row["semantic_divergence"] == 0.3
+
+
+def test_minimal_search_records_not_cleared_when_no_level_clears(tmp_path, monkeypatch):
+    b, _ = _make_bench(tmp_path, monkeypatch, docs=1, mode="minimal", level_attempts=1)
+    samples = b.generate_samples(tmp_path / "work")
+
+    def fake_rewrite(text, strength, candidates, rewrite_level=None):
+        return f"{text} rewritten", _rewrite_stats(cleared=False, attempts_made=1)
+
+    monkeypatch.setattr(b, "rewrite", fake_rewrite)
+    rows = b.minimal_search(samples, tmp_path / "work")
+    row = rows[0]
+    assert row["cleared"] is False
+    assert row["level"] == 1.0
+    assert row["semantic_divergence"] is None
+    assert "not cleared at any level" in "; ".join(row["notes"])
+
+
+def test_aggregate_minimal_means_and_usage():
+    rows = [
+        {"cleared": True, "level": 0.2, "semantic_divergence": 0.1, "lexical_divergence": 0.3},
+        {"cleared": True, "level": 0.6, "semantic_divergence": 0.4, "lexical_divergence": 0.5},
+        {"cleared": False, "level": 1.0, "semantic_divergence": None, "lexical_divergence": None},
+    ]
+    agg = bench.aggregate_minimal(rows)
+    assert agg["n_samples"] == 3
+    assert agg["n_cleared"] == 2
+    assert agg["clear_rate"] == pytest.approx(2 / 3, rel=1e-4)
+    assert agg["mean_min_level"] == pytest.approx(0.4, rel=1e-4)
+    assert agg["median_min_level"] == pytest.approx(0.6, rel=1e-4)
+    assert agg["mean_min_semantic_divergence"] == pytest.approx(0.25, rel=1e-4)
+    assert agg["mean_min_lexical_divergence"] == pytest.approx(0.4, rel=1e-4)
+    assert agg["level_usage"] == [(0.2, 1), (0.6, 1)]

--- a/tests/test_bench_synthid_text.py
+++ b/tests/test_bench_synthid_text.py
@@ -747,6 +747,26 @@ def test_semantic_embedder_graceful_when_package_missing(monkeypatch):
     assert emb.score("a", "b") is None
 
 
+def test_semantic_embedder_failsoft_after_encode_failure():
+    class _FakeModel:
+        def __init__(self):
+            self.calls = 0
+
+        def encode(self, texts, normalize_embeddings=True):
+            self.calls += 1
+            raise RuntimeError("encode exploded")
+
+    emb = bench.SemanticEmbedder("fake-model")
+    emb._model = _FakeModel()
+    emb._util = type("_U", (), {"cos_sim": lambda self, a, b: None})()
+    assert emb.score("orig", "cand") is None
+    assert emb.available() is False
+    # fail-soft: the backend is disabled after a failed encode, so a second
+    # score returns None WITHOUT re-encoding, and available() stays False.
+    assert emb.score("orig", "cand") is None
+    assert emb._model.calls == 1
+
+
 def test_quality_includes_semantic_divergence():
     class _FakeSem:
         def score(self, original, candidate):
@@ -834,6 +854,50 @@ def test_minimal_search_escalates_until_cleared(tmp_path, monkeypatch):
     assert row["semantic_divergence"] == 0.25
     # one attempt per level, escalating 0.1 -> 0.2 -> 0.3
     assert levels_called == [0.1, 0.2, 0.3]
+
+
+def test_minimal_search_always_evaluates_max_level(tmp_path, monkeypatch):
+    b, _ = _make_bench(
+        tmp_path,
+        monkeypatch,
+        docs=1,
+        mode="minimal",
+        level_attempts=1,
+        rewrite_level_start=0.1,
+        rewrite_level_step=0.2,
+        rewrite_level_max=1.0,
+    )
+    samples = b.generate_samples(tmp_path / "work")
+    levels_called = []
+
+    def fake_rewrite(text, strength, candidates, rewrite_level=None, **kw):
+        levels_called.append(rewrite_level)
+        # clears only at the configured maximum
+        return f"{text}|{rewrite_level} rewritten", _rewrite_stats(
+            cleared=(rewrite_level == 1.0), attempts_made=1
+        )
+
+    monkeypatch.setattr(b, "rewrite", fake_rewrite)
+    monkeypatch.setattr(b.semantic, "score", lambda o, c: 0.25)
+    rows = b.minimal_search(samples, tmp_path / "work")
+    row = rows[0]
+    assert row["cleared"] is True
+    assert row["level"] == 1.0
+    # 0.1, 0.3, 0.5, 0.7, 0.9 then the clamped maximum 1.0
+    assert levels_called == [0.1, 0.3, 0.5, 0.7, 0.9, 1.0]
+
+
+def test_minimal_search_rejects_bad_level_config(tmp_path, monkeypatch):
+    for overrides, err in [
+        ({"rewrite_level_step": 0.0}, "--rewrite-level-step must be > 0"),
+        ({"rewrite_level_start": 0.0}, "must be in (0,1]"),
+        ({"rewrite_level_max": 1.5}, "must be in (0,1]"),
+    ]:
+        b, _ = _make_bench(tmp_path, monkeypatch, docs=1, mode="minimal", **overrides)
+        samples = b.generate_samples(tmp_path / "work")
+        with pytest.raises(SystemExit) as e:
+            b.minimal_search(samples, tmp_path / "work")
+        assert err in str(e.value)
 
 
 def test_minimal_search_picks_min_semantic_among_clearing(tmp_path, monkeypatch):
@@ -928,7 +992,9 @@ def test_aggregate_minimal_means_and_usage():
     assert agg["n_cleared"] == 2
     assert agg["clear_rate"] == pytest.approx(2 / 3, rel=1e-4)
     assert agg["mean_min_level"] == pytest.approx(0.4, rel=1e-4)
-    assert agg["median_min_level"] == pytest.approx(0.6, rel=1e-4)
+    assert agg["median_min_level"] == pytest.approx(
+        0.4, rel=1e-4
+    )  # conventional median of {0.2, 0.6}
     assert agg["mean_min_semantic_divergence"] == pytest.approx(0.25, rel=1e-4)
     assert agg["mean_min_lexical_divergence"] == pytest.approx(0.4, rel=1e-4)
     assert agg["mean_min_margin"] == pytest.approx(1.2, rel=1e-4)  # (0.9 + 1.5) / 2

--- a/tests/test_rewrite_text.py
+++ b/tests/test_rewrite_text.py
@@ -581,7 +581,7 @@ def test_strength_chunk_reassembles_fragments(monkeypatch):
     assert info["chunk_shuffle"] is False
     # each fragment is rewritten with a fresh context (fresh per-token key)
     assert calls == ["First sentence.", "Second sentence!", "Third paragraph?"]
-    assert out == "RE: First sentence. RE: Second sentence! RE: Third paragraph?"
+    assert out == "RE: First sentence. RE: Second sentence!\n\nRE: Third paragraph?"
 
 
 def test_strength_chunk_shuffle_reorders_fragments(monkeypatch):

--- a/tests/test_rewrite_text.py
+++ b/tests/test_rewrite_text.py
@@ -64,6 +64,33 @@ def test_build_prompt_unknown_strength_raises():
         build_prompt("nope", "ABC", lang="French", original_lang="English")
 
 
+def test_build_prompt_level_embeds_level():
+    p = build_prompt(
+        "paraphrase", "Hello 42.", lang="French", original_lang="English", rewrite_level=0.3
+    )
+    assert "Hello 42." in p
+    assert "0.30" in p
+    # level prompt is not the regular paraphrase prompt
+    assert "clause order" not in p
+
+
+def test_rewrite_level_takes_precedence_over_strength():
+    out, info = rewrite(
+        "Sample prose about water marks 42.",
+        **_rewrite_kwargs(strength="paraphrase", rewrite_level=0.4),
+    )
+    assert info["mode"] == "print-prompt"
+    assert info["strength"] == "paraphrase"
+    assert info["rewrite_level"] == 0.4
+    assert "0.40" in out
+    assert "clause order" not in out
+
+
+def test_rewrite_level_out_of_range_rejected(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["rewrite_text.py", "--rewrite-level", "0", "x.txt"])
+    assert rewrite_text.main() == 2
+
+
 def test_print_prompt_backend():
     out, info = rewrite("Sample prose about water marks.", **_rewrite_kwargs())
     assert info["mode"] == "print-prompt"

--- a/tests/test_rewrite_text.py
+++ b/tests/test_rewrite_text.py
@@ -584,6 +584,35 @@ def test_strength_chunk_reassembles_fragments(monkeypatch):
     assert out == "RE: First sentence. RE: Second sentence!\n\nRE: Third paragraph?"
 
 
+def test_strength_chunk_leading_blank_line_kept(monkeypatch):
+    calls = []
+
+    def fake_ollama(base_url, model, prompt, timeout, temperature):
+        calls.append(prompt.split("---")[-1].strip())
+        return "RE: " + prompt.split("---")[-1].strip()
+
+    monkeypatch.setattr(rewrite_text, "call_ollama", fake_ollama)
+    # A blank line at the top is a separator, not a fragment: it must not be
+    # sent to the backend, but unshuffled mode keeps it in the reassembly.
+    text = "\n\nFirst sentence. Second sentence!"
+    out, _ = rewrite(
+        text,
+        backend="ollama",
+        model="m",
+        base_url="http://127.0.0.1:11434",
+        api_key=None,
+        strength="chunk",
+        lang="French",
+        original_lang="English",
+        timeout=5.0,
+        layer_a_after=False,
+        temperature=0.9,
+        candidates=1,
+    )
+    assert calls == ["First sentence.", "Second sentence!"]
+    assert out == "\n\nRE: First sentence. RE: Second sentence!"
+
+
 def test_strength_chunk_shuffle_reorders_fragments(monkeypatch):
     calls = []
 

--- a/tests/test_rewrite_text.py
+++ b/tests/test_rewrite_text.py
@@ -18,6 +18,7 @@ sys.path.insert(0, str(SCRIPTS))
 
 import rewrite_text
 from rewrite_text import (
+    _candidate_pass,
     _check_remote,
     _flag_env,
     _lexical_divergence,
@@ -283,7 +284,7 @@ def test_markllm_detector_parameterized_from_cli(monkeypatch):
     }
 
 
-def test_loop_stops_on_first_passing_attempt(monkeypatch):
+def test_evaluates_all_candidates_and_selects_pass(monkeypatch):
     monkeypatch.setattr(rewrite_text, "MarkLLMTextDetector", _FakeMarkLLM)
     monkeypatch.setattr(rewrite_text, "call_ollama", lambda *a, **k: "alpha beta gamma delta")
     out, info = rewrite(
@@ -295,7 +296,9 @@ def test_loop_stops_on_first_passing_attempt(monkeypatch):
     assert out == "alpha beta gamma delta"
     assert info["candidates"] == 3
     assert info["max_loops"] == 3
-    assert info["attempts_made"] == 1  # passed on the first attempt
+    # All three candidates pass; they are evaluated and the least-divergent
+    # one is selected (all identical here, so the first).
+    assert info["attempts_made"] == 3
     assert info["passed"] is True
     assert info["candidate_scores"][0]["selected"] is True
 
@@ -459,6 +462,156 @@ def test_single_candidate_attempt(monkeypatch):
     assert len(info["candidate_scores"]) == 1
     assert info["candidate_scores"][0]["selected"] is True
     assert info["markllm"]["cleared"] is True
+
+
+# ---------------------------------------------------------------------------
+# Robust-removal margin selection (--target-margin / --select) and chunk mode
+# ---------------------------------------------------------------------------
+
+
+def test_candidate_pass_treats_pvalue_threshold_as_no_margin():
+    # keyed-Gumbel reports a p-value threshold (1e-06) that does not scale with
+    # its score, so threshold - score is meaningless and must not gate a clear.
+    gumbel_report = {"available": True, "is_watermarked": False, "score": 0.21, "threshold": 1e-06}
+    assert _candidate_pass(gumbel_report, 0.0) == (True, None)
+    assert _candidate_pass(gumbel_report, 0.5) == (True, None)
+
+
+def test_target_margin_gates_small_margin_pass(monkeypatch):
+    """A not-watermarked candidate whose margin is below --target-margin is
+    not counted as a pass; the loop must keep the margin-meeting candidate."""
+
+    class _TinyMargin:
+        name = "markllm"
+
+        def __init__(self, **kwargs):
+            pass
+
+        def available(self):
+            return True
+
+        def detect(self, text):
+            if text == "tiny":
+                return {"available": True, "is_watermarked": False, "score": 2.95, "threshold": 3.0}
+            if text == "big":
+                return {"available": True, "is_watermarked": False, "score": 1.0, "threshold": 3.0}
+            return {"available": True, "is_watermarked": True, "score": 3.0, "threshold": 3.0}
+
+    monkeypatch.setattr(rewrite_text, "MarkLLMTextDetector", _TinyMargin)
+    texts = iter(["tiny", "big"])  # margins 0.05 then 2.0
+    monkeypatch.setattr(rewrite_text, "call_ollama", lambda *a, **k: next(texts))
+    out, info = rewrite(
+        "the cat sat on the mat",
+        **_rewrite_candidates_kwargs(
+            candidates=2, markllm_scheme="kgw", markllm_dir="/x", target_margin=1.0
+        ),
+    )
+    # "tiny" is not watermarked but its margin (0.05) never reaches the 1.0
+    # floor, so it is gated; "big"'s margin (2.0) clears the floor and wins.
+    assert out == "big"
+    assert info["passed"] is True
+    cs = info["candidate_scores"]
+    # "tiny" is gated: it cleared the watermark detector but not the margin
+    # floor, so it contributes no pass verdict; "big" meets the floor and wins.
+    assert cs[0]["passed"] is None
+    assert cs[0]["selected"] is False
+    assert cs[1]["passed"] is True
+    assert cs[1]["selected"] is True
+
+
+def test_select_max_margin_prefers_largest_margin(monkeypatch):
+    class _TwoMargins:
+        name = "markllm"
+
+        def __init__(self, **kwargs):
+            pass
+
+        def available(self):
+            return True
+
+        def detect(self, text):
+            return {
+                "available": True,
+                "is_watermarked": False,
+                "score": {"low": 2.0, "high": 1.0}[text],
+                "threshold": 3.0,
+            }
+
+    monkeypatch.setattr(rewrite_text, "MarkLLMTextDetector", _TwoMargins)
+    texts = iter(["low", "high"])  # margins 1.0 then 2.0
+    monkeypatch.setattr(rewrite_text, "call_ollama", lambda *a, **k: next(texts))
+    out, info = rewrite(
+        "the cat sat on the mat",
+        **_rewrite_candidates_kwargs(
+            candidates=2, markllm_scheme="kgw", markllm_dir="/x", selection="max-margin"
+        ),
+    )
+    assert out == "high"  # largest margin wins, not least divergence
+    assert info["passed"] is True
+    cs = info["candidate_scores"]
+    assert cs[0]["margin"] == 1.0
+    assert cs[1]["margin"] == 2.0
+    assert cs[1]["selected"] is True
+
+
+def test_strength_chunk_reassembles_fragments(monkeypatch):
+    calls = []
+
+    def fake_ollama(base_url, model, prompt, timeout, temperature):
+        calls.append(prompt.split("---")[-1].strip())
+        return "RE: " + prompt.split("---")[-1].strip()
+
+    monkeypatch.setattr(rewrite_text, "call_ollama", fake_ollama)
+    text = "First sentence. Second sentence!\n\nThird paragraph?"
+    out, info = rewrite(
+        text,
+        backend="ollama",
+        model="m",
+        base_url="http://127.0.0.1:11434",
+        api_key=None,
+        strength="chunk",
+        lang="French",
+        original_lang="English",
+        timeout=5.0,
+        layer_a_after=False,
+        temperature=0.9,
+        candidates=1,
+    )
+    assert info["chunked"] is True
+    assert info["chunk_shuffle"] is False
+    # each fragment is rewritten with a fresh context (fresh per-token key)
+    assert calls == ["First sentence.", "Second sentence!", "Third paragraph?"]
+    assert out == "RE: First sentence. RE: Second sentence! RE: Third paragraph?"
+
+
+def test_strength_chunk_shuffle_reorders_fragments(monkeypatch):
+    calls = []
+
+    def fake_ollama(base_url, model, prompt, timeout, temperature):
+        calls.append(prompt.split("---")[-1].strip())
+        return "RE: " + prompt.split("---")[-1].strip()
+
+    monkeypatch.setattr(rewrite_text, "call_ollama", fake_ollama)
+    monkeypatch.setattr(rewrite_text.random, "shuffle", lambda units: units.reverse())
+    text = "First sentence. Second sentence!\n\nThird paragraph?"
+    out, info = rewrite(
+        text,
+        backend="ollama",
+        model="m",
+        base_url="http://127.0.0.1:11434",
+        api_key=None,
+        strength="chunk",
+        lang="French",
+        original_lang="English",
+        timeout=5.0,
+        layer_a_after=False,
+        temperature=0.9,
+        candidates=1,
+        chunk_shuffle=True,
+    )
+    assert info["chunk_shuffle"] is True
+    assert calls == ["Third paragraph?", "Second sentence!", "First sentence."]
+    assert out == "RE: Third paragraph? RE: Second sentence! RE: First sentence."
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Fixes the benchmark's core weakness — it reported a "clear" on looks alone (a hair-thin threshold crossing such as `paraphrase:1` at Δ ≈ 0.035) — and adds a lever that actually destroys the watermark's context-key signal.

**Robust-removal objective.** `rewrite_text.py` no longer stops at the first not-watermarked candidate. It evaluates every candidate in a round, treats a candidate as a pass only when its after-score sits at least `--target-margin` below the detection threshold, and then selects the passing variant that changed the least (`--select min-divergence`, content-preserving) or has the largest margin (`--select max-margin`, robustness-first). A near-zero margin is no longer reported as a win.

**Chunk-and-reassemble (`--strength chunk`).** Splits the text into sentence/paragraph fragments, rewrites each with a fresh context (so every fragment gets new per-token watermark keys), and rejoins. `--chunk-shuffle` reorders fragments (opt-in). This attacks the context/prefix-ordering carrier that "changing words" misses.

**Benchmark margin reporting.** `bench_synthid_text.py` now carries a `margin` column and `mean_margin` / `mean_min_margin` aggregates across the report, CSV, and JSON, and forwards `--target-margin` into both variants and minimal modes.

**Also in this PR** (continued from the earlier commits on this branch):
- **Semantic divergence**: `1 - cosine(embed(original), embed(candidate))` via a SentenceTransformer. Optional and fail-soft: if `sentence-transformers` isn't installed the metric is `None` and reports/CSV render `—`.
- **`--mode minimal`**: per sample, raise `--rewrite-level-start` by `--rewrite-level-step` until a rewrite clears (capped at `--rewrite-level-max`), keeping the smallest-semantic-divergence rewrite at the first clearing level. `aggregate_minimal` reports clear rate, mean/median minimal level and divergence, and a level-usage histogram.
- **`rewrite_text.py --rewrite-level`**: numeric intensity in `(0,1]` that overrides `--strength` when set; validated in `main()` (exit 2 out-of-range).
- **Keyed-Gumbel fix**: its p-value threshold (`1e-06`) is not a score-scale cutoff, so `threshold - score` no longer produces a meaningless negative margin that blocked legitimate clears.
- **Cross-model hygiene warning** in `rewrite_text.py` (rewrite with a model that is neither the generator nor itself watermarked, or the text gets re-stamped) and **humanizer guidance** in the docs (it's style polish, not removal — measure with the detector score and `--target-margin`).
- New optional `service/scripts/requirements-semantic.txt` (pins `sentence-transformers==6.0.0`).
- Docs updated in `docs/synthid-text-benchmark.md`.

## Why

The variants benchmark only answers "does this rewrite remove the mark?". The minimal mode answers "what is the smallest rewrite that removes it?" — the quantity needed to tune a default rewrite level. But both previously scored a pass on a yes/no verdict, so a rewrite that crossed the threshold by a hair counted as "cleared" even though it would not survive a production detector, longer text, or any slight alteration. The margin objective (`--target-margin`, plus the `margin`/`mean_margin` columns) makes robustness measurable and selectable, while `min-divergence` selection keeps as much of the original content as possible.

## Checklist

- [x] Unit tests added/updated under `tests/` (rewrite-level prompt/precedence/range; semantic embedder scoring + graceful fallback; minimal-mode escalation, min-semantic selection, not-cleared; margin gating, max-margin selection, chunk reassemble + shuffle, gumbel p-value threshold, benchmark margin aggregation + `--target-margin` gating)
- [x] `python3 -m pytest -q` passes (full suite green)
- [x] `ruff check service tests` and `ruff format --check service tests` pass
- [x] Docs updated (`docs/synthid-text-benchmark.md`)
- [x] No drive-by refactors

## Notes for the reviewer

- **Deviation from plan**: `--rewrite-level` defaults to *unset*, not `0.5`. A literal `0.5` default would override `--strength` on every `rewrite_text.py` call and break the benchmark's existing named-strength `variants` mode.
- **Margin only applies where the threshold is score-scale** (MarkLLM). `_candidate_pass` falls back to a clean pass when a detector reports `threshold` that does not scale with `score` (keyed-Gumbel's p-value cutoff), since `threshold - score` is meaningless there.
- Detection is MarkLLM same-config only (Google retired SynthID-text on its API Aug 2026).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional semantic-divergence scoring to SynthID-text benchmarks.
  * Added minimal rewrite mode to identify the least intensive successful rewrite.
  * Added controls for rewrite levels, target margins, candidate selection, chunk rewriting, and chunk shuffling.
  * Added detection margins, semantic metrics, and minimal-mode results to console, Markdown, and CSV reports.

* **Bug Fixes**
  * Benchmarks now continue gracefully when semantic-scoring dependencies, models, or encoding are unavailable.

* **Documentation**
  * Updated guidance with setup instructions, workflows, metrics, verdict definitions, and cross-model re-stamping controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
