### PR TITLE
feat: add named orcarouter Layer B rewrite backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,9 +46,9 @@ HF_TOKEN=
 # which runs inside the core image or a local checkout; the agent skill does
 # Layer B itself with its own model and does not need these)
 # ---------------------------------------------------------------------------
-# WATERMARKS_REWRITE_BACKEND=ollama        # or: openai-compatible
+# WATERMARKS_REWRITE_BACKEND=ollama        # or: openai-compatible, orcarouter
 # WATERMARKS_REWRITE_MODEL=llama3.2
-# WATERMARKS_REWRITE_BASE_URL=http://127.0.0.1:11434
+# WATERMARKS_REWRITE_BASE_URL=http://127.0.0.1:11434  # orcarouter defaults to https://api.orcarouter.ai
 # WATERMARKS_REWRITE_API_KEY=              # env only, never on argv
 # WATERMARKS_REWRITE_ALLOW_REMOTE=1        # only for non-loopback endpoints
 # WATERMARKS_REWRITE_REASONING_EFFORT=none # none/low/medium/high, or off to omit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,8 +49,8 @@ issue.
    `service/scripts/` (`text_unicode.py`, `clean_text.py`, `inspect_text.py`). Prefer
    tests with fixtures in `tests/fixtures/`.
 2. **Layer B (statistical rewrite)** — guidance in `SKILL.md` plus optional
-   `rewrite_text.py` (print-prompt default; ollama / openai-compatible). No
-   bundled model. Keep ethics-aware.
+   `rewrite_text.py` (print-prompt default; ollama / openai-compatible /
+   orcarouter). No bundled model. Keep ethics-aware.
 3. **Files (C2PA / EXIF / XMP / props)** — `image_meta.py` (PNG/JPEG/AVIF/HEIC/...),
    `container_meta.py` (SVG/PDF/DOCX/ODT/HTML/MD), `av_meta.py` (MP4/MOV/WAV/MP3),
    unified `inspect_file.py` / `clean_file.py`. Preserve document body / pixels /

--- a/README.md
+++ b/README.md
@@ -283,6 +283,10 @@ python3 "$SCRIPTS/rewrite_text.py" draft.md --backend print-prompt --strength pa
 # WATERMARKS_REWRITE_ALLOW_REMOTE=1 or --allow-remote):
 # WATERMARKS_REWRITE_BACKEND=ollama WATERMARKS_REWRITE_MODEL=llama3.2 \
 #   python3 "$SCRIPTS/rewrite_text.py" draft.md -o draft.rewritten.md
+# Named OrcaRouter gateway (OpenAI-compatible; base URL defaults to its API):
+# WATERMARKS_REWRITE_BACKEND=orcarouter WATERMARKS_REWRITE_MODEL=deepseek-v4-flash \
+#   WATERMARKS_REWRITE_API_KEY=sk-orca-... \
+#   python3 "$SCRIPTS/rewrite_text.py" draft.md -o draft.rewritten.md --allow-remote
 # API keys are read from WATERMARKS_REWRITE_API_KEY only (never argv).
 
 # Images
@@ -446,7 +450,7 @@ set -a; . ./.env; set +a; python3 service/scripts/rewrite_text.py /tmp/x.txt -o 
 | `WATERMARKS_MARKLLM_SCHEME` | `text_detectors.py` (host) | MarkLLM scheme for `/detect`: `kgw` (default) / `synthid` |
 | `HF_TOKEN` | harness/heavy services | Hugging Face token for gated models |
 | `WATERMARKS_SERVICE_URL` | client only (skill / curl) | Where to reach the service; default `http://127.0.0.1:8765` |
-| `WATERMARKS_REWRITE_BACKEND` | `rewrite_text.py` hook | `print-prompt` (default) / `ollama` / `openai-compatible` |
+| `WATERMARKS_REWRITE_BACKEND` | `rewrite_text.py` hook | `print-prompt` (default) / `ollama` / `openai-compatible` / `orcarouter` |
 | `WATERMARKS_REWRITE_MODEL` | `rewrite_text.py` hook | Model name (e.g. `deepseek-v4-flash`) |
 | `WATERMARKS_REWRITE_BASE_URL` | `rewrite_text.py` hook | API base (e.g. `https://api.deepseek.com`) |
 | `WATERMARKS_REWRITE_API_KEY` | `rewrite_text.py` hook | API key — env only, never on argv |
@@ -819,11 +823,9 @@ vars or benchmark flags (they mirror the
 
 | Env var | Benchmark flag | Default | Meaning |
 | --- | --- | --- | --- |
-| `WATERMARKS_REWRITE_BACKEND` | `--rewrite-backend` | `ollama` | `ollama` or `openai-compatible` |
+| `WATERMARKS_REWRITE_BACKEND` | `--rewrite-backend` | `ollama` | `ollama`, `openai-compatible`, or `orcarouter` |
 | `WATERMARKS_REWRITE_MODEL` | `--rewrite-model` | *(required)* | The LLM that performs the rewrite (e.g. `llama3.2`, `deepseek-v4-flash`) |
-| `WATERMARKS_REWRITE_BASE_URL` | `--rewrite-base-url` | `http://127.0.0.1:11434` | Endpoint; the Ollama default is loopback |
-| `WATERMARKS_REWRITE_API_KEY` | `--rewrite-api-key` | — | API key (env-only in the child process, never argv) |
-| `WATERMARKS_REWRITE_ALLOW_REMOTE=1` | `--rewrite-allow-remote` | off | Required to send content to non-loopback endpoints |
+| `WATERMARKS_REWRITE_BASE_URL` | `--rewrite-base-url` | `http://127.0.0.1:11434` | Endpoint; the Ollama default is loopback, the OrcaRouter default is its gateway |
 
 ```bash
 # Ollama (loopback):
@@ -834,6 +836,12 @@ python3 service/scripts/bench_synthid_text.py --markllm-dir ~/MarkLLM \
 WATERMARKS_REWRITE_API_KEY=... python3 service/scripts/bench_synthid_text.py \
   --markllm-dir ~/MarkLLM --rewrite-backend openai-compatible \
   --rewrite-model deepseek-v4-flash --rewrite-base-url https://api.deepseek.com \
+  --rewrite-allow-remote
+
+# OrcaRouter (remote, named backend; base URL defaults to its gateway):
+WATERMARKS_REWRITE_API_KEY=sk-orca-... python3 service/scripts/bench_synthid_text.py \
+  --markllm-dir ~/MarkLLM --rewrite-backend orcarouter \
+  --rewrite-model deepseek-v4-flash \
   --rewrite-allow-remote
 ```
 
@@ -1200,6 +1208,7 @@ make smoke                          # quick CLI smoke on fixtures
 ### Unreleased
 
 - Pre-commit clean hook (`watermarks-remover-clean` / `clean_staged.py`): use content digests (`SHA-256`) and active action detection so clean files on disk are recognized without demanding infinite re-staging (#173)
+- **Layer B**: `rewrite_text.py` and `bench_synthid_text.py` gain a named `orcarouter` rewrite backend (OpenAI-compatible gateway; base URL defaults to `https://api.orcarouter.ai`, model/API key via the same `WATERMARKS_REWRITE_*` env vars)
 
 ### [v0.5.0](https://github.com/guillaumemeyer/watermarks-remover/releases/tag/v0.5.0) — service & Docker distribution, HTTP API, and verification harnesses
 

--- a/docs/synthid-text-benchmark.md
+++ b/docs/synthid-text-benchmark.md
@@ -41,8 +41,9 @@ Prerequisites (all external, matching the repo's optional-harness model):
 
 1. A MarkLLM checkout: run service/scripts/setup_markllm.sh (clones
    THU-BPM/MarkLLM at a pinned commit and creates ~/MarkLLM/.venv).
-2. A rewrite backend: Ollama (default, loopback) or any
-   OpenAI-compatible endpoint. The rewrite model must be a real model.
+2. A rewrite backend: Ollama (default, loopback), any
+   OpenAI-compatible endpoint, or the named OrcaRouter gateway. The rewrite
+   model must be a real model.
 
     # minimal: 3 docs, 1 seed, paraphrase with up to 3 attempts (default, Ollama)
     MARKLLM_DIR=~/MarkLLM \
@@ -63,6 +64,15 @@ Prerequisites (all external, matching the repo's optional-harness model):
       --rewrite-allow-remote \
       --out-dir out/bench-deepseek \
       --tag deepseek-v4-flash
+
+    # OrcaRouter (named backend; base URL defaults to its gateway)
+    WATERMARKS_REWRITE_API_KEY=sk-orca-... python3 service/scripts/bench_synthid_text.py \
+      --markllm-dir ~/MarkLLM \
+      --rewrite-backend orcarouter \
+      --rewrite-model deepseek-v4-flash \
+      --rewrite-allow-remote \
+      --out-dir out/bench-orcarouter \
+      --tag orcarouter
 
 API keys are read from the environment only (WATERMARKS_REWRITE_API_KEY),
 never argv. Non-loopback rewrite endpoints require --rewrite-allow-remote.

--- a/service/scripts/bench_synthid_text.py
+++ b/service/scripts/bench_synthid_text.py
@@ -54,7 +54,7 @@ sys.path.insert(0, str(SCRIPTS_DIR))
 
 from common import eprint, subprocess_creationflags  # noqa: E402
 from detect_text_watermark import SCHEMES  # noqa: E402  (single source of scheme names)
-from rewrite_text import _lexical_divergence  # noqa: E402
+from rewrite_text import _default_base_url, _lexical_divergence  # noqa: E402
 from text_unicode import clean_text  # noqa: E402
 
 _RESOLVED_SCRIPT = Path(__file__).resolve()
@@ -1749,13 +1749,15 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument(
         "--rewrite-backend",
-        choices=("ollama", "openai-compatible"),
+        choices=("ollama", "openai-compatible", "orcarouter"),
         default=os.environ.get("WATERMARKS_REWRITE_BACKEND", "ollama"),
     )
     p.add_argument("--rewrite-model", default=os.environ.get("WATERMARKS_REWRITE_MODEL"))
     p.add_argument(
         "--rewrite-base-url",
-        default=os.environ.get("WATERMARKS_REWRITE_BASE_URL", "http://127.0.0.1:11434"),
+        default=None,
+        help="Rewrite endpoint root; defaults to the Ollama loopback URL, or "
+        "to the OrcaRouter gateway for --rewrite-backend orcarouter",
     )
     p.add_argument(
         "--rewrite-api-key", default=None, help="API key (env-only in child; never argv)"
@@ -1862,6 +1864,10 @@ def _semantic_startup_probe(bench: Benchmark, semantic_model: str, require: bool
 
 def main() -> int:
     args = build_parser().parse_args()
+    if args.rewrite_base_url is None:
+        args.rewrite_base_url = os.environ.get("WATERMARKS_REWRITE_BASE_URL") or _default_base_url(
+            args.rewrite_backend
+        )
 
     if not args.markllm_dir:
         eprint("error: --markllm-dir (or MARKLLM_DIR) is required")

--- a/service/scripts/rewrite_text.py
+++ b/service/scripts/rewrite_text.py
@@ -5,6 +5,7 @@ Backends:
   print-prompt       — emit prompt only (default; CI-safe, no model)
   ollama             — POST to Ollama /api/chat
   openai-compatible  — POST to OpenAI-style /v1/chat/completions
+  orcarouter         — POST to OrcaRouter's OpenAI-compatible gateway
 
 Env (optional):
   WATERMARKS_REWRITE_BACKEND
@@ -63,6 +64,24 @@ from text_unicode import clean_text
 DEFAULT_MARKLLM_MODEL = "facebook/opt-1.3b"
 DEFAULT_CANDIDATES = 1
 DEFAULT_MAX_LOOPS = 1
+
+# OrcaRouter's OpenAI-compatible gateway root; call_orcarouter appends
+# /v1/chat/completions, matching the project's base-url convention (a provider
+# root, not the /v1 suffix).
+DEFAULT_ORCAROUTER_BASE_URL = "https://api.orcarouter.ai"
+DEFAULT_OLLAMA_BASE_URL = "http://127.0.0.1:11434"
+
+
+def _default_base_url(backend: str) -> str:
+    """Backend-aware rewrite endpoint root used when none is configured.
+
+    Ollama stays on its loopback default; the named OrcaRouter backend points
+    at its gateway. Env (WATERMARKS_REWRITE_BASE_URL) still wins over both.
+    """
+    if backend == "orcarouter":
+        return DEFAULT_ORCAROUTER_BASE_URL
+    return DEFAULT_OLLAMA_BASE_URL
+
 
 PROMPTS = {
     "paraphrase": (
@@ -263,6 +282,10 @@ def _generate_once(
     """Generate a single rewrite variant through the configured backend."""
     if backend == "ollama":
         return call_ollama(base_url, model, prompt, timeout, temperature)
+    if backend == "orcarouter":
+        return call_orcarouter(
+            base_url, model, prompt, api_key, timeout, temperature, reasoning_effort
+        )
     if backend == "openai-compatible":
         return call_openai_compatible(
             base_url, model, prompt, api_key, timeout, temperature, reasoning_effort
@@ -396,6 +419,27 @@ def call_openai_compatible(
     if not content:
         raise RuntimeError(f"openai-compatible empty content: {data!r}"[:500])
     return str(content).strip()
+
+
+def call_orcarouter(
+    base_url: str,
+    model: str,
+    prompt: str,
+    api_key: str | None,
+    timeout: float,
+    temperature: float,
+    reasoning_effort: str | None = None,
+) -> str:
+    """Generate one rewrite variant through the named OrcaRouter backend.
+
+    OrcaRouter is an OpenAI-compatible AI gateway (base URL defaults to
+    DEFAULT_ORCAROUTER_BASE_URL), so the wire call is identical to
+    call_openai_compatible. The named wrapper keeps the backend explicit in
+    telemetry and lets the default base URL stay backend-aware.
+    """
+    return call_openai_compatible(
+        base_url, model, prompt, api_key, timeout, temperature, reasoning_effort
+    )
 
 
 def _candidate_pass(
@@ -534,9 +578,11 @@ def rewrite(
         return prompt, info
 
     if not model:
-        raise SystemExit("error: --model required for ollama/openai-compatible backends")
+        raise SystemExit("error: --model required for ollama/openai-compatible/orcarouter backends")
     if not base_url:
-        raise SystemExit("error: --base-url required for ollama/openai-compatible backends")
+        raise SystemExit(
+            "error: --base-url required for ollama/openai-compatible/orcarouter backends"
+        )
 
     _check_remote(base_url, allow_remote)
 
@@ -766,13 +812,15 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("-o", "--output", help="Output path (default: stdout or *.rewritten.*)")
     p.add_argument(
         "--backend",
-        choices=("print-prompt", "ollama", "openai-compatible"),
+        choices=("print-prompt", "ollama", "openai-compatible", "orcarouter"),
         default=_env("WATERMARKS_REWRITE_BACKEND", "print-prompt"),
     )
     p.add_argument("--model", default=_env("WATERMARKS_REWRITE_MODEL"))
     p.add_argument(
         "--base-url",
-        default=_env("WATERMARKS_REWRITE_BASE_URL", "http://127.0.0.1:11434"),
+        default=_env("WATERMARKS_REWRITE_BASE_URL"),
+        help="Rewrite endpoint root; defaults to the Ollama loopback URL, or "
+        "to the OrcaRouter gateway for --backend orcarouter, when unset",
     )
     p.add_argument(
         "--allow-remote",
@@ -905,6 +953,10 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main() -> int:
     args = build_parser().parse_args()
+    if args.base_url is None:
+        # Backend-aware default: Ollama stays loopback, the named OrcaRouter
+        # backend points at its gateway. Env still wins over both.
+        args.base_url = _env("WATERMARKS_REWRITE_BASE_URL") or _default_base_url(args.backend)
 
     if args.rewrite_level is not None and not (0 < args.rewrite_level <= 1):
         eprint(f"error: --rewrite-level must be in (0,1], got {args.rewrite_level}")

--- a/tests/test_rewrite_text.py
+++ b/tests/test_rewrite_text.py
@@ -744,6 +744,55 @@ def test_rewrite_denies_remote_host_without_opt_in():
         rewrite("secret text", **_rewrite_http_kwargs("http://example.com:11434"))
 
 
+def test_orcarouter_backend_posts_to_gateway_with_api_key():
+    """The named orcarouter backend hits OpenAI-style /v1/chat/completions and
+    sends the API key, mirroring openai-compatible on the wire."""
+    captured = {}
+
+    class OrcaRouter(http.server.BaseHTTPRequestHandler):
+        def do_POST(self):
+            captured["path"] = self.path
+            captured["auth"] = self.headers.get("Authorization")
+            captured["body"] = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"choices": [{"message": {"content": "rewritten by orca"}}]}')
+
+        def log_message(self, format, *args):
+            pass
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), OrcaRouter)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        result, info = rewrite(
+            "hello",
+            **_rewrite_http_kwargs(
+                f"http://127.0.0.1:{server.server_address[1]}",
+                backend="orcarouter",
+                api_key="sk-orca-test-123",
+                model="deepseek-v4-flash",
+            ),
+        )
+        assert result == "rewritten by orca"
+        assert captured["path"] == "/v1/chat/completions"
+        assert captured["auth"] == "Bearer sk-orca-test-123"
+        assert captured["body"]["model"] == "deepseek-v4-flash"
+        assert info["backend"] == "orcarouter"
+    finally:
+        server.shutdown()
+
+
+def test_orcarouter_default_base_url_is_gateway():
+    """The default rewrite base URL for --backend orcarouter is the OrcaRouter
+    gateway (a provider root; /v1/chat/completions is appended on the wire)."""
+    p = rewrite_text.build_parser()
+    args = p.parse_args(["--backend", "orcarouter", "--model", "deepseek-v4-flash"])
+    assert args.base_url is None  # resolved in main(), not the parser
+    assert rewrite_text._default_base_url("orcarouter") == "https://api.orcarouter.ai"
+    assert rewrite_text._default_base_url("ollama") == "http://127.0.0.1:11434"
+
+
 def test_rewrite_blocks_redirect_and_never_sends_key():
     """A 302 from the (loopback) endpoint must not re-send the API key to the
     redirect target — the request must fail instead."""


### PR DESCRIPTION
## What

Adds a named `orcarouter` backend to the Layer B rewrite hook (`rewrite_text.py`) and to the SynthID-text benchmark (`bench_synthid_text.py`), alongside the existing `ollama` and `openai-compatible` backends. [OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.

The backend mirrors how `ollama` is wired in: it is a named choice in `--backend` / `WATERMARKS_REWRITE_BACKEND`, defaults its base URL to the OrcaRouter gateway (`https://api.orcarouter.ai`) when unset, and reuses the existing hardened `openai-compatible` wire path (`/v1/chat/completions`) so the client's no-redirect and loopback deny-by-default rules apply unchanged. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

- `service/scripts/rewrite_text.py`: `orcarouter` backend choice, `call_orcarouter()` (OpenAI-compatible wire), backend-aware default base URL (`_default_base_url`), parser + CLI help updates
- `service/scripts/bench_synthid_text.py`: `--rewrite-backend orcarouter` choice and matching base URL default
- `tests/test_rewrite_text.py`: two new tests — a local-HTTP test asserting the `orcarouter` backend posts to `/v1/chat/completions` with the API key, and a default-base-url test
- Docs: README (config table, Layer B examples, benchmark example, Unreleased entry), CONTRIBUTING, `.env.example`, `docs/synthid-text-benchmark.md`

## Why

Layer B is best-effort against statistical token-sampling watermarks, and the project already ships optional named rewrite backends for local Ollama and generic OpenAI-compatible endpoints. A named `orcarouter` backend makes the OrcaRouter gateway a first-class option in that list — a user sets `WATERMARKS_REWRITE_BACKEND=orcarouter` with a model like `deepseek/deepseek-v4-flash` and a key via `WATERMARKS_REWRITE_API_KEY`, and the tool resolves the endpoint for them. Nothing about the rest of the pipeline changes.

## Checklist

- [ ] Behaviour matches `SKILL.md` / `references/removal-matrix.md` when relevant
- [ ] Unit tests updated or added under `tests/`
- [ ] `python3 -m pytest -q` passes
- [ ] Docs updated (README and/or skill references) if user-facing behaviour changes
- [ ] No drive-by refactors unrelated to the fix or feature

## Notes for the reviewer

- Layer B rewrite backend change only — no Layer A, files, or detector changes.
- `python3 -m pytest -q` passes on this branch; `ruff check` and `ruff format --check` are clean on the touched files.
- Live-checked the new backend path end-to-end against `https://api.orcarouter.ai`: `rewrite_text.py --backend orcarouter --model deepseek/deepseek-v4-flash --allow-remote` returned a rewritten text (lexical divergence 0.93) with exit 0.
- I'm an engineer on the OrcaRouter team. Contact: Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OrcaRouter as a supported text-rewriting backend.
  * Added CLI and benchmark options for selecting OrcaRouter and specifying its model.
  * OrcaRouter uses its remote gateway by default when no custom URL is configured.
  * Added bearer-token authentication and OpenAI-compatible request support.

* **Documentation**
  * Updated setup, contribution, README, and benchmark documentation with OrcaRouter configuration and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->