### PR TITLE
fix(service): report ffmpeg as usable and install ghostscript

### DIFF
--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update \
         ca-certificates \
         curl \
         ffmpeg \
+        ghostscript \
         libarchive-zip-perl \
         libimage-exiftool-perl \
         passwd \

--- a/service/scripts/server.py
+++ b/service/scripts/server.py
@@ -132,7 +132,13 @@ def _json_ok(payload: dict[str, Any]) -> bytes:
 
 # Flag that makes each tool print its version and exit 0. They disagree:
 # exiftool treats `--version` as an unknown option and prints usage instead.
-_VERSION_FLAG = {"c2patool": "--version", "exiftool": "-ver", "qpdf": "--version"}
+_VERSION_FLAG = {
+    "c2patool": "--version",
+    "exiftool": "-ver",
+    "qpdf": "--version",
+    # ffmpeg has no --version; it exits 8 and the probe read that as unusable.
+    "ffmpeg": "-version",
+}
 
 
 @cache

--- a/tests/test_capabilities_tooling.py
+++ b/tests/test_capabilities_tooling.py
@@ -41,3 +41,6 @@ def test_core_image_installs_every_advertised_tool():
     dockerfile = (ROOT / "service" / "Dockerfile").read_text(encoding="utf-8")
     for pkg in ("ffmpeg", "ghostscript", "qpdf", "libimage-exiftool-perl"):
         assert pkg in dockerfile, f"{pkg} is advertised by /capabilities but not installed"
+    # c2patool is not an apt package: it is fetched and installed separately, so
+    # the loop above would keep passing if that step disappeared.
+    assert "/usr/local/bin/c2patool" in dockerfile

--- a/tests/test_capabilities_tooling.py
+++ b/tests/test_capabilities_tooling.py
@@ -1,0 +1,43 @@
+"""/capabilities must not report a tool as missing when the image ships it.
+
+Two separate defects, both making the report disagree with the container:
+
+* ``_tool_usable()`` probes with ``--version`` unless ``_VERSION_FLAG`` says
+  otherwise. ffmpeg has no ``--version``; it exits 8. So an image that installs
+  ffmpeg advertised ``"ffmpeg": false``.
+* the core Dockerfile never installed ghostscript, although ``/capabilities``
+  advertises it and ``_ghostscript_usable()`` probes for it.
+
+A capability report is what a caller reads before deciding a job is impossible,
+so a false negative there reads as a clean verdict about a tool nobody ran.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "service" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import server
+
+
+def test_ffmpeg_version_flag_is_declared():
+    assert server._VERSION_FLAG.get("ffmpeg") == "-version"
+
+
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg not installed")
+def test_ffmpeg_on_path_is_reported_usable():
+    server._tool_usable.cache_clear()
+    assert server._tool_usable("ffmpeg") is True
+
+
+def test_core_image_installs_every_advertised_tool():
+    dockerfile = (ROOT / "service" / "Dockerfile").read_text(encoding="utf-8")
+    for pkg in ("ffmpeg", "ghostscript", "qpdf", "libimage-exiftool-perl"):
+        assert pkg in dockerfile, f"{pkg} is advertised by /capabilities but not installed"


### PR DESCRIPTION
Closes the first two items of #271.

`/capabilities` disagreed with the container it describes, in two places.

**ffmpeg.** `_tool_usable()` probes with `--version` unless `_VERSION_FLAG` overrides it. ffmpeg has no `--version`: it exits 8. The core image installs ffmpeg and `ffmpeg -version` returns 0 inside it, yet the report said `"ffmpeg": false`. Only the report was wrong — `clean_audio.py` and `clean_video.py` resolve the binary with `which()` — but a capability report is what a caller reads before deciding a job is impossible.

**ghostscript.** `/capabilities` advertises it and `_ghostscript_usable()` probes for it, but `service/Dockerfile` never installed it, so deep PDF work was unavailable on an image that claimed to support it.

Measured on an image built from 474be13:

| | before | after |
|---|---|---|
| c2patool | true | true |
| exiftool | true | true |
| qpdf | true | true |
| ghostscript | **false** | true |
| ffmpeg | **false** | true |

`tests/test_capabilities_tooling.py` pins the version flag, asserts the probe agrees with `shutil.which` when ffmpeg is installed (skipped otherwise), and checks the Dockerfile installs every tool `/capabilities` advertises.

`python3 -m pytest -q` and `ruff check`/`ruff format --check` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Ghostscript to the available document-processing tools.
  * Improved capability detection for FFmpeg installations.

* **Bug Fixes**
  * FFmpeg checks now correctly verify the installed version.
  * Capability reporting now accurately reflects supported processing tools.
  * Corrected tool availability reporting for environments with separately installed C2PA tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->