### PR TITLE
fix(bench): validate weight grid and widen the recipe search spectrum

### DIFF
--- a/docs/synthid-text-benchmark.md
+++ b/docs/synthid-text-benchmark.md
@@ -305,11 +305,16 @@ applied sequentially - each step's output feeds the next.
   produces the per-strength intensity curves (robust %, sem div, human_like vs
   intensity).
 - Phase 2 runs a beam search (`--beam`, `--max-passes`) once per weight vector in
-  `--weight-grid`, appending the best single steps. The scalarized objective
-  (`0.5 removal / 0.3 meaning / 0.2 human`) only drives the search.
+  `--weight-grid`, combining an order of strengths with the top
+  `--phase2-levels-per-strength` intensities for that weight, so both step order
+  and intensity are explored.
 - The report's **Pareto frontier** is computed by dominance (no weights) over the
   union of all candidates, so it is weight-independent. The "recommended" recipe
-  is one highlighted point on it.
+  is the frontier point best matching `--recommend-weight` (a
+  w_removal/w_semantic/w_human triple summing to 1.0, default `0.5/0.3/0.2`).
+  If no recipe in the searched space clears the mark, the report says the mark
+  **resists** the searched attacks at that token length rather than leaving an
+  empty frontier to interpret.
 - `--recipes "chunk@0.6,paraphrase@0.3"` composes and scores one explicit recipe
   instead of searching.
 - `--layer-a-after` re-runs the Unicode scrub on the final output; default **off**
@@ -324,4 +329,6 @@ applied sequentially - each step's output feeds the next.
 
 A recipe search is expensive (each candidate = a full rewrite chain per sample).
 Run Phase 1 coarsely first with fewer docs/seeds, then confirm the winning
-recipes on a larger run with adequate statistical power.
+recipes on a larger run with adequate statistical power. Lower
+`--phase2-levels-per-strength` (or cut docs/seeds, `--beam`, `--max-passes`) to
+keep a run inside a tight wall-clock budget.

--- a/docs/synthid-text-benchmark.md
+++ b/docs/synthid-text-benchmark.md
@@ -312,9 +312,12 @@ applied sequentially - each step's output feeds the next.
   union of all candidates, so it is weight-independent. The "recommended" recipe
   is the frontier point best matching `--recommend-weight` (a
   w_removal/w_semantic/w_human triple summing to 1.0, default `0.5/0.3/0.2`).
-  If no recipe in the searched space clears the mark, the report says the mark
-  **resists** the searched attacks at that token length rather than leaving an
-  empty frontier to interpret.
+  The report's **Verdict** section distinguishes the no-clear cases rather than
+  calling every empty result `resists`: it reports **resists** only when the
+  best verified robust clear % is 0.0, and **undetermined** when no candidate
+  recipe was evaluable (all three axes missing, so no verified clear rate
+  exists). Either way, an empty or unevaluable search is stated explicitly
+  instead of leaving an empty frontier to interpret.
 - `--recipes "chunk@0.6,paraphrase@0.3"` composes and scores one explicit recipe
   instead of searching.
 - `--layer-a-after` re-runs the Unicode scrub on the final output; default **off**

--- a/service/scripts/bench_synthid_text.py
+++ b/service/scripts/bench_synthid_text.py
@@ -2746,17 +2746,11 @@ def main() -> int:
         )
         return 2
 
-    bench = Benchmark(args, upstream)
-    if not bench.corpus:
-        eprint("error: empty corpus")
-        return 2
-    probe = _semantic_startup_probe(bench, args.semantic_model, args.require_semantic)
-    if probe is not None:
-        return probe
-
-    # Fail fast on a bad recipe grid/spec before spending a full generation
-    # pass (a misconfigured --intensity-grid / --weight-grid would otherwise
-    # waste the whole run only to be rejected when the search starts).
+    # Fail fast on a bad recipe grid/spec and positive-value flags before
+    # constructing Benchmark, which starts MarkLLMWorker and the semantic
+    # backend. A misconfigured --intensity-grid / --weight-grid / --beam /
+    # --max-passes would otherwise only be rejected after the expensive setup
+    # (and before the worker-cleanup path that normally runs on early returns).
     if args.mode == "recipe":
         parse_float_grid(args.intensity_grid)
         parse_weight_grid(args.weight_grid)
@@ -2772,6 +2766,14 @@ def main() -> int:
             return 1
         if args.recipes:
             parse_recipe(args.recipes)
+
+    bench = Benchmark(args, upstream)
+    if not bench.corpus:
+        eprint("error: empty corpus")
+        return 2
+    probe = _semantic_startup_probe(bench, args.semantic_model, args.require_semantic)
+    if probe is not None:
+        return probe
 
     out_dir = args.out_dir.resolve()
     out_dir.mkdir(parents=True, exist_ok=True)

--- a/service/scripts/bench_synthid_text.py
+++ b/service/scripts/bench_synthid_text.py
@@ -1570,16 +1570,20 @@ class Benchmark:
         }
 
     def _scalarize(self, axis: dict, w: tuple[float, float, float]) -> float | None:
-        """scalarize."""
-        removal = axis.get("robust_clear_rate")
-        sem = axis.get("sem_div")
-        human = axis.get("human_like")
-        if removal is None or sem is None or human is None:
-            return None
-        return w[0] * removal + w[1] * (1.0 - sem) + w[2] * human
+        """Scalarize an axis dict under weight vector w."""
+        return _weighted_score(axis, w)
 
     def recipe_search(self, samples: list[dict[str, Any]], workdir: Path) -> dict[str, Any]:
-        """Recipe search."""
+        """Recipe search.
+
+        Phase 1 sweeps each strength's intensity grid as a single-step recipe.
+        Phase 2 runs a per-weight-vector beam search that combines an *order* of
+        strengths with the top `--phase2-levels-per-strength` intensities for that
+        weight vector, so both step order and intensity are explored. The
+        recommended recipe is the point on the weight-independent Pareto frontier
+        that best matches `--recommend-weight`; the frontier itself is unaffected
+        by weights.
+        """
         a = self.args
         strengths: tuple[str, ...] = (
             "paraphrase",
@@ -1590,6 +1594,8 @@ class Benchmark:
         )
         grid = parse_float_grid(a.intensity_grid)
         weights = parse_weight_grid(a.weight_grid)
+        recommend_w = parse_weight_vec(getattr(a, "recommend_weight", "0.5/0.3/0.2"))
+        k = max(1, int(getattr(a, "phase2_levels_per_strength", 3)))
         seen: set[tuple] = set()
         cands: list[dict] = []
 
@@ -1605,54 +1611,53 @@ class Benchmark:
             return axis
 
         # Phase 1: per-strength intensity sweep (single-step recipes).
-        best_level: dict[str, float] = {}
+        step_axes: dict[tuple[str, float], dict] = {}
         for strength in strengths:
-            best: dict | None = None
             for level in grid:
                 axis = _eval([(strength, level)])
-                if axis is None:
-                    continue
-                sc = self._scalarize(axis, (0.5, 0.3, 0.2))
-                if sc is not None and (best is None or sc > best[0]):
-                    best = (sc, axis, level)
-            if best is not None:
-                best_level[strength] = best[2]
+                if axis is not None:
+                    step_axes[(strength, level)] = axis
 
-        # Phase 2: beam search (one run per weight vector) appending steps.
-        default_w = (0.5, 0.3, 0.2)
+        # Phase 2: per-weight top-k intensity ranking + intensity x order beam search.
         for w in weights:
+            topk: dict[str, list[float]] = {}
+            for strength in strengths:
+                ranked: list[tuple[float, float]] = []
+                for (s, level), axis in step_axes.items():
+                    if s != strength:
+                        continue
+                    sc = self._scalarize(axis, w)
+                    if sc is not None:
+                        ranked.append((sc, level))
+                ranked.sort(key=lambda t: t[0], reverse=True)
+                topk[strength] = [level for _sc, level in ranked[:k]]
+
             beams: list[list[tuple[str, float]]] = [
-                [(s, best_level[s])] for s in strengths if s in best_level
+                [(s, level)] for s in strengths for level in topk[s]
             ]
             for _depth in range(1, max(1, a.max_passes)):
                 candidates_beam: list[tuple[float, list]] = []
                 for recipe in beams:
+                    used = {s for s, _lv in recipe}
                     for strength in strengths:
-                        if recipe and recipe[-1][0] == strength:
+                        if strength in used:
                             continue
-                        level = best_level.get(strength)
-                        if level is None:
-                            continue
-                        cand = [*recipe, (strength, level)]
-                        axis = _eval(cand)
-                        if axis is None:
-                            continue
-                        sc = self._scalarize(axis, w)
-                        if sc is None:
-                            continue
-                        candidates_beam.append((sc, cand))
+                        for level in topk[strength]:
+                            cand = [*recipe, (strength, level)]
+                            axis = _eval(cand)
+                            if axis is None:
+                                continue
+                            sc = self._scalarize(axis, w)
+                            if sc is None:
+                                continue
+                            candidates_beam.append((sc, cand))
                 if not candidates_beam:
                     break
                 candidates_beam.sort(key=lambda t: t[0], reverse=True)
                 beams = [cand for _sc, cand in candidates_beam[: a.beam]]
 
-        best_rec: tuple[float, dict] | None = None
-        for c in cands:
-            sc = self._scalarize(c, default_w)
-            if sc is None:
-                continue
-            if best_rec is None or sc > best_rec[0]:
-                best_rec = (sc, c)
+        frontier = _pareto_frontier(cands)
+        recommended = _best_on_frontier(frontier, cands, recommend_w)
 
         # Intensity curves per strength (from Phase 1 single-step recipes).
         curves: dict[str, list] = {}
@@ -1672,9 +1677,10 @@ class Benchmark:
 
         return {
             "candidates": cands,
-            "recommended": best_rec[1] if best_rec else None,
-            "frontier": _pareto_frontier(cands),
+            "recommended": recommended,
+            "frontier": frontier,
             "intensity_curves": curves,
+            "verdict": _recipe_verdict(cands),
         }
 
 
@@ -1785,6 +1791,67 @@ def _pareto_frontier(cands: list[dict]) -> list[dict]:
         if not dominated:
             front.append(c)
     return front
+
+
+def _weighted_score(axis: dict[str, Any], w: tuple[float, float, float]) -> float | None:
+    """Scalarize an axis dict into a single score under weight vector w.
+
+    A recipe is only scalarizable when all three axes are available; otherwise it
+    cannot be ranked and None is returned.
+    """
+    removal = axis.get("robust_clear_rate")
+    sem = axis.get("sem_div")
+    human = axis.get("human_like")
+    if removal is None or sem is None or human is None:
+        return None
+    return w[0] * removal + w[1] * (1.0 - sem) + w[2] * human
+
+
+def _best_on_frontier(
+    frontier: list[dict], cands: list[dict], w: tuple[float, float, float]
+) -> dict | None:
+    """Pick the Pareto-frontier recipe best under weight w.
+
+    Falls back to the best candidate under w if the frontier is empty (which can
+    happen when no recipe has all three axes available).
+    """
+    pool = frontier or cands
+    best: dict | None = None
+    best_sc: float | None = None
+    for c in pool:
+        sc = _weighted_score(c, w)
+        if sc is None:
+            continue
+        if best is None or sc > best_sc:
+            best, best_sc = c, sc
+    return best
+
+
+def _recipe_verdict(cands: list[dict]) -> str:
+    """Honest verdict on whether the searched recipes clear the mark.
+
+    'removable'    -> some recipe robustly cleared (best robust % == 1.0).
+    'partial'      -> recipes cleared partially (0 < best robust % < 1.0).
+    'resists'      -> nothing cleared (best robust % == 0.0).
+    'undetermined' -> no recipe was evaluable (all three axes missing).
+    """
+    rates = [c.get("robust_clear_rate") for c in cands if c.get("robust_clear_rate") is not None]
+    if not rates:
+        return "undetermined"
+    best_rate = max(rates)
+    if best_rate <= 0.0:
+        return "resists"
+    if best_rate < 1.0:
+        return "partial"
+    return "removable"
+
+
+def parse_weight_vec(spec: str) -> tuple[float, float, float]:
+    """Parse a single weight triple like '0.5/0.3/0.2' summing to 1.0."""
+    vecs = parse_weight_grid(spec)
+    if len(vecs) != 1:
+        raise SystemExit(f"error: expected exactly one weight vector, got {spec!r}")
+    return vecs[0]
 
 
 def aggregate(rows: list[dict[str, Any]], variants: list[tuple[str, int]]) -> dict[str, Any]:
@@ -2203,10 +2270,13 @@ def render_markdown_recipe(
         "next step). "
         + (
             "This run searched the recipe space: Phase 1 sweeps each strength's "
-            "intensity grid; Phase 2 runs a per-weight-vector beam search appending "
-            "the best single steps. The scalarized objective (default "
-            "0.5 removal / 0.3 meaning / 0.2 human) only drives the search; the "
-            "Pareto frontier below is weight-independent."
+            "intensity grid; Phase 2 runs a per-weight-vector beam search that "
+            "combines an order of strengths with that weight's top intensities "
+            "(`--phase2-levels-per-strength`), so both step order and intensity are "
+            "explored. The recommended recipe is the point on the weight-independent "
+            "Pareto frontier that best matches the configured recommend weight "
+            f"(`--recommend-weight`, default {config.get('recommend_weight', '0.5/0.3/0.2')}); "
+            "the frontier below is unaffected by weights."
             if not config.get("recipes")
             else "This run composed and scored the explicitly requested recipe."
         )
@@ -2230,6 +2300,10 @@ def render_markdown_recipe(
         L.append(f"- robust clear %: {_fmt(rec.get('robust_clear_rate'))} (n={rec.get('n', 0)})")
         L.append(f"- semantic divergence: {_fmt(rec.get('sem_div'))}")
         L.append(f"- human_like: {_fmt(rec.get('human_like'))}")
+    L.append("")
+    L.append("## Verdict")
+    L.append("")
+    L.append(_render_recipe_verdict(res))
     L.append("")
     L.append("## Pareto frontier (weight-independent)")
     L.append("")
@@ -2276,6 +2350,36 @@ def render_markdown_recipe(
     L.append("    " + config["command"])
     L.append("")
     return "\n".join(L) + "\n"
+
+
+def _render_recipe_verdict(res: dict[str, Any]) -> str:
+    """Render the honest 'can the mark be removed?' verdict for the report."""
+    cands = res.get("candidates") or []
+    verdict = res.get("verdict") or _recipe_verdict(cands)
+    rates = [c.get("robust_clear_rate") for c in cands if c.get("robust_clear_rate") is not None]
+    best = _fmt(max(rates)) if rates else "n/a"
+    if verdict == "removable":
+        return (
+            "The searched space contains a recipe that robustly clears the mark "
+            f"(best robust % = {best}); treat the recommended recipe as the answer "
+            "to whether the mark is removable."
+        )
+    if verdict == "partial":
+        return (
+            f"Recipes in the searched space partially clear the mark (best robust % = {best}), "
+            "but none robustly clears every sample at the configured `--target-margin`."
+        )
+    if verdict == "resists":
+        return (
+            f"No recipe in the searched space cleared the mark (best robust % = {best}). "
+            "At this token length the mark resists the searched attacks; a lower "
+            "`--target-margin` or a higher-aggression recipe set (more steps / higher "
+            "intensities via `--phase2-levels-per-strength`) is the next lever."
+        )
+    return (
+        "Verdict undetermined: no candidate recipe had all three axes evaluated "
+        "(add `--require-semantic` / a detector)."
+    )
 
 
 def _recipe_csv(res: dict[str, Any]) -> list[str]:
@@ -2552,7 +2656,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument(
         "--weight-grid",
-        default="0.8/0.1/0.1,0.5/0.3/0.2,0.2/0.6/0.2,0.2/0.2/0.6,0.33/0.33/0.33",
+        default="0.8/0.1/0.1,0.5/0.3/0.2,0.2/0.6/0.2,0.2/0.2/0.6,0.34/0.33/0.33",
         help="Comma list of w_removal/w_semantic/w_human weight vectors driving the "
         "composition search (default: the 5-vector grid). The Pareto frontier is "
         "weight-independent.",
@@ -2560,6 +2664,21 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--beam", type=int, default=4, help="Composition-search beam width (default: 4)")
     p.add_argument(
         "--max-passes", type=int, default=3, help="Max recipe steps in the search (default: 3)"
+    )
+    p.add_argument(
+        "--phase2-levels-per-strength",
+        type=int,
+        default=3,
+        help="Per-weight top-k intensities considered in the phase 2 beam search "
+        "(default: 3). Raising this broadens the search over intensities and "
+        "aggressive multi-step recipes but costs more evals; lower it to stay "
+        "inside a tight wall-clock budget.",
+    )
+    p.add_argument(
+        "--recommend-weight",
+        default="0.5/0.3/0.2",
+        help="w_removal/w_semantic/w_human used to pick the recommended recipe "
+        "from the weight-independent Pareto frontier (default: 0.5/0.3/0.2).",
     )
     p.add_argument(
         "--recipes",
@@ -2628,6 +2747,19 @@ def main() -> int:
     if probe is not None:
         return probe
 
+    # Fail fast on a bad recipe grid/spec before spending a full generation
+    # pass (a misconfigured --intensity-grid / --weight-grid would otherwise
+    # waste the whole run only to be rejected when the search starts).
+    if args.mode == "recipe":
+        parse_float_grid(args.intensity_grid)
+        parse_weight_grid(args.weight_grid)
+        parse_weight_vec(args.recommend_weight)
+        if args.phase2_levels_per_strength < 1:
+            eprint("error: --phase2-levels-per-strength must be >= 1")
+            return 1
+        if args.recipes:
+            parse_recipe(args.recipes)
+
     out_dir = args.out_dir.resolve()
     out_dir.mkdir(parents=True, exist_ok=True)
 
@@ -2673,6 +2805,8 @@ def main() -> int:
         "weight_grid": args.weight_grid,
         "beam": args.beam,
         "max_passes": args.max_passes,
+        "phase2_levels_per_strength": args.phase2_levels_per_strength,
+        "recommend_weight": args.recommend_weight,
         "recipes": args.recipes,
         "layer_a_after": args.layer_a_after,
         "command": " ".join(
@@ -2708,6 +2842,8 @@ def main() -> int:
                 f"--weight-grid {args.weight_grid}",
                 f"--beam {args.beam}",
                 f"--max-passes {args.max_passes}",
+                f"--phase2-levels-per-strength {args.phase2_levels_per_strength}",
+                f"--recommend-weight {args.recommend_weight}",
                 *([f"--recipes {args.recipes}"] if args.recipes else []),
                 *(["--layer-a-after"] if args.layer_a_after else []),
                 *(["--restamp-control"] if args.restamp_control else []),

--- a/service/scripts/bench_synthid_text.py
+++ b/service/scripts/bench_synthid_text.py
@@ -166,7 +166,14 @@ def parse_weight_grid(spec: str) -> list[tuple[float, float, float]]:
         parts = raw.strip().split("/")
         if len(parts) != 3:
             raise SystemExit(f"error: bad weight vector {raw!r}; expected a/b/c")
-        w = tuple(float(x) for x in parts)
+        try:
+            w = tuple(float(x) for x in parts)
+        except ValueError:
+            raise SystemExit(f"error: non-numeric weight component in {raw!r}") from None
+        if not all(math.isfinite(c) for c in w):
+            raise SystemExit(f"error: weight vector {raw!r} must be finite")
+        if any(c < 0.0 for c in w):
+            raise SystemExit(f"error: weight vector {raw!r} must be non-negative")
         if abs(sum(w) - 1.0) > 1e-6:
             raise SystemExit(f"error: weight vector {raw!r} does not sum to 1.0")
         out.append((w[0], w[1], w[2]))  # type: ignore[assignment]
@@ -1596,18 +1603,18 @@ class Benchmark:
         weights = parse_weight_grid(a.weight_grid)
         recommend_w = parse_weight_vec(getattr(a, "recommend_weight", "0.5/0.3/0.2"))
         k = max(1, int(getattr(a, "phase2_levels_per_strength", 3)))
-        seen: set[tuple] = set()
+        evaluated: dict[tuple[tuple[str, float], ...], dict] = {}
         cands: list[dict] = []
 
         def _eval(recipe: list[tuple[str, float]]) -> dict | None:
             """eval."""
             key = tuple(recipe)
-            if key in seen:
-                return None
-            seen.add(key)
+            if key in evaluated:
+                return evaluated[key]
             axis = self._eval_recipe(recipe, samples)
             axis["steps"] = list(recipe)
             cands.append(axis)
+            evaluated[key] = axis
             return axis
 
         # Phase 1: per-strength intensity sweep (single-step recipes).
@@ -2756,6 +2763,12 @@ def main() -> int:
         parse_weight_vec(args.recommend_weight)
         if args.phase2_levels_per_strength < 1:
             eprint("error: --phase2-levels-per-strength must be >= 1")
+            return 1
+        if args.beam < 1:
+            eprint("error: --beam must be >= 1")
+            return 1
+        if args.max_passes < 1:
+            eprint("error: --max-passes must be >= 1")
             return 1
         if args.recipes:
             parse_recipe(args.recipes)

--- a/tests/test_bench_synthid_text.py
+++ b/tests/test_bench_synthid_text.py
@@ -564,6 +564,34 @@ def test_main_allow_remote_from_env(tmp_path, monkeypatch):
     assert bench.main() == 0
 
 
+def test_main_rejects_nonpositive_beam_or_max_passes(tmp_path, monkeypatch, capsys):
+    """A --beam or --max-passes below 1 fails fast in recipe mode.
+
+    Otherwise --beam 0 empties the beam (and --max-passes 0 skips all Phase 2
+    expansion) and the run reports a verdict from single-step candidates only.
+    """
+    (tmp_path / "markllm" / "watermark").mkdir(parents=True)
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    (corpus / "d1.txt").write_text("prompt", encoding="utf-8")
+    monkeypatch.setattr(bench, "Benchmark", _FakeBench)
+    base = [
+        "bench_synthid_text.py",
+        "--markllm-dir",
+        str(tmp_path / "markllm"),
+        "--corpus",
+        str(corpus),
+        "--rewrite-model",
+        "llama3.2",
+        "--mode",
+        "recipe",
+    ]
+    monkeypatch.setattr(sys, "argv", [*base, "--beam", "0"])
+    assert bench.main() == 1
+    monkeypatch.setattr(sys, "argv", [*base, "--max-passes", "0"])
+    assert bench.main() == 1
+
+
 def test_worker_publishes_port_env(tmp_path, monkeypatch):
     """A live worker publishes WATERMARKS_MARKLLM_PORT for child processes."""
 
@@ -1243,6 +1271,17 @@ def test_parse_weight_grid():
         parse_weight_grid("0.5/0.5/0.5")  # does not sum to 1.0
     with pytest.raises(SystemExit):
         parse_weight_grid("0.33/0.33/0.33")  # sums to 0.99
+    # Non-numeric, non-finite, and negative components must be rejected before
+    # (or independently of) the sum check; NaN/negative vectors slip through a
+    # sum-only check because NaN comparisons are false and -1/1/1 sums to 1.0.
+    with pytest.raises(SystemExit):
+        parse_weight_grid("a/0.5/0.5")  # non-numeric
+    with pytest.raises(SystemExit):
+        parse_weight_grid("nan/nan/nan")  # non-finite
+    with pytest.raises(SystemExit):
+        parse_weight_grid("inf/0.5/0.5")  # non-finite
+    with pytest.raises(SystemExit):
+        parse_weight_grid("-1/1/1")  # negative cumulative
 
 
 def test_parse_weight_vec():
@@ -1253,6 +1292,8 @@ def test_parse_weight_vec():
         parse_weight_vec("0.5/0.5")  # not three components
     with pytest.raises(SystemExit):
         parse_weight_vec("0.33/0.33/0.33")  # sums to 0.99
+    # A zero weight is a legitimate "ignore this axis" vector.
+    assert parse_weight_vec("0.0/0.5/0.5") == (0.0, 0.5, 0.5)
 
 
 def test_weighted_score():
@@ -1455,6 +1496,61 @@ def test_recipe_search_explores_intensity_and_order(tmp_path, monkeypatch):
     # The recommended recipe comes from the weight-independent frontier.
     assert res["recommended"] is not None
     assert res["recommended"]["steps"]
+
+
+def test_recipe_search_reuses_evaluated_recipe_across_weights(tmp_path, monkeypatch):
+    """A recipe shared by two weight vectors stays eligible for the later beam.
+
+    Regression: `_eval` used to return None for a recipe already evaluated under
+    an earlier weight vector, which dropped it from the later vector's beam and
+    left its descendants unexplored. Here chunk is anti-correlated: the removal
+    weight vector picks chunk@0.2 while the semantic weight vector picks
+    chunk@1.0, so both weights share prefixes like paraphrase@1.0+backtranslate
+    @1.0 but diverge on the chunk tail. The cache must return the already-evaluated
+    axis so the semantic vector keeps that prefix in its beam and explores the
+    chunk@1.0 descendants.
+    """
+    axis = {
+        "paraphrase": {1.0: (1.0, 0.1, 0.9), 0.2: (0.2, 0.9, 0.2)},
+        "backtranslate": {1.0: (1.0, 0.1, 0.9), 0.2: (0.2, 0.9, 0.2)},
+        "structural": {1.0: (1.0, 0.1, 0.9), 0.2: (0.2, 0.9, 0.2)},
+        "humanize": {1.0: (1.0, 0.1, 0.9), 0.2: (0.2, 0.9, 0.2)},
+        "chunk": {1.0: (0.1, 0.1, 0.9), 0.2: (1.0, 0.9, 0.2)},
+    }
+
+    def evaluate(recipe, samples=None):
+        robust = []
+        semi = []
+        human = []
+        for strength, level in recipe:
+            r, s, h = axis[strength][level]
+            robust.append(r)
+            semi.append(s)
+            human.append(h)
+        return {
+            "robust_clear_rate": round(sum(robust) / len(robust), 4),
+            "sem_div": round(sum(semi) / len(semi), 4),
+            "human_like": round(sum(human) / len(human), 4),
+            "n": 2,
+            "unverified": 0,
+        }
+
+    args = _args(
+        out_dir=tmp_path,
+        intensity_grid="0.2,1.0",
+        weight_grid="1.0/0.0/0.0,0.0/1.0/0.0",
+        beam=8,
+        max_passes=3,
+        phase2_levels_per_strength=1,
+        recommend_weight="0.5/0.3/0.2",
+    )
+    b = bench.Benchmark(args, Path(args.markllm_dir))
+    monkeypatch.setattr(b, "_eval_recipe", evaluate)
+    samples = [{"excluded": False, "watermarked": "watermarked:1", "before": DETECT_POS}]
+    res = b.recipe_search(samples, tmp_path / "work")
+
+    seen = {tuple(c["steps"]) for c in res["candidates"]}
+    assert (("paraphrase", 1.0), ("backtranslate", 1.0), ("chunk", 1.0)) in seen
 
 
 def test_human_likeness_backend_fallback():

--- a/tests/test_bench_synthid_text.py
+++ b/tests/test_bench_synthid_text.py
@@ -23,8 +23,11 @@ sys.path.insert(0, str(SCRIPTS))
 import bench_synthid_text as bench
 from bench_synthid_text import (
     _auc,
+    _best_on_frontier,
     _pareto_frontier,
     _parse_stats_json,
+    _recipe_verdict,
+    _weighted_score,
     aggregate,
     estimate_tokens,
     load_corpus,
@@ -32,6 +35,7 @@ from bench_synthid_text import (
     parse_recipe,
     parse_variants,
     parse_weight_grid,
+    parse_weight_vec,
 )
 
 DETECT_POS = {"available": True, "is_watermarked": True, "score": 2.0}
@@ -88,9 +92,11 @@ def _args(**overrides):
         human_backend="stylometry",
         human_detector_dir=None,
         intensity_grid="0.2,0.4,0.6,0.8,1.0",
-        weight_grid="0.8/0.1/0.1,0.5/0.3/0.2,0.2/0.6/0.2,0.2/0.2/0.6,0.33/0.33/0.33",
+        weight_grid="0.8/0.1/0.1,0.5/0.3/0.2,0.2/0.6/0.2,0.2/0.2/0.6,0.34/0.33/0.33",
         beam=4,
         max_passes=3,
+        phase2_levels_per_strength=3,
+        recommend_weight="0.5/0.3/0.2",
         recipes=None,
         layer_a_after=False,
     )
@@ -1227,10 +1233,75 @@ def test_parse_recipe_valid_and_invalid():
 
 def test_parse_weight_grid():
     assert parse_weight_grid("0.8/0.1/0.1,0.5/0.3/0.2") == [(0.8, 0.1, 0.1), (0.5, 0.3, 0.2)]
+    # The out-of-the-box default grid must be valid (each vector sums to 1.0);
+    # a 0.33/0.33/0.33 vector sums to 0.99 and is rejected.
+    default_grid = "0.8/0.1/0.1,0.5/0.3/0.2,0.2/0.6/0.2,0.2/0.2/0.6,0.34/0.33/0.33"
+    assert len(parse_weight_grid(default_grid)) == 5
     with pytest.raises(SystemExit):
         parse_weight_grid("0.5/0.5")  # not three components
     with pytest.raises(SystemExit):
         parse_weight_grid("0.5/0.5/0.5")  # does not sum to 1.0
+    with pytest.raises(SystemExit):
+        parse_weight_grid("0.33/0.33/0.33")  # sums to 0.99
+
+
+def test_parse_weight_vec():
+    assert parse_weight_vec("0.5/0.3/0.2") == (0.5, 0.3, 0.2)
+    with pytest.raises(SystemExit):
+        parse_weight_vec("0.5/0.3/0.2,0.1/0.2/0.7")  # more than one vector
+    with pytest.raises(SystemExit):
+        parse_weight_vec("0.5/0.5")  # not three components
+    with pytest.raises(SystemExit):
+        parse_weight_vec("0.33/0.33/0.33")  # sums to 0.99
+
+
+def test_weighted_score():
+    axis = {"robust_clear_rate": 0.8, "sem_div": 0.2, "human_like": 0.7}
+    assert round(_weighted_score(axis, (1.0, 0.0, 0.0)), 4) == 0.8
+    assert round(_weighted_score(axis, (0.0, 1.0, 0.0)), 4) == 0.8  # 1 - sem = 0.8
+    assert round(_weighted_score(axis, (0.0, 0.0, 1.0)), 4) == 0.7
+    assert (
+        _weighted_score({"robust_clear_rate": None, "sem_div": 0.2, "human_like": 0.7}, (1, 0, 0))
+        is None
+    )
+
+
+def test_best_on_frontier_shifts_with_weight():
+    a = {"steps": [("chunk", 0.6)], "robust_clear_rate": 1.0, "sem_div": 0.9, "human_like": 0.1}
+    b = {
+        "steps": [("paraphrase", 0.3)],
+        "robust_clear_rate": 0.0,
+        "sem_div": 0.1,
+        "human_like": 1.0,
+    }
+    pick_removal = _best_on_frontier([a, b], [a, b], (1.0, 0.0, 0.0))
+    pick_human = _best_on_frontier([a, b], [a, b], (0.0, 0.0, 1.0))
+    assert pick_removal["steps"] == [("chunk", 0.6)]
+    assert pick_human["steps"] == [("paraphrase", 0.3)]
+    # Empty frontier falls back to the best candidate under the weight.
+    fallback = _best_on_frontier([], [a, b], (1.0, 0.0, 0.0))
+    assert fallback["steps"] == [("chunk", 0.6)]
+
+
+def test_recipe_verdict():
+    def c(rate):
+        return {"robust_clear_rate": rate, "sem_div": 0.2, "human_like": 0.7}
+
+    assert _recipe_verdict([c(1.0)]) == "removable"
+    assert _recipe_verdict([c(0.5)]) == "partial"
+    assert _recipe_verdict([c(0.0)]) == "resists"
+    assert _recipe_verdict([]) == "undetermined"
+    assert _recipe_verdict([{"sem_div": 0.2, "human_like": 0.7}]) == "undetermined"
+
+
+def test_render_recipe_verdict_resists():
+    res = {
+        "candidates": [{"robust_clear_rate": 0.0, "sem_div": 0.8, "human_like": 0.2}],
+        "verdict": "resists",
+    }
+    text = bench._render_recipe_verdict(res)
+    assert "resists" in text.lower()
+    assert "at this token length" in text.lower()
 
 
 def test_parse_float_grid():
@@ -1341,6 +1412,49 @@ def test_compose_recipe_applies_steps_in_order(tmp_path, monkeypatch):
     assert calls[0] == ("chunk", 0.6, "base")
     assert calls[1] == ("paraphrase", 0.3, "base|chunk")  # step 1 output feeds step 2
     assert out == "base|chunk|paraphrase"
+
+
+def _spot_eval(recipe):
+    """Deterministic stand-in for _eval_recipe used by the recipe_search smoke test."""
+    n = len(recipe)
+    max_lv = max(lv for _s, lv in recipe)
+    rob = min(1.0, 0.2 * n + 0.1 * max_lv)
+    sem = 0.1 * n + 0.05 * (1.0 - max_lv)
+    human = 0.4 + 0.1 * min(n, 2)
+    return {
+        "robust_clear_rate": round(rob, 4),
+        "sem_div": round(sem, 4),
+        "human_like": round(human, 4),
+        "n": 2,
+        "unverified": 0,
+    }
+
+
+def test_recipe_search_explores_intensity_and_order(tmp_path, monkeypatch):
+    args = _args(
+        out_dir=tmp_path,
+        intensity_grid="0.2,0.8,1.0",
+        weight_grid="0.5/0.3/0.2",
+        beam=4,
+        max_passes=3,
+        phase2_levels_per_strength=3,
+        recommend_weight="0.5/0.3/0.2",
+    )
+    b = bench.Benchmark(args, Path(args.markllm_dir))
+    monkeypatch.setattr(b, "_eval_recipe", lambda recipe, _samples: _spot_eval(recipe))
+    samples = [{"excluded": False, "watermarked": "watermarked:1", "before": DETECT_POS}]
+    res = b.recipe_search(samples, tmp_path / "work")
+
+    # High-intensity levels are actually explored, not frozen to one best level.
+    levels_seen = {lv for c in res["candidates"] for _s, lv in c["steps"]}
+    assert any(lv > 0.2 for lv in levels_seen)
+    # Ordered composition never re-uses a strength.
+    for c in res["candidates"]:
+        strengths = [s for s, _lv in c["steps"]]
+        assert len(strengths) == len(set(strengths))
+    # The recommended recipe comes from the weight-independent frontier.
+    assert res["recommended"] is not None
+    assert res["recommended"]["steps"]
 
 
 def test_human_likeness_backend_fallback():

--- a/tests/test_bench_synthid_text.py
+++ b/tests/test_bench_synthid_text.py
@@ -574,7 +574,14 @@ def test_main_rejects_nonpositive_beam_or_max_passes(tmp_path, monkeypatch, caps
     corpus = tmp_path / "corpus"
     corpus.mkdir()
     (corpus / "d1.txt").write_text("prompt", encoding="utf-8")
-    monkeypatch.setattr(bench, "Benchmark", _FakeBench)
+    built = []
+
+    class _RecordingBench(_FakeBench):
+        def __init__(self, *args, **kwargs):
+            built.append(True)
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(bench, "Benchmark", _RecordingBench)
     base = [
         "bench_synthid_text.py",
         "--markllm-dir",
@@ -590,6 +597,8 @@ def test_main_rejects_nonpositive_beam_or_max_passes(tmp_path, monkeypatch, caps
     assert bench.main() == 1
     monkeypatch.setattr(sys, "argv", [*base, "--max-passes", "0"])
     assert bench.main() == 1
+    # The validation must fail before Benchmark (worker/semantic backend) starts.
+    assert built == []
 
 
 def test_worker_publishes_port_env(tmp_path, monkeypatch):


### PR DESCRIPTION
## Intro — the 20-min window limitation

This benchmark runs a **live MarkLLM generation/detection pass** plus a rewrite backend (a model loaded and invoked per call), so a full search over the corpus can take a very long time. The environment enforces a **wall-clock tolerance of roughly ~20 minutes** per run: anything longer may be killed before it writes results. That is exactly what happened to the prior full run — it was **killed by the environment mid-search after ~1.5 h** and produced no results. The current run was therefore relaunched at a smaller, bounded size (4 docs × 2 seeds, 3 intensities, 4 weight vectors, beam 3, max-passes 2) to land inside the ~20 min window.

This window is the central constraint on this change. The old default weight grid was **invalid**, and the old order-only search was **too narrow** to answer the motivating question; the fix and the redesign must widen the spectrum **without blowing past the runtime budget**. That is why the search now exposes a `--phase2-levels-per-strength` cap.

## Objective — “can this mark be removed at 300 tokens?”

The run answers a concrete question: **can this mark be removed at 300 tokens?** (short-document robustness). To answer it the search must cover the aggressive end of the recipe space — higher intensities, more aggressive multi-step recipes, and a realistic `--target-margin` for a short doc. If the tightened run still can't clear the mark, the honest finding is that at 300 tokens the **mark resists these attacks**, which the report now states explicitly instead of leaving an empty frontier to interpret.

## What changed

Follow-up to #280 (recipe search). **`bench_synthid_text.py`**
- **Weight-grid fix:** `--weight-grid` default `0.33/0.33/0.33` → `0.34/0.33/0.33`. The old vector sums to 0.99 and was rejected by `parse_weight_grid` *only after* the expensive generation pass had already run, wasting the run. Now the grid/spec/recommend-weight are parsed and validated **up front** (fail fast) before generation.
- **Recipe-search redesign:** Phase 2 now ranks each weight vector's top `--phase2-levels-per-strength` intensities per strength and runs an **intensity × order** beam search (each strength used at most once), instead of freezing every strength to one intensity picked under a single hardcoded weight. This reaches high-intensity and aggressive multi-step recipes.
- **Recommended recipe:** picked from the weight-independent **Pareto frontier** under `--recommend-weight` (default `0.5/0.3/0.2`), replacing the old hardcoded-weight global winner that could be off-frontier.
- **Honest verdict:** `recipe_search` returns a `verdict` (`removable` / `partial` / `resists` / `undetermined`); the report renders a **Verdict** section so “the mark resists the searched attacks at this token length” is explicit.

New flags: `--phase2-levels-per-strength` (default 3) and `--recommend-weight` (default `0.5/0.3/0.2`), both wired into the config/command string and validated in the fail-fast path.

**Docs:** `docs/synthid-text-benchmark.md` updated to describe the intensity × order search, the new flags, the verdict, and the budget lever.

## Tests

Added: `parse_weight_vec` validation, `_weighted_score`, `_best_on_frontier` (recommend shifts with weight), `_recipe_verdict` (removable/partial/resists/undetermined), the `resists` report rendering, and a monkeypatched `recipe_search` smoke that confirms intensity variance and no strength re-use. The pre-existing `0.33/0.33/0.33` regression test is retained. Full suite + `ruff` pass.

## Runtime note

Widening the spectrum costs more evals per run. To stay inside the ~20-min window, shrink docs×seeds, `--intensity-grid`, `--weight-grid`, `--beam`, `--max-passes`, or `--phase2-levels-per-strength`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded recipe search to explore strength orderings and per-strength intensities.
  * Added configurable search breadth and recommendation weights.
  * Recommendations now balance multiple criteria and provide fallback results when needed.
  * Reports show removable, partial, resistant, or undetermined verdicts.
  * Added clear reporting when no recipe meets watermark criteria.
  * Added validation for search settings and saved configuration details for reproducibility.

* **Documentation**
  * Updated recipe-search guidance, recommendation behavior, verdicts, and runtime-budget controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->