### PR TITLE
fix(audio): keep the re-encode dest distinct from the container-clean dest

### DIFF
--- a/service/scripts/clean_audio.py
+++ b/service/scripts/clean_audio.py
@@ -243,7 +243,12 @@ def audio_purify(
 
     rc, stderr = _run_ffmpeg(cmd, timeout, "ffmpeg audio degradation")
     if rc != 0:
-        return {"available": False, "error": (stderr or "").strip()[-2000:]}
+        err = (stderr or "").strip()
+        # ffmpeg's stderr is commonly led by its configure/build banner; keep the
+        # trailing lines where the actual failure reason appears so it isn't buried.
+        err_lines = [ln for ln in err.splitlines() if ln.strip()]
+        err = "\n".join(err_lines[-8:]) if err_lines else err
+        return {"available": False, "error": err[-2000:]}
 
     return {
         "available": True,

--- a/service/scripts/server.py
+++ b/service/scripts/server.py
@@ -987,7 +987,12 @@ def _clean_payload(data: bytes, name: str, options: dict[str, Any]) -> dict[str,
             definitely_audio = is_audio_format(result.get("format", ""))
             is_audio = definitely_audio or (is_audio_name(name) and media_has_video(src) is False)
             if is_audio and options.get("remove_audio_watermark"):
-                audio_dest = _tmp_path(tmpdir, "out.m4a")
+                # The container-clean dest above is "out" + the input suffix, so an
+                # .m4a input made both paths "out.m4a". ffmpeg refuses to edit a file
+                # in place, which silently skipped the chain while /clean still 200'd,
+                # so keep the re-encode dest literally distinct (an input suffix can
+                # never be "-audio.m4a").
+                audio_dest = _tmp_path(tmpdir, "out-audio.m4a")
                 audio_res = audio_purify(dest, audio_dest)
                 result["audio_mark_removal"] = audio_res
                 if audio_res.get("available"):

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -238,6 +238,39 @@ def test_clean_av_honors_remove_audio_watermark(conn):
     assert len(base64.b64decode(body["cleaned"])) == body["report"]["bytes_out"]
 
 
+def test_clean_av_m4a_reencode_dest_distinct_from_container_clean(conn, monkeypatch):
+    """An .m4a input must not reuse the container-clean dest for the re-encode.
+
+    The AV branch derives the container-clean dest as ``out<ext>`` (so ``.m4a``
+    gives ``out.m4a``). If the audio chain re-used the same name, ffmpeg would
+    refuse to edit its input in place and silently skip the chain. This stubs
+    ``audio_purify`` so the regression is independent of whether ffmpeg is on
+    the runner.
+    """
+    calls: list[tuple[Path, Path]] = []
+
+    def fake_purify(src: Path, dest: Path) -> dict:
+        calls.append((src, dest))
+        return {"available": False, "error": "spy: ffmpeg unavailable"}
+
+    monkeypatch.setattr(server, "audio_purify", fake_purify)
+    monkeypatch.setattr(server, "media_has_video", lambda path: False)
+
+    status, _ = _post(
+        conn,
+        "/clean",
+        {
+            "file": _b64(_minimal_mp4()),
+            "name": "audio.m4a",
+            "options": {"remove_audio_watermark": True},
+        },
+    )
+    assert status == 200
+    assert len(calls) == 1, "audio_purify should run once for an .m4a audio item"
+    src, dest = calls[0]
+    assert src != dest, "re-encode dest must be distinct from the container-clean dest"
+
+
 def test_clean_av_rejects_invalid_remove_pixel(conn):
     data = _minimal_mp4()
     status, body = _post(

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -11,6 +11,7 @@ import sys
 import threading
 import zlib
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -269,6 +270,40 @@ def test_clean_av_m4a_reencode_dest_distinct_from_container_clean(conn, monkeypa
     assert len(calls) == 1, "audio_purify should run once for an .m4a audio item"
     src, dest = calls[0]
     assert src != dest, "re-encode dest must be distinct from the container-clean dest"
+
+
+def test_clean_av_m4a_success_uses_reencode_dest_output(conn, monkeypatch):
+    """A successful purify run must become the returned report and cleaned bytes.
+
+    The success path re-points the handler at the re-encode dest: after the
+    chain writes its output there, `bytes_out`/`cleaned` must reflect that file,
+    not the earlier container-clean output.
+    """
+    out_bytes = _minimal_mp4()
+
+    def fake_purify(src: Path, dest: Path) -> dict:
+        dest.write_bytes(out_bytes)
+        return {"available": True, "tempo": 1.08, "pitch_semitones": 2.0, "codec": "aac"}
+
+    after = SimpleNamespace(has_c2pa=False, has_ai_metadata=False, findings=[], format="mp4")
+    monkeypatch.setattr(server, "audio_purify", fake_purify)
+    monkeypatch.setattr(server, "media_has_video", lambda path: False)
+    monkeypatch.setattr(server, "inspect_av", lambda path: after)
+
+    status, body = _post(
+        conn,
+        "/clean",
+        {
+            "file": _b64(_minimal_mp4()),
+            "name": "audio.m4a",
+            "options": {"remove_audio_watermark": True},
+        },
+    )
+    assert status == 200
+    assert body["report"]["audio_mark_removal"]["available"] is True
+    assert any("destructive audio watermark chain" in a for a in body["report"]["actions"])
+    assert body["report"]["bytes_out"] == len(out_bytes)
+    assert base64.b64decode(body["cleaned"]) == out_bytes
 
 
 def test_clean_av_rejects_invalid_remove_pixel(conn):


### PR DESCRIPTION
## What

`remove_audio_watermark` silently no-ops on `.m4a` input. In `server.py`'s AV branch the container-clean dest is `"out" + input_suffix` (so `audio.m4a` → `out.m4a`), and the audio chain then re-used the hardcoded `_tmp_path(tmpdir, "out.m4a")` as its *output*. `src == dest` for the ffmpeg call, ffmpeg refuses to edit a file in place, and the destructive audio chain is skipped — while `POST /clean` still returns **200** with `changed: true` because the container metadata strip succeeded. Only the nested `audio_mark_removal.available: false` (and a `skipped:` action buried under ffmpeg's configure banner) reveals the chain never ran.

## Fix

- Rename the re-encode dest to a literally distinct name (`out-audio.m4a`) that an input suffix can never produce, so it can't collide with the container-clean dest.
- Trim the ffmpeg stderr captured into the `skipped:` action to its trailing lines, so a future failure is readable instead of being dominated by the build banner.

Closes #270.

## Checklist

- [x] Behaviour matches `SKILL.md` / `references/removal-matrix.md` when relevant
- [x] Unit tests updated or added under `tests/`
- [x] `python3 -m pytest -q` passes
- [x] No drive-by refactors unrelated to the fix

## Notes for the reviewer

- The regression test stubs `audio_purify` and `media_has_video` so it reproduces the dest-collision regardless of whether the runner has ffmpeg. Verified it fails on the pre-fix code (`out.m4a` == `out.m4a`) and passes with the fix.
- Note: this overlaps with the audio-domain bug only; the other report defects (#163/#191/#262) are covered by PRs #201 and #263.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio-processing error messages by showing the most relevant recent details.
  * Fixed `.m4a` audio watermark removal to avoid conflicts when reading and writing the same file.

* **Tests**
  * Added regression coverage to verify successful `.m4a` processing with separate input and output files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->