### PR TITLE
feat(bench): add Pangram bulk API as a human-likeness backend

### DIFF
--- a/docs/synthid-text-benchmark.md
+++ b/docs/synthid-text-benchmark.md
@@ -290,8 +290,11 @@ unless you want the raw samples.
   complements clear %: a row that clears by a hair still moves AUROC little,
   while a row that erases the mark's distributional signal drives AUROC toward
   0.5. Requires `--restamp-control`; degrades to `—` otherwise.
-- **human ↓.** AI-likeness under `--human-backend` (stylometry by default, or an
-  optional offline detector). A gauge, not a proof of human authorship.
+- **human ↓.** AI-likeness under `--human-backend`: `stylometry` (default,
+  stdlib), `lastde`/`binoculars` (offline `ai_human.py` checkout), or `pangram`
+  (Pangram Labs async **bulk** API; key in `PANGRAM_API_KEY`, model via
+  `--human-pangram-model`). A gauge, not a proof of human authorship; a missing
+  key/backend degrades to stylometry.
 
 ## Recipe search mode (`--mode recipe`)
 

--- a/docs/synthid-text-benchmark.md
+++ b/docs/synthid-text-benchmark.md
@@ -290,11 +290,12 @@ unless you want the raw samples.
   complements clear %: a row that clears by a hair still moves AUROC little,
   while a row that erases the mark's distributional signal drives AUROC toward
   0.5. Requires `--restamp-control`; degrades to `—` otherwise.
-- **human ↓.** AI-likeness under `--human-backend`: `stylometry` (default,
-  stdlib), `lastde`/`binoculars` (offline `ai_human.py` checkout), or `pangram`
-  (Pangram Labs async **bulk** API; key in `PANGRAM_API_KEY`, model via
-  `--human-pangram-model`). A gauge, not a proof of human authorship; a missing
-  key/backend degrades to stylometry.
+- **human_like ↑** (`1 − AI-likeness`) under `--human-backend`: `stylometry`
+  (default, stdlib), `lastde`/`binoculars` (offline `ai_human.py` checkout), or
+  `pangram` (Pangram Labs async **bulk** API; key in `PANGRAM_API_KEY`, model via
+  `--human-pangram-model`). In the variants table the same backend score is
+  shown as raw `AI-likeness ↓`. A gauge, not a proof of human authorship; a
+  missing key/backend degrades to stylometry.
 
 ## Recipe search mode (`--mode recipe`)
 

--- a/service/scripts/bench_synthid_text.py
+++ b/service/scripts/bench_synthid_text.py
@@ -775,6 +775,9 @@ class HumanLikeness:
             if time.monotonic() > deadline:
                 raise TimeoutError("pangram bulk job timed out")
             time.sleep(2.0)
+        if status == "failed":
+            # Every item failed; trigger score_many's stylometry fallback.
+            raise RuntimeError("pangram bulk job failed (all items failed)")
         scores: dict[str, float | None] = {}
         offset = 0
         while True:
@@ -2217,7 +2220,7 @@ def render_markdown(
     L.append("")
     post = (auroc or {}).get("post") or {}
     L.append(
-        "| Variant | n | clear % | robust % | Δscore μ | margin μ | lex div | sem div | human ↓ | AUROC ↓ | len ratio | nums keep | tok out | att | s/doc | clears/MTok | noop |"
+        "| Variant | n | clear % | robust % | Δscore μ | margin μ | lex div | sem div | AI-likeness ↓ | AUROC ↓ | len ratio | nums keep | tok out | att | s/doc | clears/MTok | noop |"
     )
     L.append(
         "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
@@ -2460,7 +2463,7 @@ def render_markdown_recipe(
     if not front:
         L.append("No recipe had all three axes available; the frontier is empty.")
     else:
-        L.append("| recipe | robust % | sem div | human_like |")
+        L.append("| recipe | robust % | sem div | human_like ↑ |")
         L.append("| --- | ---: | ---: | ---: |")
         for c in front:
             L.append(
@@ -2477,7 +2480,7 @@ def render_markdown_recipe(
         for strength, rows in curves.items():
             L.append(f"### {strength}")
             L.append("")
-            L.append("| level | robust % | sem div | human_like |")
+            L.append("| level | robust % | sem div | human_like ↑ |")
             L.append("| ---: | ---: | ---: | ---: |")
             for r in rows:
                 L.append(
@@ -2965,7 +2968,7 @@ def main() -> int:
         "noop_lex_floor": args.noop_lex_floor,
         "human_backend": args.human_backend,
         "human_detector_dir": args.human_detector_dir,
-        "human_pangram_model": args.human_pangram_model,
+        "human_pangram_model": bench.human.pangram_model,
         "human_backend_used": bench.human.backend_used,
         "intensity_grid": args.intensity_grid,
         "weight_grid": args.weight_grid,

--- a/service/scripts/bench_synthid_text.py
+++ b/service/scripts/bench_synthid_text.py
@@ -2208,8 +2208,15 @@ def render_markdown(
     )
     L.append("")
     L.append(
-        "**Human ↓:** AI-likeness under the configured human-likeness backend "
-        f"({config.get('human_backend', 'stylometry')}); lower = more human. "
+        "**AI-likeness ↓:** the configured human-likeness backend "
+        f"({config.get('human_backend', 'stylometry')}"
+        + (
+            f", using {config.get('human_backend_used')}"
+            if config.get("human_backend_used")
+            else ""
+        )
+        + (f" - {config.get('human_backend_reason')}" if config.get("human_backend_reason") else "")
+        + "); lower = more human. "
         "**AUROC ↓:** post-removal AUROC (rewritten-watermarked vs rewritten-plain "
         "scores); closer to 0.5 = the rewritten population is less separable "
         "(more removal). **noop:** rewrites that returned ≈ their input (see "
@@ -2410,6 +2417,7 @@ def render_markdown_recipe(
             if config.get("human_backend_used")
             else ""
         )
+        + (f" - {config.get('human_backend_reason')}" if config.get("human_backend_reason") else "")
     )
     L.append(f"- Semantic model: {config.get('semantic_model') or 'not configured'}")
     L.append("")
@@ -3059,6 +3067,11 @@ def main() -> int:
             rows = bench.run_variants(samples, workdir)
     finally:
         bench.close_worker()
+
+    # Scoring is done; reflect any backend fallback (e.g. Pangram -> stylometry)
+    # that happened while measuring, so the report labels the scores correctly.
+    config["human_backend_used"] = bench.human.backend_used
+    config["human_backend_reason"] = bench.human.reason()
 
     if args.mode == "minimal":
         agg = aggregate_minimal(rows)

--- a/service/scripts/bench_synthid_text.py
+++ b/service/scripts/bench_synthid_text.py
@@ -603,26 +603,63 @@ class HumanLikeness:
     """Human-likeness axis: stylometry (always on) or an optional detector.
 
     ``score(text)`` returns AI-likeness in [0,1] (lower = more human);
-    ``human_like = 1 - score``. For 'lastde'/'binoculars' the caller supplies a
-    checkout via ``--human-detector-dir`` that contains an ``ai_human.py``
-    module exposing ``score(text) -> float`` (AI-likeness). If it cannot be
-    imported the backend degrades to the stdlib stylometry score, reported via
+    ``human_like = 1 - score``. Backends:
+
+    - 'stylometry' (default): stdlib-only burstiness/MATTR/AI-phrase gauge.
+    - 'lastde'/'binoculars': an offline ``ai_human.py`` module in
+      ``--human-detector-dir`` exposing ``score(text) -> float``.
+    - 'pangram': the Pangram Labs async **bulk** API (``--human-pangram-model``,
+      API key in ``PANGRAM_API_KEY``). Batching is via ``score_many`` (one bulk
+      job per call); ``score`` is a one-item bulk job.
+
+    A backend that fails to load or run degrades to stylometry, reported via
     ``reason()``. Stylometry returns ``None`` (uncalibrated) below
     ``MIN_SAMPLE_WORDS`` words; the caller excludes those from averages.
     """
 
-    def __init__(self, backend: str, detector_dir: str | None = None) -> None:
-        """init."""
+    PANGRAM_BASE_URL = "https://text.external-api.pangram.com"
+
+    def __init__(
+        self, backend: str, detector_dir: str | None = None, pangram_model: str | None = None
+    ) -> None:
+        """HumanLikeness."""
         self.backend = backend
         self.detector_dir = detector_dir
+        self.pangram_model = pangram_model or "pangram-4"
         self.backend_used = "stylometry"
         self._failed: str | None = None
         self._detector = None
+        self._pangram_key: str | None = None
+        self._pangram_models: list[str] | None = None
         self._load()
 
     def _load(self) -> None:
-        """load."""
+        """Load the requested backend (fail-soft to stylometry)."""
         if self.backend == "stylometry":
+            return
+        if self.backend == "pangram":
+            key = os.environ.get("PANGRAM_API_KEY")
+            if not key:
+                self._failed = "PANGRAM_API_KEY not set"
+                return
+            self._pangram_key = key
+            try:
+                models = self._pangram_request("GET", "/models") or {}
+                self._pangram_models = list(models.get("models") or [])
+            except Exception as e:  # fail-soft: auth / network / bad key
+                self._pangram_key = None
+                self._failed = f"pangram unavailable: {e}"
+                return
+            allowed = self._pangram_models
+            if self.pangram_model not in allowed:
+                self.pangram_model = (
+                    "default" if "default" in allowed else (allowed[0] if allowed else None)
+                )
+                if self.pangram_model is None:
+                    self._failed = f"no pangram model available ({allowed})"
+                    return
+            self._pangram_key = key
+            self.backend_used = "pangram"
             return
         if not self.detector_dir:
             self._failed = f"{self.backend} requires --human-detector-dir"
@@ -643,21 +680,29 @@ class HumanLikeness:
 
     def available(self) -> bool:
         """Available."""
-        return True  # stylometry fallback always scores
+        return True  # a fallback always scores
 
     def reason(self) -> str | None:
         """Reason."""
         return self._failed
 
-    def score(self, text: str) -> float | None:
-        """Score human-likeness of text."""
-        if self._detector is not None:
-            try:
-                v = self._detector(text)
-                return round(float(v), 4) if isinstance(v, (int, float)) else None
-            except Exception as e:
-                self._detector = None
-                self._failed = f"detector error: {e}"
+    def _pangram_request(self, method: str, path: str, body: dict | None = None) -> dict:
+        """Talk to the Pangram text API over https (no shell; urllib only)."""
+        import urllib.request
+
+        url = self.PANGRAM_BASE_URL + path
+        if not (url.startswith("https://") or url.startswith("http://")):
+            raise ValueError(f"refusing non-http(s) pangram endpoint: {url}")
+        req = urllib.request.Request(url, method=method)  # noqa: S310 - scheme checked above
+        req.add_header("x-api-key", self._pangram_key or "")
+        req.add_header("Content-Type", "application/json")
+        if body is not None:
+            req.data = json.dumps(body).encode("utf-8")
+        with urllib.request.urlopen(req, timeout=30.0) as resp:  # noqa: S310
+            return json.loads(resp.read().decode("utf-8"))
+
+    def _stylometry(self, text: str) -> float | None:
+        """Stdlib stylometry score."""
         try:
             from score_stylometry import score_text_stylometry
 
@@ -668,6 +713,93 @@ class HumanLikeness:
         except Exception as e:
             self._failed = f"stylometry failed: {e}"
             return None
+
+    def _pangram_answer_score(self, result: dict | None) -> float | None:
+        """AI-likeness from a Pangram result: 1 - fraction_human (fallback fraction_ai)."""
+        if not isinstance(result, dict):
+            return None
+        fh = result.get("fraction_human")
+        if isinstance(fh, (int, float)):
+            return round(min(1.0, max(0.0, 1.0 - float(fh))), 4)
+        fa = result.get("fraction_ai")
+        if isinstance(fa, (int, float)):
+            return round(min(1.0, max(0.0, float(fa))), 4)
+        return None
+
+    def score_many(self, texts: list[str]) -> list[float | None]:
+        """Score many texts; the Pangram backend uses one async bulk job.
+
+        Non-Pangram backends fall back to per-text ``score``.
+        """
+        if self._pangram_key and self.backend_used == "pangram":
+            try:
+                return self._pangram_batch(texts)
+            except Exception as e:  # fail-soft: disable pangram, fall back to stylometry
+                self._failed = f"pangram error: {e}"
+                self.backend_used = "stylometry"
+                self._pangram_key = None
+        return [self.score(t) for t in texts]
+
+    def _pangram_batch(self, texts: list[str]) -> list[float | None]:
+        """Submit/poll/fetch one bulk job covering all texts; align results by id."""
+        import time
+
+        index_of: dict[str, int] = {}
+        items: list[dict] = []
+        for i, t in enumerate(texts):
+            if not t or not t.strip():
+                continue
+            index_of[str(i)] = i
+            items.append({"id": str(i), "text": t})
+        if not items:
+            return [None] * len(texts)
+        submit = self._pangram_request(
+            "POST", "/bulk", {"items": items, "model": self.pangram_model}
+        )
+        bulk_id = submit.get("bulk_id")
+        if not bulk_id:
+            raise RuntimeError(f"pangram bulk submit returned no bulk_id: {submit}")
+        deadline = time.monotonic() + 60.0  # overall wait before giving up
+        while True:
+            st = self._pangram_request("GET", f"/bulk/{bulk_id}")
+            status = st.get("status")
+            if status in ("succeeded", "failed", "partial"):
+                break
+            if time.monotonic() > deadline:
+                raise TimeoutError("pangram bulk job timed out")
+            time.sleep(2.0)
+        scores: dict[str, float | None] = {}
+        offset = 0
+        while True:
+            page = self._pangram_request(
+                "GET", f"/bulk/{bulk_id}/results?offset={offset}&limit=1000"
+            )
+            entries = page.get("items") or page.get("results") or []
+            if not entries:
+                break
+            for entry in entries:
+                id_ = str(
+                    entry.get("id") if entry.get("id") is not None else entry.get("index") or ""
+                )
+                scores[id_] = self._pangram_answer_score(entry.get("result"))
+            if len(entries) < 1000:
+                break
+            offset += len(entries)
+        return [scores.get(str(i)) for i in range(len(texts))]
+
+    def score(self, text: str) -> float | None:
+        """Score human-likeness of a single text."""
+        if self._pangram_key and self.backend_used == "pangram":
+            return self.score_many([text])[0]
+        if self._detector is not None:
+            try:
+                v = self._detector(text)
+                return round(float(v), 4) if isinstance(v, (int, float)) else None
+            except Exception as e:
+                self._detector = None
+                self.backend_used = "stylometry"
+                self._failed = f"detector error: {e}"
+        return self._stylometry(text)
 
 
 def _quality(
@@ -860,7 +992,9 @@ class Benchmark:
         self.corpus = load_corpus(args.corpus, args.docs)
         self.chars_per_token = args.chars_per_token
         self.semantic = SemanticEmbedder(args.semantic_model)
-        self.human = HumanLikeness(args.human_backend, args.human_detector_dir)
+        self.human = HumanLikeness(
+            args.human_backend, args.human_detector_dir, pangram_model=args.human_pangram_model
+        )
         self.scheme = args.scheme
         self.config = args.config
         self.worker = None
@@ -1522,6 +1656,8 @@ class Benchmark:
         final markllm after-report is available.
         """
         rows_in: list[dict[str, Any]] = []
+        outs: list[str] = []
+        score_at: list[int] = []
         for s in samples:
             if s.get("excluded"):
                 continue
@@ -1545,8 +1681,14 @@ class Benchmark:
                 cleared is True and margin is not None and margin >= self.args.target_margin - 1e-9
             )
             sem = self.semantic.score(orig, out) if self.semantic is not None else None
-            human = self.human.score(out)
-            rows_in.append({"robust": robust, "sem": sem, "human": human})
+            rows_in.append({"robust": robust, "sem": sem, "human": None})
+            outs.append(out)
+            score_at.append(len(rows_in) - 1)
+        if outs:
+            # Batch the human-likeness scoring (one Pangram bulk job per recipe).
+            scored = self.human.score_many(outs)
+            for idx, val in zip(score_at, scored, strict=True):
+                rows_in[idx]["human"] = val
         verified = [r for r in rows_in if r["robust"] is not None]
         n = len(verified)
         unverified = len(rows_in) - n
@@ -2531,18 +2673,26 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument(
         "--human-backend",
-        choices=("stylometry", "lastde", "binoculars"),
+        choices=("stylometry", "lastde", "binoculars", "pangram"),
         default="stylometry",
         help="Human-likeness axis. 'stylometry' (default) is the always-on "
         "stdlib-only score; 'lastde'/'binoculars' run an optional offline "
-        "AI-text detector (probed at startup, degrade to stylometry if absent). "
-        "Score is AI-likeness (lower = more human); human_like = 1 - score.",
+        "AI-text detector (probed at startup, degrade to stylometry if absent); "
+        "'pangram' uses the Pangram Labs async **bulk** API (key in "
+        "PANGRAM_API_KEY, model via --human-pangram-model). Score is AI-likeness "
+        "(lower = more human); human_like = 1 - score.",
     )
     p.add_argument(
         "--human-detector-dir",
         default=os.environ.get("HUMAN_DETECTOR_DIR"),
         help="Checkout root for the Lastde/Binoculars detector (default: "
         "$HUMAN_DETECTOR_DIR). Required when --human-backend is a detector.",
+    )
+    p.add_argument(
+        "--human-pangram-model",
+        default=os.environ.get("PANGRAM_MODEL", "pangram-4"),
+        help="Pangram model id (default: pangram-4; falls back to an allowed "
+        "model discovered via GET /models). Key is read from PANGRAM_API_KEY.",
     )
     p.add_argument(
         "--intensity-grid",
@@ -2668,6 +2818,7 @@ def main() -> int:
         "noop_lex_floor": args.noop_lex_floor,
         "human_backend": args.human_backend,
         "human_detector_dir": args.human_detector_dir,
+        "human_pangram_model": args.human_pangram_model,
         "human_backend_used": bench.human.backend_used,
         "intensity_grid": args.intensity_grid,
         "weight_grid": args.weight_grid,
@@ -2702,6 +2853,11 @@ def main() -> int:
                 *(
                     [f"--human-detector-dir {args.human_detector_dir}"]
                     if args.human_detector_dir
+                    else []
+                ),
+                *(
+                    [f"--human-pangram-model {args.human_pangram_model}"]
+                    if args.human_backend == "pangram"
                     else []
                 ),
                 f"--intensity-grid {args.intensity_grid}",

--- a/tests/test_bench_synthid_text.py
+++ b/tests/test_bench_synthid_text.py
@@ -1681,6 +1681,7 @@ def test_human_likeness_pangram_bulk_failed_falls_back(monkeypatch):
     # A job-level "failed" raises, so score_many degrades to stylometry.
     assert h.backend_used == "stylometry"
     assert scores == [None]  # short text -> stylometry uncalibrated
+    assert h.reason() and "failed" in h.reason()  # reason persisted for the report
 
 
 def test_human_likeness_pangram_model_fallback_resolved(monkeypatch):

--- a/tests/test_bench_synthid_text.py
+++ b/tests/test_bench_synthid_text.py
@@ -87,6 +87,7 @@ def _args(**overrides):
         noop_lex_floor=0.05,
         human_backend="stylometry",
         human_detector_dir=None,
+        human_pangram_model="pangram-4",
         intensity_grid="0.2,0.4,0.6,0.8,1.0",
         weight_grid="0.8/0.1/0.1,0.5/0.3/0.2,0.2/0.6/0.2,0.2/0.2/0.6,0.33/0.33/0.33",
         beam=4,
@@ -381,7 +382,9 @@ class _FakeBench:
         self.corpus = load_corpus(args.corpus, args.docs)
         self.chars_per_token = args.chars_per_token
         self.semantic = bench.SemanticEmbedder(args.semantic_model)
-        self.human = bench.HumanLikeness(args.human_backend, args.human_detector_dir)
+        self.human = bench.HumanLikeness(
+            args.human_backend, args.human_detector_dir, pangram_model=args.human_pangram_model
+        )
 
     def close_worker(self):
         pass
@@ -1351,6 +1354,93 @@ def test_human_likeness_backend_fallback():
     assert s is None or isinstance(s, (int, float))
     h2 = bench.HumanLikeness("stylometry")
     assert h2.backend_used == "stylometry"
+
+
+def test_human_likeness_pangram_requires_key(monkeypatch):
+    monkeypatch.delenv("PANGRAM_API_KEY", raising=False)
+    h = bench.HumanLikeness("pangram", None)
+    assert h.backend_used == "stylometry"
+    assert h.reason() and "PANGRAM_API_KEY" in h.reason()
+
+
+def test_pangram_answer_score():
+    h = bench.HumanLikeness("stylometry")
+    assert h._pangram_answer_score({"fraction_human": 0.2, "fraction_ai": 0.8}) == 0.8
+    assert h._pangram_answer_score({"fraction_human": None, "fraction_ai": 0.3}) == 0.3
+    assert h._pangram_answer_score({"fraction_ai": -0.1}) == 0.0  # clamped
+    assert h._pangram_answer_score({"fraction_ai": 1.7}) == 1.0  # clamped
+    assert h._pangram_answer_score({}) is None
+    assert h._pangram_answer_score(None) is None
+
+
+def test_human_likeness_pangram_bulk(monkeypatch):
+    monkeypatch.setenv("PANGRAM_API_KEY", "k")
+    calls: dict[str, object] = {}
+
+    def fake(method: str, path: str, body: dict | None = None) -> dict:
+        if path == "/models":
+            return {"models": ["pangram-4"]}
+        if method == "POST" and path == "/bulk":
+            calls["submit"] = body
+            return {"bulk_id": "blk_1", "status": "queued"}
+        if method == "GET" and path == "/bulk/blk_1":
+            return {"status": "succeeded", "succeeded": 2}
+        if method == "GET" and path.startswith("/bulk/blk_1/results"):
+            return {
+                "items": [
+                    {"id": "0", "result": {"prediction_short": "AI", "fraction_human": 0.1}},
+                    {"id": "1", "result": {"prediction_short": "Human", "fraction_human": 1.0}},
+                ]
+            }
+        raise AssertionError(f"unexpected pangram call {method} {path}")
+
+    monkeypatch.setattr(bench.HumanLikeness, "_pangram_request", staticmethod(fake))
+    h = bench.HumanLikeness("pangram", None)
+    assert h.backend_used == "pangram"
+    assert h.score_many(["aaa", "bbb"]) == [0.9, 0.0]  # 1 - fraction_human
+    assert calls["submit"]["model"] == "pangram-4"
+    assert len(calls["submit"]["items"]) == 2
+    assert h.reason() is None
+
+
+def test_human_likeness_pangram_batches_in_one_job(monkeypatch):
+    monkeypatch.setenv("PANGRAM_API_KEY", "k")
+    submits: list[dict] = []
+
+    def fake(method: str, path: str, body: dict | None = None) -> dict:
+        if path == "/models":
+            return {"models": ["pangram-4"]}
+        if method == "POST" and path == "/bulk":
+            submits.append(body or {})
+            return {"bulk_id": f"blk_{len(submits)}", "status": "queued"}
+        if method == "GET" and "/results" in path:
+            # echo back one result per submitted item id, aligned by index
+            n = len(submits[-1].get("items") or [])
+            return {"items": [{"id": str(i), "result": {"fraction_human": 0.0}} for i in range(n)]}
+        if method == "GET" and path.startswith("/bulk/blk_"):
+            return {"status": "succeeded"}
+        raise AssertionError(f"unexpected {method} {path}")
+
+    monkeypatch.setattr(bench.HumanLikeness, "_pangram_request", staticmethod(fake))
+    h = bench.HumanLikeness("pangram", None)
+    assert h.score_many(["x", "y", "z", ""]) == [1.0, 1.0, 1.0, None]  # empty -> None
+    assert len(submits) == 1  # one bulk job for all non-empty texts
+
+
+def test_human_likeness_pangram_fallback_on_error(monkeypatch):
+    monkeypatch.setenv("PANGRAM_API_KEY", "k")
+
+    def fake(method: str, path: str, body: dict | None = None) -> dict:
+        if path == "/models":
+            return {"models": ["pangram-4"]}
+        raise OSError("network down")
+
+    monkeypatch.setattr(bench.HumanLikeness, "_pangram_request", staticmethod(fake))
+    h = bench.HumanLikeness("pangram", None)
+    assert h.backend_used == "pangram"
+    scores = h.score_many(["text here enough words about watermarks"])
+    assert h.backend_used == "stylometry"  # degraded after batch error
+    assert all(s is None or isinstance(s, float) for s in scores)
 
 
 def test_render_markdown_recipe_and_csv():

--- a/tests/test_bench_synthid_text.py
+++ b/tests/test_bench_synthid_text.py
@@ -1662,6 +1662,42 @@ def test_human_likeness_pangram_fallback_on_error(monkeypatch):
     assert all(s is None or isinstance(s, float) for s in scores)
 
 
+def test_human_likeness_pangram_bulk_failed_falls_back(monkeypatch):
+    monkeypatch.setenv("PANGRAM_API_KEY", "k")
+
+    def fake(method: str, path: str, body: dict | None = None) -> dict:
+        if path == "/models":
+            return {"models": ["pangram-4"]}
+        if method == "POST" and path == "/bulk":
+            return {"bulk_id": "blk_1", "status": "queued"}
+        if method == "GET" and path == "/bulk/blk_1":
+            return {"status": "failed"}
+        raise AssertionError(f"unexpected {method} {path}")
+
+    monkeypatch.setattr(bench.HumanLikeness, "_pangram_request", staticmethod(fake))
+    h = bench.HumanLikeness("pangram", None)
+    assert h.backend_used == "pangram"
+    scores = h.score_many(["short text"])
+    # A job-level "failed" raises, so score_many degrades to stylometry.
+    assert h.backend_used == "stylometry"
+    assert scores == [None]  # short text -> stylometry uncalibrated
+
+
+def test_human_likeness_pangram_model_fallback_resolved(monkeypatch):
+    monkeypatch.setenv("PANGRAM_API_KEY", "k")
+
+    def fake(method: str, path: str, body: dict | None = None) -> dict:
+        if path == "/models":
+            return {"models": ["default"]}
+        raise AssertionError(f"unexpected {method} {path}")
+
+    monkeypatch.setattr(bench.HumanLikeness, "_pangram_request", staticmethod(fake))
+    h = bench.HumanLikeness("pangram", None, pangram_model="pangram-4")
+    assert h.backend_used == "pangram"
+    # The resolved (allowed) selector is persisted for the metadata field.
+    assert h.pangram_model == "default"
+
+
 def test_render_markdown_recipe_and_csv():
     rec = {
         "steps": [("chunk", 0.6)],


### PR DESCRIPTION
## What
Adds **`pangram`** as a new `--human-backend` choice, driving the Pangram Labs AI-text detector through its **async bulk API** — not the realtime/single-task path.

## How it uses bulk
- **`HumanLikeness`** gains a `pangram` backend: reads `PANGRAM_API_KEY`, `--human-pangram-model` (default `pangram-4`, auto-fallback to an allowed model from `GET /models`), https via `urllib` only (scheme validated; no shell).
- **`score_many(texts)`** submits **one `POST /bulk`** job per call, polls `GET /bulk/{id}` to a terminal status, then pages `GET /bulk/{id}/results` (limit 1000) and maps each item's `result` to AI-likeness = `1 - fraction_human` (`fraction_ai` fallback). `score(text)` is a one-item bulk job.
- **`_eval_recipe`** now batches human-likeness scoring across a recipe's outputs via `score_many()`, so a recipe search issues **one bulk job per recipe** (every sample's output in a single job) instead of one per sample.
- Degrades to stylometry on a missing key / network / model error (`reason()` reports why), matching the other backends.

## Tests (`tests/test_bench_synthid_text.py`)
- missing key → stylometry fallback + reason
- score extraction from `fraction_human`/`fraction_ai` (incl. clamping)
- one bulk job per `score_many`, alignment by item id, empty item → `None`
- degrade-to-stylometry on batch error

`ruff check`/`ruff format` clean; full suite passes. Live call not exercised here (no `PANGRAM_API_KEY` in this env) — the HTTP flow is mocked in tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Pangram Labs as a human-likeness evaluation option.
  * Added support for selecting Pangram models and processing scores in batches.
  * Added raw AI-likeness reporting and benchmark metadata for Pangram evaluations.
  * Added automatic fallback to stylometry when Pangram is unavailable or encounters an error.

* **Documentation**
  * Updated benchmark documentation with backend configuration, credentials, offline detectors, bulk scoring, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->