### PR TITLE
Skip discarded exiftool and redundant SynthID in clean_image post-cle…

### DIFF
--- a/service/scripts/image_meta.py
+++ b/service/scripts/image_meta.py
@@ -1349,7 +1349,7 @@ def strip_tiff(data: bytes, *, strip_all_metadata: bool = True) -> tuple[bytes, 
     return bytes(out), actions
 
 
-def run_optional_tools(path: Path) -> dict[str, Any]:
+def run_optional_tools(path: Path, *, include_exiftool: bool = True) -> dict[str, Any]:
     tools: dict[str, Any] = {}
     c2patool = which("c2patool")
     if c2patool:
@@ -1401,7 +1401,7 @@ def run_optional_tools(path: Path) -> dict[str, Any]:
     else:
         tools["c2patool"] = {"available": False}
 
-    exiftool = which("exiftool")
+    exiftool = which("exiftool") if include_exiftool else None
     if exiftool:
         try:
             r = subprocess.run(
@@ -1739,8 +1739,13 @@ def run_ctrlregen_clean(
 def inspect_image(
     path: Path,
     synthid_dir: str | None = None,
+    *,
+    data: bytes | None = None,
+    run_synthid: bool = True,
+    include_exiftool: bool = True,
 ) -> ImageInspectReport:
-    data = path.read_bytes()
+    if data is None:
+        data = path.read_bytes()
     fmt = detect_format(data)
     if fmt == "png":
         has_c2pa, has_ai, findings = inspect_png(data)
@@ -1769,7 +1774,7 @@ def inspect_image(
             "format not fully inspected; only PNG/JPEG/WebP/AVIF/HEIC/BMP/GIF/TIFF are supported"
         )
 
-    tools = run_optional_tools(path)
+    tools = run_optional_tools(path, include_exiftool=include_exiftool)
     # Elevate flags from tools
     ct = tools.get("c2patool") or {}
     if ct.get("has_manifest"):
@@ -1786,7 +1791,7 @@ def inspect_image(
         has_ai_metadata=has_ai,
         findings=findings,
         tools=tools,
-        synthid=run_synthid_score(path, synthid_dir),
+        synthid=run_synthid_score(path, synthid_dir) if run_synthid else None,
         notes=notes,
     )
 
@@ -2169,8 +2174,24 @@ def clean_image(
         else:
             raise ValueError(f"unknown pixel remover: {remove_pixel}")
 
-    after = inspect_image(dest, synthid_dir=synthid_dir)
-    changed = dest.read_bytes() != data
+    # Residual scan on the final cleaned bytes: run the stdlib inspector plus
+    # the c2patool C2PA verifier only. clean_image discards the exiftool tool
+    # dump, so skip that subprocess. SynthID scores pixels, so a metadata-only
+    # clean leaves the score identical to synthid_before; re-score only when a
+    # pixel remover actually changed the image.
+    final_bytes = dest.read_bytes()
+    changed = final_bytes != data
+    after = inspect_image(
+        dest,
+        synthid_dir=synthid_dir,
+        data=final_bytes,
+        run_synthid=False,
+        include_exiftool=False,
+    )
+    if pixel_removal is not None and pixel_removal.get("available"):
+        synthid_after = run_synthid_score(dest, synthid_dir)
+    else:
+        synthid_after = synthid_before
     return {
         "input": str(path),
         "output": str(dest),
@@ -2183,6 +2204,6 @@ def clean_image(
         "still_has_ai_metadata": after.has_ai_metadata,
         "post_findings": after.findings,
         "synthid_before": synthid_before,
-        "synthid_after": after.synthid,
+        "synthid_after": synthid_after,
         "pixel_removal": pixel_removal,
     }

--- a/tests/test_clean_image.py
+++ b/tests/test_clean_image.py
@@ -195,6 +195,44 @@ def test_clean_image_roundtrip(tmp_path: Path):
     assert result["bytes_out"] > 0
 
 
+def test_clean_image_residual_scan_skips_exiftool_and_redundant_synthid(tmp_path: Path):
+    """The post-clean residual scan keeps the c2patool C2PA verifier but must not
+    spawn the (discarded) exiftool dump, and a metadata-only clean reuses
+    synthid_before instead of re-scoring the unchanged pixels."""
+    from unittest.mock import patch
+
+    import image_meta
+
+    src = tmp_path / "t.png"
+    src.write_bytes(_minimal_png_with_text())
+    dest = tmp_path / "t.cleaned.png"
+
+    exiftool_flags: list[bool] = []
+    synthid_calls = 0
+    real_run_optional_tools = image_meta.run_optional_tools
+
+    def spy_tools(path, *, include_exiftool=True):
+        exiftool_flags.append(include_exiftool)
+        return real_run_optional_tools(path, include_exiftool=include_exiftool)
+
+    def fake_synthid(path, upstream_dir=None):
+        nonlocal synthid_calls
+        synthid_calls += 1
+        return {"available": True, "score": 0.5}
+
+    with (
+        patch.object(image_meta, "run_optional_tools", spy_tools),
+        patch.object(image_meta, "run_synthid_score", fake_synthid),
+    ):
+        result = clean_image(src, dest, synthid_dir="/fake/dir")
+
+    # Residual scan ran run_optional_tools exactly once, with exiftool disabled.
+    assert exiftool_flags == [False]
+    # SynthID scored once (before); metadata-only clean reuses it for _after.
+    assert synthid_calls == 1
+    assert result["synthid_after"] == result["synthid_before"] == {"available": True, "score": 0.5}
+
+
 def test_webp_c2pa_and_xmp_are_detected_and_removed(tmp_path: Path):
     data = _minimal_webp(
         (b"VP8X", b"\x04" + b"\x00" * 9),


### PR DESCRIPTION
## What

Make `clean_image`'s post-clean scan a **residual scan** instead of a full `inspect_image`. It keeps the stdlib inspector and the c2patool C2PA verifier (so `still_has_c2pa` / `still_has_ai_metadata` / `post_findings` are unchanged) but stops doing work whose result the clean path discards or recomputes:

- Skips the `exiftool` inspection subprocess whose output `clean_image` never reads (it only lands in `after.tools`), via a new `include_exiftool` toggle on `run_optional_tools` / `inspect_image`.
- Re-scores SynthID only when a pixel remover actually changed the image; a metadata-only clean reuses `synthid_before` (identical score, since SynthID scores pixels), saving a redundant model/HTTP call.
- Reads `dest` once instead of twice (`inspect_image` now accepts pre-read bytes).

No key in the clean result changes — this is strictly less work per clean.

## Why

Closes #260. Every image clean spawned an `exiftool` process whose output is discarded and (when a SynthID scorer is configured) made a redundant scorer call on pixels a metadata-only clean never touched — extra latency per clean, most
visible on the HTTP `/clean` path. The `still_has_c2pa` result depends on the c2patool probe, which is kept.

## Checklist

- [x] Behaviour matches `SKILL.md` / `references/removal-matrix.md` when relevant
      <!-- no behaviour change: same result keys/values, strictly less work -->
- [x] Unit tests updated or added under `tests/`
- [ ] `python3 -m pytest -q` passes <!-- pending: see note -->
- [x] Docs updated (README and/or skill references) if user-facing behaviour
      changes <!-- N/A: no user-facing behaviour change -->
- [x] No drive-by refactors unrelated to the fix or feature

## Notes for the reviewer

- **Layer:** Files (C2PA/metadata), image path only.
- **No output change:** every key in `clean_image`'s result is identical; the new regression test asserts the post-clean scan calls `run_optional_tools` with exiftool disabled and does not re-score SynthID for a metadata-only clean.
- The skipped exiftool is the **inspection dump** (`-G1 -a -s`, discarded); the legitimate `exiftool -all=` **stripping** pass earlier in `clean_image` is untouched.
- Scope is `clean_image` only. `clean_av` (re-read dedup) and `clean_container` (overlaps the PDF tool-gate) are deliberately left for separate changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image-cleaning verification to report SynthID results accurately after metadata-only or pixel changes.
  * Prevented unnecessary repeated image analysis during cleanup.
  * Ensured final residual scans use the appropriate inspection tools.

* **Tests**
  * Added regression coverage for metadata-only cleaning and optional tool execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->