### PR TITLE
fix(test): make clean_staged PDF end-to-end test environment-independent

### DIFF
--- a/tests/test_precommit_hooks.py
+++ b/tests/test_precommit_hooks.py
@@ -215,15 +215,14 @@ def test_clean_staged_same_length_pdf_report_exits_1(tmp_path, monkeypatch, caps
     assert "cleaned 1 file(s)" in capsys.readouterr().err
 
 
-def test_clean_staged_same_length_pdf_end_to_end_exits_1(tmp_path, monkeypatch, capsys):
-    """Real subprocess clean on a PDF with XMP overwrites XMP with spaces, exits 1, same length."""
+def test_clean_staged_pdf_end_to_end_exits_1(tmp_path, monkeypatch, capsys):
+    """Real subprocess clean on a PDF with XMP removes the marker and exits 1."""
     f = tmp_path / "marked.pdf"
     pdf_bytes = _minimal_pdf_with_xmp()
     f.write_bytes(pdf_bytes)
     monkeypatch.setattr(sys, "argv", ["clean_staged.py", str(f)])
     assert clean_staged.main() == 1
     cleaned = f.read_bytes()
-    assert len(cleaned) == len(pdf_bytes)
     assert cleaned != pdf_bytes
     assert b"trainedAlgorithmicMedia" not in cleaned
     assert "cleaned 1 file(s)" in capsys.readouterr().err


### PR DESCRIPTION
Closes #290

## Problem

`test_clean_staged_same_length_pdf_end_to_end_exits_1` asserted byte-length preservation, which only holds on the pure-stdlib fallback path. On a machine where `exiftool` and `qpdf` are installed, the real path runs, qpdf linearizes the document, and the length assertion fails (`assert 1087 == 335`) even though the AI/C2PA marker is correctly removed.

## Change

Drop the environment-dependent length assertion and assert the actual contract instead: marker removed, file changed, exit code 1. Renamed and re-documented the test to `test_clean_staged_pdf_end_to_end_exits_1` so it no longer claims length preservation.

## Verification

- `./.venv/bin/python -m pytest tests/test_precommit_hooks.py` passes (25/25).
- Full suite passes on this machine (`python -m pytest -q`, exit 0). This machine lacks `exiftool`/`qpdf`, so the fallback path runs here; the change makes the test deterministic whether or not the tools are present.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated PDF cleaning coverage to verify that the cleaner removes XMP metadata and changes the file contents.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->