### PR TITLE
feat(av): recognize the C2PA content-provenance uuid box on MP4/MOV/AVIF/HEIC

### DIFF
--- a/service/scripts/image_meta.py
+++ b/service/scripts/image_meta.py
@@ -506,6 +506,11 @@ def inspect_webp(data: bytes) -> tuple[bool, bool, list[str]]:
 
 XMP_UUID = b"\xbe\x7a\xcf\xcb\x97\xa9\x42\xe8\x9c\x71\x99\x94\x91\xe3\xaf\xac"
 
+# C2PA stores its manifest in BMFF containers (MP4/MOV/HEIF/AVIF) as a top-level
+# `uuid` box whose user type is this ContentProvenanceBox UUID -- not as a `c2pa`
+# box. c2pa-rs writes it this way for video and for AVIF/HEIC images.
+C2PA_BMFF_UUID = b"\xd8\xfe\xc3\xd6\x1b\x0e\x48\x3c\x92\x97\x58\x28\x87\x7e\xc4\x81"
+
 
 def _parse_isobmff_boxes(
     data: bytes, start: int = 0, end: int | None = None
@@ -555,6 +560,19 @@ def _isobmff_free_box(size: int, header_size: int = 8) -> bytes:
     return _build_isobmff_box(b"free", b"\x00" * (size - header_size), header_size)
 
 
+def _is_c2pa_bmff_prov_box(payload: bytes) -> bool:
+    """True when a `uuid` box is a C2PA content-provenance box.
+
+    The C2PA content-provenance UUID is the 16-byte user type that sits
+    immediately after the `uuid` fourcc. Some writers put a 4-byte FullBox
+    version/flags prefix before it, so accept the UUID at offset 0 or offset 4
+    of the payload. Recognizing it by UUID keeps detection and stripping
+    deterministic instead of depending on `c2pa`/`jumb` ASCII appearing in the
+    manifest payload.
+    """
+    return bool(payload) and C2PA_BMFF_UUID in payload[:20]
+
+
 def inspect_isobmff(data: bytes, fmt: str = "avif") -> tuple[bool, bool, list[str]]:
     findings: list[str] = []
     has_c2pa = False
@@ -592,6 +610,11 @@ def inspect_isobmff(data: bytes, fmt: str = "avif") -> tuple[bool, bool, list[st
                     h.lower() in ("c2pa", "contentcredentials", "jumb", "contentauth") for h in hits
                 ):
                     has_c2pa = True
+            elif _is_c2pa_bmff_prov_box(payload):
+                has_c2pa = True
+                findings.append(
+                    f"{fmt.upper()} uuid box (C2PA content-provenance manifest, user type d8fec3d6...)"
+                )
             else:
                 hits = _contains_any(payload, AI_META_HINTS + C2PA_MARKERS)
                 if hits:
@@ -616,6 +639,11 @@ def inspect_isobmff(data: bytes, fmt: str = "avif") -> tuple[bool, bool, list[st
                             findings.append(f"{fmt.upper()} meta XMP uuid box")
                         if any(h.lower() in ("c2pa", "contentcredentials", "jumb") for h in hits):
                             has_c2pa = True
+                    elif _is_c2pa_bmff_prov_box(s_payload):
+                        has_c2pa = True
+                        findings.append(
+                            f"{fmt.upper()} meta uuid box (C2PA content-provenance manifest)"
+                        )
                     else:
                         hits = _contains_any(s_payload, AI_META_HINTS + C2PA_MARKERS)
                         if hits:
@@ -633,6 +661,12 @@ def inspect_isobmff(data: bytes, fmt: str = "avif") -> tuple[bool, bool, list[st
     if whole and not has_c2pa:
         has_c2pa = True
         findings.append(f"byte-scan C2PA markers: {', '.join(whole[:6])}")
+    elif C2PA_BMFF_UUID in data and not has_c2pa:
+        # A C2PA content-provenance uuid box whose manifest bytes carry no
+        # ASCII 'c2pa'/'jumb' marker (e.g. an auxiliary "merkle" box, or a
+        # truncated manifest) is still a manifest box; catch it by user type.
+        has_c2pa = True
+        findings.append("byte-scan C2PA BMFF content-provenance user type")
 
     return has_c2pa, has_ai or has_c2pa, findings
 
@@ -2013,6 +2047,10 @@ def strip_isobmff(
                 actions.append(f"drop top-level {name} box (XMP metadata)")
                 out.extend(_isobmff_free_box(size, header_size))
                 continue
+            if _is_c2pa_bmff_prov_box(payload):
+                actions.append(f"drop top-level {name} box (C2PA content-provenance manifest)")
+                out.extend(_isobmff_free_box(size, header_size))
+                continue
             if strip_all_metadata or _contains_any(payload, AI_META_HINTS + C2PA_MARKERS):
                 actions.append(f"drop top-level {name} box (UUID metadata)")
                 out.extend(_isobmff_free_box(size, header_size))
@@ -2031,6 +2069,12 @@ def strip_isobmff(
                 if s_fourcc == b"uuid":
                     if s_payload.startswith(XMP_UUID):
                         actions.append(f"drop meta sub-box {s_name} (XMP metadata)")
+                        clean_sub.extend(_isobmff_free_box(s_size, s_hdr))
+                        continue
+                    if _is_c2pa_bmff_prov_box(s_payload):
+                        actions.append(
+                            f"drop meta sub-box {s_name} (C2PA content-provenance manifest)"
+                        )
                         clean_sub.extend(_isobmff_free_box(s_size, s_hdr))
                         continue
                     if strip_all_metadata or _contains_any(s_payload, AI_META_HINTS + C2PA_MARKERS):

--- a/service/scripts/image_meta.py
+++ b/service/scripts/image_meta.py
@@ -570,7 +570,24 @@ def _is_c2pa_bmff_prov_box(payload: bytes) -> bool:
     deterministic instead of depending on `c2pa`/`jumb` ASCII appearing in the
     manifest payload.
     """
-    return bool(payload) and C2PA_BMFF_UUID in payload[:20]
+    return payload[:16] == C2PA_BMFF_UUID or payload[4:20] == C2PA_BMFF_UUID
+
+
+def _contains_c2pa_prov_box(data: bytes) -> bool:
+    """True when *data* holds a BMFF `uuid` box with the C2PA user type.
+
+    Used only by the whole-file fallback in inspect_isobmff, when the box walk
+    cannot parse a header. Requiring the C2PA UUID to follow a `uuid` fourcc
+    (optionally after a 4-byte FullBox prefix) keeps a coincidental UUID byte
+    sequence inside `mdat` or another container from being reported as C2PA.
+    """
+    pos = 0
+    while (idx := data.find(b"uuid", pos)) != -1:
+        after = data[idx + 4 : idx + 24]
+        if after[:16] == C2PA_BMFF_UUID or after[4:20] == C2PA_BMFF_UUID:
+            return True
+        pos = idx + 4
+    return False
 
 
 def inspect_isobmff(data: bytes, fmt: str = "avif") -> tuple[bool, bool, list[str]]:
@@ -662,7 +679,7 @@ def inspect_isobmff(data: bytes, fmt: str = "avif") -> tuple[bool, bool, list[st
     if whole and not has_c2pa:
         has_c2pa = True
         findings.append(f"byte-scan C2PA markers: {', '.join(whole[:6])}")
-    elif C2PA_BMFF_UUID in data and not has_c2pa:
+    elif _contains_c2pa_prov_box(data) and not has_c2pa:
         # A C2PA content-provenance uuid box whose manifest bytes carry no
         # ASCII 'c2pa'/'jumb' marker (e.g. an auxiliary "merkle" box, or a
         # truncated manifest) is still a manifest box; catch it by user type.

--- a/service/scripts/image_meta.py
+++ b/service/scripts/image_meta.py
@@ -613,7 +613,8 @@ def inspect_isobmff(data: bytes, fmt: str = "avif") -> tuple[bool, bool, list[st
             elif _is_c2pa_bmff_prov_box(payload):
                 has_c2pa = True
                 findings.append(
-                    f"{fmt.upper()} uuid box (C2PA content-provenance manifest, user type d8fec3d6...)"
+                    f"{fmt.upper()} uuid box "
+                    "(C2PA content-provenance manifest, user type d8fec3d6...)"
                 )
             else:
                 hits = _contains_any(payload, AI_META_HINTS + C2PA_MARKERS)

--- a/skills/remove-ai-marks/references/removal-matrix.md
+++ b/skills/remove-ai-marks/references/removal-matrix.md
@@ -6,6 +6,7 @@
 | Stylometric AI cadence / burstiness / n-grams (zero-LLM) | Statistical variance & cadence scoring | `score_stylometry.py`, `inspect_text.py --stylometry`, `audit_dir.py --check-stylometry` | None (detection only) | Yes (calibrated score + phrase spans) |
 | Statistical text watermark (SynthID-class / Kirchenbauer) | Multi-pass paraphrase / humanize / back-translate / structural | Agent Layer B + optional `rewrite_text.py` | Meaning/style drift | No without vendor key/detector; **MarkLLM harness** (`detect_text_watermark.py`) verifies a specific scheme config before/after |
 | C2PA on PNG/JPEG/WebP/AVIF/HEIC | Drop APP11 / PNG `caBX` / RIFF `C2PA` / ISOBMFF `jumb` & `uuid` / exiftool | `clean_image.py` | Loses provenance metadata | Yes |
+| C2PA on WAV/MP3/MP4/MOV (ISOBMFF `jumb`/`c2pa`/`uuid` incl. the C2PA content-provenance `uuid` box, RIFF `C2PA`, ID3v2) | Drop the C2PA box/chunk/frame (offset-preserving `free` box in ISOBMFF) | `av_meta.py` (`clean_av`) | Loses provenance metadata | Yes (re-inspect) |
 | GIF comment/XMP extensions | Drop 0xFE / XMP application extensions (keep `NETSCAPE2.0`) | `clean_image.py` | Loses GIF comments/XMP | Yes (re-inspect) |
 | TIFF XMP/EXIF/GPS/IPTC/MakerNote (classic + BigTIFF) | Drop IFD tags, zero payloads, keep strip offsets | `clean_image.py` | Loses TIFF metadata | Yes (re-inspect) |
 | BMP trailing metadata | Truncate non-image trailing bytes, fix file-size field | `clean_image.py` | Removes appended metadata | Yes (re-inspect) |

--- a/tests/test_av_meta.py
+++ b/tests/test_av_meta.py
@@ -15,6 +15,7 @@ from av_meta import (
     detect_av_format,
     inspect_av,
 )
+from image_meta import _contains_c2pa_prov_box
 
 # ---------------------------------------------------------------------------
 # Fixture builders
@@ -570,6 +571,49 @@ def test_mp4_c2pa_merkle_aux_box_detected_by_user_type(tmp_path):
     report = inspect_av(src)
     assert report.has_c2pa is True
     assert any("content-provenance" in f for f in report.findings)
+
+
+def test_mp4_uuid_box_with_c2pa_bytes_at_invalid_offset_not_treated_as_manifest(tmp_path):
+    # A non-C2PA uuid box whose payload happens to hold the C2PA UUID at an
+    # invalid offset (1) must not be classified as a C2PA manifest box, and must
+    # survive a keep-mode clean (the old `uuid in payload[:20]` matched here).
+    bad_box = _isobmff_box(b"uuid", b"\x00" + C2PA_BMFF_UUID + b"not-a-manifest")
+    data = _mp4(bad_box, _isobmff_box(b"mdat", b"\x00" * 16))
+    src = tmp_path / "clip.mp4"
+    src.write_bytes(data)
+
+    report = inspect_av(src)
+    assert report.has_c2pa is False
+
+    dest = tmp_path / "clip.cleaned.mp4"
+    result = clean_av(src, dest, strip_all_metadata=False)
+    assert C2PA_BMFF_UUID in dest.read_bytes()  # preserved in keep-mode
+    assert not any("content-provenance" in a for a in result["actions"])
+
+
+def test_mp4_c2pa_manifest_uuid_at_offset_4_still_detected(tmp_path):
+    # Accept the defensive FullBox layout (version/flags before the user type):
+    # the UUID is at payload offset 4 and must still be recognized.
+    data = _mp4(
+        _isobmff_box(b"uuid", b"\x00\x00\x00\x00" + C2PA_BMFF_UUID + b"manifest\x00" + b"data"),
+        _isobmff_box(b"mdat", b"\x00" * 16),
+    )
+    src = tmp_path / "clip.mp4"
+    src.write_bytes(data)
+
+    report = inspect_av(src)
+    assert report.has_c2pa is True
+
+    dest = tmp_path / "clip.cleaned.mp4"
+    result = clean_av(src, dest, strip_all_metadata=False)
+    assert result["still_has_c2pa"] is False
+
+
+def test_c2pa_prov_box_scan_requires_uuid_fourcc():
+    # The whole-file fallback must only report C2PA when the UUID follows a
+    # `uuid` fourcc, not for a UUID-like byte sequence elsewhere (e.g. in mdat).
+    assert _contains_c2pa_prov_box(b"\x00" * 8 + b"uuid" + C2PA_BMFF_UUID + b"rest") is True
+    assert _contains_c2pa_prov_box(b"\x00" * 10 + C2PA_BMFF_UUID + b"\x00" * 10) is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_av_meta.py
+++ b/tests/test_av_meta.py
@@ -41,6 +41,8 @@ def _moov_with_udta(udta_payload: bytes) -> bytes:
 
 
 XMP_UUID_HEX = bytes.fromhex("be7acfcb97a942e89c71999491e3afac")
+# C2PA ContentProvenanceBox user type for BMFF containers (MP4/MOV/HEIF/AVIF).
+C2PA_BMFF_UUID = bytes.fromhex("d8fec3d61b0e483c92975828877ec481")
 
 
 def _mp4_with_xmp(xmp_text: bytes) -> bytes:
@@ -55,6 +57,14 @@ def _mp4_with_udta_tag(tag_text: bytes) -> bytes:
     )
     mdat = _isobmff_box(b"mdat", b"\x00" * 16)
     return _mp4(moov, mdat)
+
+
+def _mp4_with_c2pa_manifest(purpose: bytes = b"manifest", data: bytes | None = None) -> bytes:
+    if data is None:
+        data = b"c2pa" + b"\x00" * 8 + b"jumb" + b"\x00" * 4  # fake JUMBF-ish store
+    c2pa_box = _isobmff_box(b"uuid", C2PA_BMFF_UUID + purpose + b"\x00" + data)
+    mdat = _isobmff_box(b"mdat", b"\x00" * 16)
+    return _mp4(c2pa_box, mdat)
 
 
 def _riff_chunk(cid: bytes, payload: bytes) -> bytes:
@@ -479,6 +489,87 @@ def test_mp4_clean_file_is_idempotent_when_already_clean(tmp_path):
     result = clean_av(src, dest, strip_all_metadata=True)
     assert result["still_has_ai_metadata"] is False
     assert result["still_has_c2pa"] is False
+
+
+def test_mp4_c2pa_manifest_uuid_detected_and_stripped(tmp_path):
+    data = _mp4_with_c2pa_manifest()
+    src = tmp_path / "clip.mp4"
+    src.write_bytes(data)
+
+    report = inspect_av(src)
+    assert report.format == "mp4"
+    assert report.has_c2pa is True
+    assert report.has_ai_metadata is True
+    assert any("content-provenance" in f for f in report.findings)
+
+    dest = tmp_path / "clip.cleaned.mp4"
+    result = clean_av(src, dest, strip_all_metadata=True)
+    cleaned = dest.read_bytes()
+    assert result["still_has_c2pa"] is False
+    assert C2PA_BMFF_UUID not in cleaned
+    assert any("content-provenance" in a for a in result["actions"])
+
+
+def test_mp4_c2pa_manifest_stripped_in_keep_mode_by_user_type(tmp_path):
+    # Manifest data with NO ASCII 'c2pa'/'jumb' marker: the old substring scan
+    # would miss it in keep-mode, so this proves the C2PA user type alone now
+    # drives detection and removal.
+    data = _mp4_with_c2pa_manifest(data=bytes(range(1, 64)))
+    src = tmp_path / "clip.mp4"
+    src.write_bytes(data)
+
+    report = inspect_av(src)
+    assert report.has_c2pa is True
+
+    dest = tmp_path / "clip.cleaned.mp4"
+    result = clean_av(src, dest, strip_all_metadata=False)
+    assert result["still_has_c2pa"] is False
+    assert C2PA_BMFF_UUID not in dest.read_bytes()
+    assert any("content-provenance" in a for a in result["actions"])
+
+
+def test_mp4_c2pa_manifest_preserves_mdat_offset(tmp_path):
+    data = _mp4_with_c2pa_manifest()
+    src = tmp_path / "clip.mp4"
+    src.write_bytes(data)
+    dest = tmp_path / "clip.cleaned.mp4"
+
+    clean_av(src, dest, strip_all_metadata=True)
+
+    cleaned = dest.read_bytes()
+    assert cleaned.index(b"mdat") == data.index(b"mdat")
+    assert C2PA_BMFF_UUID not in cleaned
+    assert b"free" in cleaned  # replaced with an equal-size free box, offsets intact
+
+
+def test_mp4_c2pa_update_manifest_appended_stripped(tmp_path):
+    # Update manifests are appended as the last box with box_purpose "update".
+    data = _mp4(
+        _isobmff_box(b"mdat", b"\x00" * 16),
+        _isobmff_box(b"uuid", C2PA_BMFF_UUID + b"update\x00" + bytes(range(1, 32))),
+    )
+    src = tmp_path / "clip.mp4"
+    src.write_bytes(data)
+
+    report = inspect_av(src)
+    assert report.has_c2pa is True
+
+    dest = tmp_path / "clip.cleaned.mp4"
+    result = clean_av(src, dest, strip_all_metadata=False)
+    assert result["still_has_c2pa"] is False
+    assert C2PA_BMFF_UUID not in dest.read_bytes()
+
+
+def test_mp4_c2pa_merkle_aux_box_detected_by_user_type(tmp_path):
+    # A "merkle" auxiliary box holds only binary Merkle data (no ASCII marker),
+    # so recognition must come from the C2PA user type, not a substring scan.
+    data = _mp4_with_c2pa_manifest(purpose=b"merkle", data=bytes(range(1, 128)))
+    src = tmp_path / "clip.mp4"
+    src.write_bytes(data)
+
+    report = inspect_av(src)
+    assert report.has_c2pa is True
+    assert any("content-provenance" in f for f in report.findings)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Hardens C2PA manifest removal for audio/video containers. `av_meta.py` already strips C2PA from MP4/MOV, WAV, MP3, and FLAC, but for BMFF containers it only special-cased XMP's `uuid` user type and otherwise relied on a substring scan for ASCII `c2pa`/`jumb` inside the manifest payload.

The C2PA spec (and `c2pa-rs`, which provcheck uses) stores the manifest in MP4/MOV/HEIF/AVIF as a **top-level `uuid` box whose user type is the ContentProvenanceBox UUID `d8fec3d6-1b0e-483c-9297-5828877ec481`** — not as a `c2pa` box. That means a C2PA `manifest`/`update`/`merkle` box whose payload carries no ASCII `c2pa`/`jumb` marker was detected only by luck (in strip-all mode) and missed entirely in keep-non-ai-metadata mode.

## Change

- Add `C2PA_BMFF_UUID` and a `_is_c2pa_bmff_prov_box()` helper in `service/scripts/image_meta.py`.
- Detect and strip the C2PA `uuid` box explicitly in both `inspect_isobmff` and `strip_isobmff` (top-level and `meta` sub-box), correctly labelled and deterministic in both strip-all and keep modes. The offset-preserving `free`-box replacement is unchanged, so `mdat`/`moov` offsets stay valid.
- Include the C2PA user type in the truncated-file byte-scan fallback.
- Add spec-accurate tests in `tests/test_av_meta.py` (manifest detect+strip, keep-mode by user type, `mdat` offset preservation, `update` appended box, `merkle` auxiliary box).
- Note the AV C2PA row in the removal matrix (previously listed only image containers).

## Verification

- Targeted AV/ISOBMFF/image tests — pass.
- `.venv/bin/python -m pytest -q` (full suite) — pass (only expected skips).
- `ruff check service/scripts/image_meta.py tests/test_av_meta.py` — clean.

## Scope note

This does not add new AV-format support — it makes the existing AV C2PA handling correct and deterministic for the exact container `c2pa-rs`/provcheck write. Neural audio/video watermarks (silentcipher/AudioSeal/WavMark/TrustMark) remain out of scope, as documented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detection of C2PA content-provenance metadata in AVIF, HEIC, MP4, and MOV files.
  * Recognizes standard, nested, binary-only, update, and Merkle-based provenance manifests.

* **Bug Fixes**
  * Improved fallback detection when readable C2PA markers are absent.
  * Expanded C2PA metadata removal across supported audio and video containers while preserving file structure, offsets, content data, and file size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->