### PR TITLE
feat(api): expose explicit evidence classes in /inspect suspicious payload

### DIFF
--- a/service/scripts/server.py
+++ b/service/scripts/server.py
@@ -778,10 +778,7 @@ def _suspicious_report(report: dict[str, Any]) -> dict[str, Any]:
     treating one boolean as a unified provenance judgment.
     """
     detectors = report.get("text_detectors") or []
-    detected_wm = any(
-        entry.get("available") and entry.get("is_watermarked")
-        for entry in detectors
-    )
+    detected_wm = any(entry.get("available") and entry.get("is_watermarked") for entry in detectors)
     stylometry = report.get("stylometry") or {}
     styl_score = stylometry.get("score") or 0.0
     styl_present = stylometry.get("status") == "ok" and styl_score >= 0.65

--- a/service/scripts/server.py
+++ b/service/scripts/server.py
@@ -235,6 +235,7 @@ def _suspicious_schema() -> dict[str, Any]:
     """OpenAPI schema for the structured `suspicious` evidence object."""
 
     def cls(name: str, strength: str, signals: dict[str, Any]) -> dict[str, Any]:
+        """Build the schema for one evidence class."""
         return _schema(
             type="object",
             properties={
@@ -285,8 +286,9 @@ def _suspicious_schema() -> dict[str, Any]:
                         "stylometry",
                         "heuristic",
                         {
-                            "score": _schema(type="number"),
-                            "density_tier": _schema(type="string"),
+                            # Non-text assets have no stylometry, so these are null.
+                            "score": _schema(type="number", nullable=True),
+                            "density_tier": _schema(type="string", nullable=True),
                         },
                     ),
                 },
@@ -829,6 +831,7 @@ def _suspicious_report(report: dict[str, Any]) -> dict[str, Any]:
 
 
 def _inspect_payload(data: bytes, name: str, run_detect: bool) -> dict[str, Any]:
+    """Inspect a file and return findings plus a structured suspicious report."""
     kind = classify_bytes(data, Path(name).suffix)
     if kind == "unknown":
         return {

--- a/service/scripts/server.py
+++ b/service/scripts/server.py
@@ -207,6 +207,94 @@ def _schema(**props: Any) -> dict[str, Any]:
     return props
 
 
+# Plain-language meaning of each evidence class, keyed by class name. Shared by
+# the OpenAPI schema and the runtime payload so the two never drift.
+_SUSPICIOUS_CLASS_DESCRIPTIONS = {
+    "provenance": (
+        "Observable, deterministic provenance metadata (C2PA/Content Credentials "
+        "or AI-metadata markers) embedded in the file. Strongest evidence class: "
+        "directly inspectable, not inferred."
+    ),
+    "layer_a_unicode": (
+        "Invisible/format Unicode carriers (Layer A) detected in the text body. "
+        "Deterministic but edit-based: a known carrier was present, not proof of "
+        "AI authorship."
+    ),
+    "watermark_detector": (
+        "A positive result from a detector configured for a specific watermark "
+        "scheme. Strong only for that scheme; it is not evidence of any other mark."
+    ),
+    "stylometry": (
+        "Stylometric AI-density score reached the threshold. Heuristic and "
+        "statistical: weaker than observable metadata and subject to false positives."
+    ),
+}
+
+
+def _suspicious_schema() -> dict[str, Any]:
+    """OpenAPI schema for the structured `suspicious` evidence object."""
+
+    def cls(name: str, strength: str, signals: dict[str, Any]) -> dict[str, Any]:
+        return _schema(
+            type="object",
+            properties={
+                "present": _schema(type="boolean"),
+                "strength": _schema(type="string", description=strength),
+                "description": _schema(
+                    type="string", description=_SUSPICIOUS_CLASS_DESCRIPTIONS[name]
+                ),
+                "signals": _schema(type="object", properties=signals),
+            },
+        )
+
+    return _schema(
+        type="object",
+        description=(
+            "Heterogeneous evidence for suspected marking, reported per evidence "
+            "class so callers can weigh each signal instead of trusting one boolean. "
+            "Not a single provenance judgment."
+        ),
+        properties={
+            "verdict": _schema(type="boolean"),
+            "description": _schema(type="string"),
+            "classes": _schema(
+                type="object",
+                properties={
+                    "provenance": cls(
+                        "provenance",
+                        "definitive",
+                        {
+                            "has_c2pa": _schema(type="boolean"),
+                            "has_ai_metadata": _schema(type="boolean"),
+                        },
+                    ),
+                    "layer_a_unicode": cls(
+                        "layer_a_unicode",
+                        "deterministic",
+                        {"suspicious_total": _schema(type="integer")},
+                    ),
+                    "watermark_detector": cls(
+                        "watermark_detector",
+                        "scheme_specific",
+                        {
+                            "detected_any": _schema(type="boolean"),
+                            "detectors": _schema(type="array", items=_schema(type="object")),
+                        },
+                    ),
+                    "stylometry": cls(
+                        "stylometry",
+                        "heuristic",
+                        {
+                            "score": _schema(type="number"),
+                            "density_tier": _schema(type="string"),
+                        },
+                    ),
+                },
+            ),
+        },
+    )
+
+
 def _file_request(extra: dict[str, Any] | None = None) -> dict[str, Any]:
     schema: dict[str, Any] = {
         "type": "object",
@@ -339,7 +427,7 @@ _OPENAPI_PATHS: dict[str, dict[str, Any]] = {
                     properties={
                         "ok": _schema(type="boolean"),
                         "kind": _schema(type="string", enum=["text", "image", "container", "av"]),
-                        "suspicious": _schema(type="boolean"),
+                        "suspicious": _suspicious_schema(),
                         "report": _schema(type="object"),
                     },
                 )
@@ -418,7 +506,7 @@ _OPENAPI_PATHS: dict[str, dict[str, Any]] = {
                                         type="string",
                                         enum=["text", "image", "container", "av", "unknown"],
                                     ),
-                                    "suspicious": _schema(type="boolean"),
+                                    "suspicious": _suspicious_schema(),
                                     "report": _schema(type="object"),
                                     "error": _schema(type="string"),
                                 },
@@ -680,6 +768,66 @@ def _batch_items(
     return items
 
 
+def _suspicious_report(report: dict[str, Any]) -> dict[str, Any]:
+    """Break the collapsed `suspicious` boolean into explicit evidence classes.
+
+    Each class keeps its own evidentiary weight and a plain-language
+    `description`, so a downstream agent can weigh the signals rather than
+    treating one boolean as a unified provenance judgment.
+    """
+    detectors = report.get("text_detectors") or []
+    detected_wm = any(
+        entry.get("available") and entry.get("is_watermarked")
+        for entry in detectors
+    )
+    stylometry = report.get("stylometry") or {}
+    styl_score = stylometry.get("score") or 0.0
+    styl_present = stylometry.get("status") == "ok" and styl_score >= 0.65
+
+    classes = {
+        "provenance": {
+            "present": bool(report.get("has_c2pa") or report.get("has_ai_metadata")),
+            "strength": "definitive",
+            "description": _SUSPICIOUS_CLASS_DESCRIPTIONS["provenance"],
+            "signals": {
+                "has_c2pa": bool(report.get("has_c2pa")),
+                "has_ai_metadata": bool(report.get("has_ai_metadata")),
+            },
+        },
+        "layer_a_unicode": {
+            "present": bool(report.get("suspicious_total")),
+            "strength": "deterministic",
+            "description": _SUSPICIOUS_CLASS_DESCRIPTIONS["layer_a_unicode"],
+            "signals": {"suspicious_total": report.get("suspicious_total", 0)},
+        },
+        "watermark_detector": {
+            "present": detected_wm,
+            "strength": "scheme_specific",
+            "description": _SUSPICIOUS_CLASS_DESCRIPTIONS["watermark_detector"],
+            "signals": {"detected_any": detected_wm, "detectors": detectors},
+        },
+        "stylometry": {
+            "present": styl_present,
+            "strength": "heuristic",
+            "description": _SUSPICIOUS_CLASS_DESCRIPTIONS["stylometry"],
+            "signals": {
+                "score": stylometry.get("score"),
+                "density_tier": stylometry.get("density_tier"),
+            },
+        },
+    }
+
+    return {
+        "verdict": any(c["present"] for c in classes.values()),
+        "description": (
+            "Combined across heterogeneous evidence classes. A hint to inspect "
+            "further, not a single provenance judgment: a file flagged here is "
+            "not necessarily watermark-free or human-authored."
+        ),
+        "classes": classes,
+    }
+
+
 def _inspect_payload(data: bytes, name: str, run_detect: bool) -> dict[str, Any]:
     kind = classify_bytes(data, Path(name).suffix)
     if kind == "unknown":
@@ -687,7 +835,7 @@ def _inspect_payload(data: bytes, name: str, run_detect: bool) -> dict[str, Any]
             "ok": True,
             "kind": "unknown",
             "report": {"note": "unrecognized format; use a filename with a known extension"},
-            "suspicious": False,
+            "suspicious": _suspicious_report({}),
         }
     with tempfile.TemporaryDirectory(prefix="wm-inspect-") as tmp:
         path = _tmp_path(Path(tmp), name or "input")
@@ -709,20 +857,7 @@ def _inspect_payload(data: bytes, name: str, run_detect: bool) -> dict[str, Any]
             report = inspect_av(path).to_dict()
         else:
             report = inspect_container(path).to_dict()
-    detected_wm = any(
-        entry.get("available") and entry.get("is_watermarked")
-        for entry in report.get("text_detectors") or []
-    )
-    suspicious = (
-        bool(report.get("suspicious_total"))
-        or bool(report.get("has_c2pa") or report.get("has_ai_metadata"))
-        or bool(
-            report.get("stylometry", {}).get("status") == "ok"
-            and (report.get("stylometry", {}).get("score") or 0.0) >= 0.65
-        )
-        or detected_wm
-    )
-    return {"ok": True, "kind": kind, "report": report, "suspicious": suspicious}
+    return {"ok": True, "kind": kind, "report": report, "suspicious": _suspicious_report(report)}
 
 
 def _detect_payload(data: bytes, name: str) -> dict[str, Any]:

--- a/tests/test_detect_endpoint.py
+++ b/tests/test_detect_endpoint.py
@@ -168,7 +168,12 @@ def test_inspect_detect_is_opt_in(conn, monkeypatch, tmp_path):
     status, body = _post(conn, "/inspect", {"file": _b64(txt), "name": "notes.txt", "detect": True})
     assert status == 200
     assert "text_detectors" in body["report"]
-    assert body["suspicious"] is True
+    assert body["suspicious"]["verdict"] is True
+    wm = body["suspicious"]["classes"]["watermark_detector"]
+    assert wm["present"] is True
+    assert wm["strength"] == "scheme_specific"
+    assert wm["description"]
+    assert body["suspicious"]["description"]
 
 
 def test_clean_text_detect_before_after(conn, monkeypatch, tmp_path):

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -327,6 +327,11 @@ def test_inspect_unknown_format_reports_kind(conn):
     assert status == 200
     assert body["kind"] == "unknown"
     assert body["suspicious"]["verdict"] is False
+    # No stylometry is computed for a non-text asset, so its signals are null
+    # rather than omitted; the OpenAPI schema must permit that.
+    styl = body["suspicious"]["classes"]["stylometry"]
+    assert styl["signals"]["score"] is None
+    assert styl["signals"]["density_tier"] is None
     assert "note" in body["report"]
 
 

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -165,8 +165,12 @@ def test_inspect_text_finds_watermark(conn):
     status, body = _post(conn, "/inspect", {"file": _b64(data), "name": "note.txt"})
     assert status == 200
     assert body["kind"] == "text"
-    assert body["suspicious"] is True
+    assert body["suspicious"]["verdict"] is True
     assert body["report"]["suspicious_total"] == 2
+    layer_a = body["suspicious"]["classes"]["layer_a_unicode"]
+    assert layer_a["present"] is True
+    assert layer_a["strength"] == "deterministic"
+    assert layer_a["description"]
 
 
 def test_clean_text_roundtrip(conn):
@@ -322,7 +326,7 @@ def test_inspect_unknown_format_reports_kind(conn):
     status, body = _post(conn, "/inspect", {"file": _b64(data), "name": "input"})
     assert status == 200
     assert body["kind"] == "unknown"
-    assert body["suspicious"] is False
+    assert body["suspicious"]["verdict"] is False
     assert "note" in body["report"]
 
 
@@ -401,9 +405,9 @@ def test_inspect_batch_mixed_results(conn):
     assert body["ok"] is True
     results = {r["name"]: r for r in body["results"]}
     assert results["a.txt"]["ok"] is True
-    assert results["a.txt"]["suspicious"] is True
+    assert results["a.txt"]["suspicious"]["verdict"] is True
     assert results["b.txt"]["ok"] is True
-    assert results["b.txt"]["suspicious"] is False
+    assert results["b.txt"]["suspicious"]["verdict"] is False
 
 
 def test_clean_batch_mixed_results(conn):


### PR DESCRIPTION
## What

Replaces the flat `suspicious: boolean` returned by `POST /inspect` and `POST /inspect/batch` with a structured object that reports evidence per class, plus a `description` on the overall verdict and on every class.

## Why

The old boolean aggregated four heterogeneous signals into a single flag:

- C2PA / AI-metadata provenance (`has_c2pa`, `has_ai_metadata`)
- Invisible Unicode carriers (`suspicious_total`)
- Watermark-detector positives (`text_detectors`)
- Stylometric score (heuristic, `>= 0.65`)

These do not carry the same evidentiary weight. Observable C2PA data and a positive result from a scheme-specific detector are strong; a stylometric threshold crossing is a weak statistical hint. Collapsing them let a downstream agent treat one boolean as a unified provenance judgment, which is misleading.

This change makes the evidence classes explicit and labels each with its `strength` and a plain-language `description`, so callers can weigh signals independently.

## New payload shape

```json
{
  "suspicious": {
    "verdict": true,
    "description": "Combined across heterogeneous evidence classes. A hint to inspect further, not a single provenance judgment...",
    "classes": {
      "provenance":      { "present": true, "strength": "definitive",      "description": "...", "signals": { "has_c2pa": true, "has_ai_metadata": true } },
      "layer_a_unicode": { "present": true, "strength": "deterministic",   "description": "...", "signals": { "suspicious_total": 3 } },
      "watermark_detector": { "present": true, "strength": "scheme_specific", "description": "...", "signals": { "detected_any": true, "detectors": [] } },
      "stylometry":      { "present": true, "strength": "heuristic",       "description": "...", "signals": { "score": 0.71, "density_tier": "high" } }
    }
  }
}
```

The OpenAPI spec (`/openapi.json`) for both endpoints is updated to describe the new object. Everything already available in `report` is unchanged.

## Breaking change

`suspicious` is no longer a boolean; consumers should read `suspicious.verdict` and, ideally, the per-class `present`/`strength`/`description` fields.

## Tests

Updated the existing `suspicious` assertions and added checks that per-class `description` and `strength` are present. Full suite: 944 passed, 13 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Suspicious-content inspection now provides a structured verdict with evidence categories, strength, descriptions, and relevant signals.
  * Reports identify evidence from provenance, Unicode patterns, watermark detection, and stylometry.
  * Single and batch inspection responses now document and return the structured evidence report.

* **Bug Fixes**
  * Standardized suspicious verdicts across recognized, unknown-format, and mixed batch inspections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->