### PR TITLE
feat(stealer): add black-box watermark-stealing module and prompt corpus downloader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,11 +36,16 @@
 !/requirements-dev.txt
 !/ruff.toml
 !/SECURITY.md
+!/stealer/
+!/stealer/**
 
 # Exceptions even inside allowed trees
 .env
 **/__pycache__/
 *.pyc
+# The stealer's downloaded prompt corpus is generated data, not source.
+stealer/prompts/
+stealer/prompts/**
 .venv/
 .firecrawl/
 .figlet/

--- a/stealer/README.md
+++ b/stealer/README.md
@@ -43,6 +43,22 @@ step, subtract `delta * s*` from the candidate logits to demote green tokens;
 keep only paraphrases that stay similar and fail the detector.  `s*` can be
 applied directly by a caller via `scorer.apply_delta`.
 
+### The three models
+
+The full pipeline involves up to three models, but **`steal.py` only ever queries
+two of them**:
+
+| # | Role | Which model | Used by |
+| --- | --- | --- | --- |
+| 1 | **Target** — the watermarked model whose mark we extract | the model you want to cleanse | `steal.py query` (first run) |
+| 2 | **Baseline** — non-watermarked reference distribution | a *different* model (or old unwatermarked dumps) | `steal.py query` (second run) |
+| 3 | **Scrubber / paraphraser** — applies `s*` to logits at cleanup time | e.g. DIPPER | downstream; **not** called by `steal.py` |
+
+`build` and `detect` are **model-free**: they derive `s*` and score text with
+deterministic counting, so there is no third "analysis" LLM.  The baseline `#2`
+may be a different model from the target `#1` — the question the shared
+conversation started from.
+
 ## Quick start
 
 ```bash
@@ -66,7 +82,26 @@ python3 stealer/steal.py build --replies stealer/replies.jsonl \
 python3 stealer/steal.py detect --text "some text" --s-star stealer/s_star.json --ctx 8
 ```
 
-### Real model query
+### Configuring the target and baseline models
+
+Each `query` run talks to **one** model, so the target and baseline are each
+configured by their own `query` invocation (see the quick start above).  Point
+the target run at the model you want to cleanse and the baseline run at a
+different model:
+
+```bash
+# 1. Target — the watermarked model whose mark we're extracting.
+WATERMARKS_STEAL_BASE_URL=<url> WATERMARKS_STEAL_API_KEY=<key> \
+WATERMARKS_STEAL_MODEL=<target-model> \
+  python3 stealer/steal.py query --prompts stealer/prompts/prompts.jsonl \
+  --out stealer/replies.jsonl
+
+# 2. Baseline — a *different*, non-watermarked model.
+#    A loopback endpoint (e.g. local Ollama) needs no --allow-remote.
+WATERMARKS_STEAL_BASE_URL=<url> WATERMARKS_STEAL_MODEL=<baseline-model> \
+  python3 stealer/steal.py query --prompts stealer/prompts/prompts.jsonl \
+  --out stealer/baseline.jsonl
+```
 
 `query` reads the same env vars the rest of the repo uses for the rewrite
 backend (`WATERMARKS_REWRITE_*`) and mirrors them:
@@ -75,11 +110,13 @@ backend (`WATERMARKS_REWRITE_*`) and mirrors them:
 | --- | --- | --- |
 | `WATERMARKS_STEAL_BASE_URL` | `--base-url` | OpenAI-compatible base (default `https://api.openai.com/v1`) |
 | `WATERMARKS_STEAL_API_KEY` | `--api-key` | Key — env only, never on argv; empty = disable remote |
-| `WATERMARKS_STEAL_MODEL` | `--model` | Model to query |
+| `WATERMARKS_STEAL_MODEL` | `--model` | Model this run queries (target on run 1, baseline on run 2) |
 | `WATERMARKS_STEAL_ALLOW_REMOTE=1` | `--allow-remote` | Required to hit a non-loopback endpoint |
 
 Keys are read from the environment only.  `dry-run` writes deterministic
-placeholder replies so the rest of the pipeline runs without a model.
+placeholder replies so the rest of the pipeline runs without a model.  A
+baseline is optional but recommended — without it `build()` falls back to
+unigram statistics.
 
 ## Downloader
 

--- a/stealer/README.md
+++ b/stealer/README.md
@@ -15,7 +15,7 @@ estimator, not the true green set — see [the honest-use caveats](#honest-use).
 
 ## Layout
 
-```
+```text
 stealer/
   download_prompts.py   fetch a prompt corpus (default 30k C4 RealNewsLike)
   tokens.py             tokenizer + (context, next-token) counting
@@ -103,13 +103,14 @@ WATERMARKS_STEAL_BASE_URL=<url> WATERMARKS_STEAL_MODEL=<baseline-model> \
   --out stealer/baseline.jsonl
 ```
 
-`query` reads the same env vars the rest of the repo uses for the rewrite
-backend (`WATERMARKS_REWRITE_*`) and mirrors them:
+`query` reads these vars from the environment.  They mirror the repo's
+`WATERMARKS_REWRITE_*` naming under their own `WATERMARKS_STEAL_*` prefix, so the
+rewrite backend's settings never leak into a steal run:
 
 | Env var | Flag | Meaning |
 | --- | --- | --- |
 | `WATERMARKS_STEAL_BASE_URL` | `--base-url` | OpenAI-compatible base (default `https://api.openai.com/v1`) |
-| `WATERMARKS_STEAL_API_KEY` | `--api-key` | Key — env only, never on argv; empty = disable remote |
+| `WATERMARKS_STEAL_API_KEY` | — | Key — read from the environment only, never on argv |
 | `WATERMARKS_STEAL_MODEL` | `--model` | Model this run queries (target on run 1, baseline on run 2) |
 | `WATERMARKS_STEAL_ALLOW_REMOTE=1` | `--allow-remote` | Required to hit a non-loopback endpoint |
 
@@ -123,8 +124,9 @@ unigram statistics.
 `download_prompts.py` uses the Hugging Face datasets-server `rows` API
 (`allenai/c4`, config `realnewslike`), so it needs only the stdlib.  It applies
 `--min-chars` / `--max-chars` filtering, writes `prompts.jsonl` line-buffered,
-and checkpoints its offset in `prompts/.download-state.json` so a big run can be
-paused and resumed without re-fetching pages.
+and checkpoints after each complete page in `prompts/.download-state.json`, so a
+big run can be paused and resumed without duplicating or dropping rows — an
+interrupted page is rolled back to the last committed boundary.
 
 C4 RealNewsLike is news-article prose, not literally prompts; the module treats
 each passage as a query you send to the model.

--- a/stealer/README.md
+++ b/stealer/README.md
@@ -1,0 +1,111 @@
+# stealer
+
+Black-box watermark-stealing module for SynthID-class text watermarks, and the
+prompt-corpus downloader it runs on.  It implements the one-time **steal** step
+of the attack from the shared conversation (and the corresponding ETH SRI line
+of work on SynthID-Text detection): collect a large corpus of watermarked model
+replies, estimate how much each next token is boosted after each short context
+relative to a non-watermarked baseline, and emit that estimate as
+`s*(token | context)`.  A downstream cleaner can consume `s*` to demote the
+"green" tokens the watermark favors.
+
+This is research / robustness tooling for content and models you run or are
+authorized to test.  It does not recover the secret key, and `s*` is an
+estimator, not the true green set — see [the honest-use caveats](#honest-use).
+
+## Layout
+
+```
+stealer/
+  download_prompts.py   fetch a prompt corpus (default 30k C4 RealNewsLike)
+  tokens.py             tokenizer + (context, next-token) counting
+  scorer.py             build s* and apply it (score / demote / promote)
+  steal.py              CLI: query -> build -> detect
+  prompts/              where the downloaded corpus lands (prompts.jsonl)
+```
+
+## Steal pipeline
+
+The conversation describes three steps:
+
+1. **Query** the watermarked model with many benign prompts; collect long
+   watermarked replies.  (`steal.py query`)
+2. **Count** how often each next token follows each short context in the
+   watermarked replies, vs a non-watermarked baseline (a different model or
+   old unwatermarked dumps — the baseline model need not match the watermarked
+   one).  (`steal.py build`)
+3. Convert the ratios into a score `s*(token | context)`: high ⇒ "likely green
+   / watermark-boosted."  The output is **not** the secret key, but a reusable
+   table/function.  (`steal.py build --out s_star.json`)
+
+Then use `s*` to scrub: run a paraphraser on the text to clean and, at each
+step, subtract `delta * s*` from the candidate logits to demote green tokens;
+keep only paraphrases that stay similar and fail the detector.  `s*` can be
+applied directly by a caller via `scorer.apply_delta`.
+
+## Quick start
+
+```bash
+# 1. Corpus of prompts (30k C4 RealNewsLike passages) -> stealer/prompts/prompts.jsonl
+python3 stealer/download_prompts.py --count 30000
+
+# 2. Collect watermarked replies (dry-run by default; point at a model for real)
+python3 stealer/steal.py query --prompts stealer/prompts/prompts.jsonl \
+  --out stealer/replies.jsonl --backend openai-compatible --model <model>
+
+# 2b. Non-watermarked baseline replies from a different model (optional but
+#     recommended; without it build() falls back to unigram statistics)
+python3 stealer/steal.py query --prompts stealer/prompts/prompts.jsonl \
+  --out stealer/baseline.jsonl --backend openai-compatible --model <baseline-model>
+
+# 3. Derive s* (scorer table)
+python3 stealer/steal.py build --replies stealer/replies.jsonl \
+  --baseline stealer/baseline.jsonl --ctx 8 --topk 50 --out stealer/s_star.json
+
+# 4. Score a candidate text against the stolen scorer
+python3 stealer/steal.py detect --text "some text" --s-star stealer/s_star.json --ctx 8
+```
+
+### Real model query
+
+`query` reads the same env vars the rest of the repo uses for the rewrite
+backend (`WATERMARKS_REWRITE_*`) and mirrors them:
+
+| Env var | Flag | Meaning |
+| --- | --- | --- |
+| `WATERMARKS_STEAL_BASE_URL` | `--base-url` | OpenAI-compatible base (default `https://api.openai.com/v1`) |
+| `WATERMARKS_STEAL_API_KEY` | `--api-key` | Key — env only, never on argv; empty = disable remote |
+| `WATERMARKS_STEAL_MODEL` | `--model` | Model to query |
+| `WATERMARKS_STEAL_ALLOW_REMOTE=1` | `--allow-remote` | Required to hit a non-loopback endpoint |
+
+Keys are read from the environment only.  `dry-run` writes deterministic
+placeholder replies so the rest of the pipeline runs without a model.
+
+## Downloader
+
+`download_prompts.py` uses the Hugging Face datasets-server `rows` API
+(`allenai/c4`, config `realnewslike`), so it needs only the stdlib.  It applies
+`--min-chars` / `--max-chars` filtering, writes `prompts.jsonl` line-buffered,
+and checkpoints its offset in `prompts/.download-state.json` so a big run can be
+paused and resumed without re-fetching pages.
+
+C4 RealNewsLike is news-article prose, not literally prompts; the module treats
+each passage as a query you send to the model.
+
+To lift the unauthenticated datasets-server rate limit, export `HF_TOKEN` and
+the downloader sends it as a bearer header (env-only, never printed):
+
+```bash
+HF_TOKEN=$(cat ~/.hf_token) python3 stealer/download_prompts.py --count 30000
+```
+
+## Honest use
+
+- `s*` is a black-box estimate of the watermark's green-set prior.  It is valid
+  for the model family / context-length it was built against, and becomes stale
+  if the vendor changes the scheme.
+- This is the same honesty caveat the repo applies to its other same-scheme
+  harnesses: "same-config-only, not a vendor oracle."  A high `s*` removes the
+  *stolen* prior, not necessarily the mark a vendor's detector checks.
+- Remove provenance marks only on content **you own or are authorized to
+  process**; see [`skills/remove-ai-marks/references/ethics.md`](../skills/remove-ai-marks/references/ethics.md).

--- a/stealer/__init__.py
+++ b/stealer/__init__.py
@@ -1,0 +1,20 @@
+"""Black-box watermark-stealing module for SynthID-class text watermarks.
+
+This package implements the one-time "steal" step of the attack described in
+the shared conversation and in the ETH SRI line of work on SynthID-Text
+detection: query a watermarked model with a benign prompt corpus, count how
+often each next token follows each short context, compare those counts against
+a non-watermarked baseline, and derive a reusable scorer ``s*(token | context)``
+that ranks which tokens the watermark boosted ("green").  The scorer can then
+drive scrubbing (demote green tokens) or, sign-flipped, spoofing.
+
+Everything here is stdlib-only so it fits the rest of the repository.  The
+model-query step is pluggable and defaults to a dry-run so the pipeline runs
+offline; a real run points ``query`` at an OpenAI-compatible endpoint.
+"""
+
+from __future__ import annotations
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/stealer/download_prompts.py
+++ b/stealer/download_prompts.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Download a prompt corpus from a Hugging Face dataset via datasets-server.
+
+Default: 30k C4 RealNewsLike passages into ./stealer/prompts/prompts.jsonl.
+
+Stdlib only.  Uses the datasets-server ``rows`` API so it never depends on the
+``datasets`` / ``pyarrow`` packages.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+DATASETS_SERVER_BASE = "https://datasets-server.huggingface.co"
+DEFAULT_COUNT = 30_000
+DEFAULT_CONFIG = "realnewslike"
+DEFAULT_DATASET = "allenai/c4"
+
+
+def fetch_rows(base, dataset, config, split, offset, length, token=None):
+    """Return one page of rows as parsed JSON.
+
+    ``token`` (an ``hf_`` value from ``HF_TOKEN``) is sent as a bearer header; it
+    lifts the unauthenticated datasets-server rate limit.  The token is only
+    ever read from the environment and never printed.
+    """
+
+    query = urllib.parse.urlencode(
+        {
+            "dataset": dataset,
+            "config": config,
+            "split": split,
+            "offset": offset,
+            "length": length,
+        }
+    )
+    url = f"{base}/rows?{query}"
+    if not url.startswith(("https://", "http://")):
+        raise ValueError(f"refusing non-http(s) datasets-server URL: {url!r}")
+    headers = {"User-Agent": "watermarks-remover/stealer"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(url, headers=headers)  # noqa: S310
+    with urllib.request.urlopen(req, timeout=90) as resp:  # noqa: S310
+        return json.load(resp)
+
+
+def _retry_after(header):
+    """Parse a Retry-After header into seconds (capped), or 0 if absent/invalid."""
+
+    if not header:
+        return 0.0
+    try:
+        return max(1.0, min(float(header), 120.0))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def fetch_rows_retrying(
+    base,
+    dataset,
+    config,
+    split,
+    offset,
+    length,
+    token=None,
+    attempts=8,
+    base_delay=2.0,
+    max_delay=90.0,
+):
+    """Fetch rows, backoff on transient 5xx / 429 with jittered exponential delay.
+
+    Auth failures (400/401/403/404) are fatal; rate limits and 5xx wait out the
+    window (honoring ``Retry-After`` when present) and retry.
+    """
+
+    last = None
+    for attempt in range(attempts):
+        try:
+            return fetch_rows(base, dataset, config, split, offset, length, token=token)
+        except urllib.error.HTTPError as exc:
+            last = exc
+            if exc.code in (400, 401, 403, 404):
+                raise
+            delay = _retry_after(exc.headers.get("Retry-After")) if exc.headers else 0.0
+            if delay <= 0:
+                delay = min(max_delay, base_delay * (2.0**attempt) + random.uniform(0, 0.5))  # noqa: S311
+            print(f"  {exc.code}; retry in {delay:.1f}s", file=sys.stderr)
+            time.sleep(delay)
+        except (urllib.error.URLError, TimeoutError, ConnectionError) as exc:
+            last = exc
+            delay = min(max_delay, base_delay * (2.0**attempt) + random.uniform(0, 0.5))  # noqa: S311
+            print(f"  {exc}; retry in {delay:.1f}s", file=sys.stderr)
+            time.sleep(delay)
+    raise RuntimeError(f"could not fetch rows at offset {offset}: {last}")
+
+
+def load_state(state_path):
+    if state_path.exists():
+        try:
+            data = json.loads(state_path.read_text(encoding="utf-8"))
+            return int(data.get("next_offset", 0)), int(data.get("written", 0))
+        except (ValueError, json.JSONDecodeError):
+            pass
+    return 0, 0
+
+
+def save_state(state_path, next_offset, written):
+    state_path.write_text(
+        json.dumps({"next_offset": next_offset, "written": written}), encoding="utf-8"
+    )
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--dataset", default=DEFAULT_DATASET, help="HF dataset id")
+    p.add_argument("--config", default=DEFAULT_CONFIG, help="dataset config (subset)")
+    p.add_argument("--split", default="train", help="split to read")
+    p.add_argument("--count", type=int, default=DEFAULT_COUNT, help="number of passages to keep")
+    p.add_argument("--field", default="text", help="row field used as the prompt")
+    p.add_argument("--out", default=None, help="output directory (default: ./stealer/prompts)")
+    p.add_argument("--base-url", default=DATASETS_SERVER_BASE, help="datasets-server base URL")
+    p.add_argument("--delay", type=float, default=1.5, help="seconds between page requests")
+    p.add_argument("--min-chars", type=int, default=0, help="drop prompts shorter than this")
+    p.add_argument(
+        "--max-chars", type=int, default=0, help="truncate prompts longer than this (0 = keep)"
+    )
+    p.add_argument("--offset", type=int, default=0, help="row offset to start from")
+    p.add_argument("--start-over", action="store_true", help="ignore any resume state")
+    args = p.parse_args(argv)
+
+    out_dir = Path(args.out) if args.out else Path(__file__).resolve().parent / "prompts"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    prompts_path = out_dir / "prompts.jsonl"
+    state_path = out_dir / ".download-state.json"
+
+    token = os.environ.get("HF_TOKEN")
+
+    offset, written = (0, 0) if args.start_over else load_state(state_path)
+    if args.offset:
+        offset = args.offset
+    if args.start_over and prompts_path.exists():
+        prompts_path.unlink()
+
+    first = fetch_rows_retrying(
+        args.base_url, args.dataset, args.config, args.split, offset, 1, token=token
+    )
+    page_size = int(first.get("num_rows_per_page", 100))
+    page_size = max(1, min(page_size, 100))
+
+    if written == 0 and not prompts_path.exists():
+        prompts_path.write_text("", encoding="utf-8")
+
+    print(
+        f"downloading {args.dataset}:{args.config}:{args.split} "
+        f"({args.count} prompts) -> {prompts_path}"
+    )
+
+    try:
+        with prompts_path.open("a", encoding="utf-8") as fh:
+            while written < args.count:
+                rows = fetch_rows_retrying(
+                    args.base_url,
+                    args.dataset,
+                    args.config,
+                    args.split,
+                    offset,
+                    page_size,
+                    token=token,
+                )
+                items = rows.get("rows", [])
+                if not items:
+                    print("  no more rows", file=sys.stderr)
+                    break
+                for item in items:
+                    if written >= args.count:
+                        break
+                    text = (item.get("row") or {}).get(args.field)
+                    if not isinstance(text, str):
+                        continue
+                    if args.min_chars and len(text) < args.min_chars:
+                        continue
+                    if args.max_chars and len(text) > args.max_chars:
+                        text = text[: args.max_chars]
+                    fh.write(json.dumps({"text": text}, ensure_ascii=False) + "\n")
+                    written += 1
+                fh.flush()
+                offset += len(items)
+                save_state(state_path, offset, written)
+                if written % 1000 < page_size or written >= args.count:
+                    print(f"  {written}/{args.count} prompts")
+                time.sleep(args.delay)
+    except KeyboardInterrupt:
+        print("\ninterrupted; state saved, resume with --start-over off", file=sys.stderr)
+        save_state(state_path, offset, written)
+        return 130
+
+    if written >= args.count:
+        # Completing the run makes the resume offset meaningless; reset it.
+        save_state(state_path, offset, written)
+        print(f"done: {written} prompts in {prompts_path}")
+        return 0
+    print(f"stopped early: {written} prompts (dataset exhausted?)", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/stealer/download_prompts.py
+++ b/stealer/download_prompts.py
@@ -91,6 +91,8 @@ def fetch_rows_retrying(
             last = exc
             if exc.code in (400, 401, 403, 404):
                 raise
+            if attempt + 1 >= attempts:
+                break
             delay = _retry_after(exc.headers.get("Retry-After")) if exc.headers else 0.0
             if delay <= 0:
                 delay = min(max_delay, base_delay * (2.0**attempt) + random.uniform(0, 0.5))  # noqa: S311
@@ -98,6 +100,8 @@ def fetch_rows_retrying(
             time.sleep(delay)
         except (urllib.error.URLError, TimeoutError, ConnectionError) as exc:
             last = exc
+            if attempt + 1 >= attempts:
+                break
             delay = min(max_delay, base_delay * (2.0**attempt) + random.uniform(0, 0.5))  # noqa: S311
             print(f"  {exc}; retry in {delay:.1f}s", file=sys.stderr)
             time.sleep(delay)
@@ -105,6 +109,8 @@ def fetch_rows_retrying(
 
 
 def load_state(state_path):
+    """Return the persisted resume cursor ``(next_offset, written)``, or ``(0, 0)``."""
+
     if state_path.exists():
         try:
             data = json.loads(state_path.read_text(encoding="utf-8"))
@@ -115,12 +121,15 @@ def load_state(state_path):
 
 
 def save_state(state_path, next_offset, written):
+    """Persist the resume cursor as JSON."""
+
     state_path.write_text(
         json.dumps({"next_offset": next_offset, "written": written}), encoding="utf-8"
     )
 
 
 def main(argv=None) -> int:
+    """Fetch pages and append prompts until ``--count`` is reached, checkpointing per page."""
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--dataset", default=DEFAULT_DATASET, help="HF dataset id")
     p.add_argument("--config", default=DEFAULT_CONFIG, help="dataset config (subset)")
@@ -165,8 +174,11 @@ def main(argv=None) -> int:
         f"({args.count} prompts) -> {prompts_path}"
     )
 
+    committed_offset, committed_written = offset, written
+    committed_bytes = 0
     try:
         with prompts_path.open("a", encoding="utf-8") as fh:
+            committed_bytes = fh.tell()
             while written < args.count:
                 rows = fetch_rows_retrying(
                     args.base_url,
@@ -181,6 +193,7 @@ def main(argv=None) -> int:
                 if not items:
                     print("  no more rows", file=sys.stderr)
                     break
+                batch: list[str] = []
                 for item in items:
                     if written >= args.count:
                         break
@@ -191,17 +204,32 @@ def main(argv=None) -> int:
                         continue
                     if args.max_chars and len(text) > args.max_chars:
                         text = text[: args.max_chars]
-                    fh.write(json.dumps({"text": text}, ensure_ascii=False) + "\n")
+                    batch.append(json.dumps({"text": text}, ensure_ascii=False) + "\n")
                     written += 1
+                for line in batch:
+                    fh.write(line)
                 fh.flush()
                 offset += len(items)
                 save_state(state_path, offset, written)
+                committed_offset, committed_written, committed_bytes = offset, written, fh.tell()
                 if written % 1000 < page_size or written >= args.count:
                     print(f"  {written}/{args.count} prompts")
                 time.sleep(args.delay)
     except KeyboardInterrupt:
-        print("\ninterrupted; state saved, resume with --start-over off", file=sys.stderr)
+        # Roll back any page written this round so a resume cannot duplicate rows
+        # while the persisted cursor still points at the previous page boundary.
+        if committed_bytes:
+            try:
+                with prompts_path.open("r+b") as rf:
+                    rf.truncate(committed_bytes)
+            except OSError:
+                pass
+        offset, written = committed_offset, committed_written
         save_state(state_path, offset, written)
+        print(
+            "\ninterrupted; rolled back to the last complete page; resume with --start-over off",
+            file=sys.stderr,
+        )
         return 130
 
     if written >= args.count:

--- a/stealer/scorer.py
+++ b/stealer/scorer.py
@@ -1,0 +1,131 @@
+"""Build and apply the stolen scorer ``s*(token | context)``.
+
+`s*` estimates how much a token is boosted after a short context relative to a
+non-watermarked baseline.  High positive values mean "likely green" — the
+watermark favored that token.  A scrubber demotes green tokens (``apply_delta``
+with positive ``delta`` subtracts ``delta * s*`` from their logits); spoofing
+flips the sign.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+
+def _prob(count: int, total: int, vocab: int, alpha: float) -> float:
+    """Add-alpha smoothed probability, falling back to a tiny floor."""
+
+    return (count + alpha) / max(total + alpha * max(vocab, 1), 1.0)
+
+
+def build_scorer(
+    wm,
+    base,
+    context_len: int,
+    topk: int = 50,
+    alpha: float = 0.4,
+    min_context: int = 1,
+) -> dict:
+    """Derive ``s*`` from watermarked and baseline (context, next-token) counts.
+
+    ``wm`` and ``base`` are the ``(context_map, context_totals, unigrams)``
+    tuples returned by :func:`stealer.tokens.count_ngrams`.  For each context
+    seen in the watermarked corpus, the log-ratio
+    ``log((p_wm(t|ctx) + eps) / (p_base(t|ctx) + eps))`` is computed per token;
+    the top ``topk`` highest-ratio tokens are kept, sorted descending.
+
+    The baseline's per-context distribution is used when that context was
+    observed; otherwise the baseline unigram distribution is the fallback, so a
+    baseline model different from the watermarked model still works.
+    """
+
+    wm_map, wm_totals, wm_unis = wm
+    base_map, base_totals, base_unis = base
+    wm_vocab = max(len(wm_unis), 1)
+    base_vocab = max(len(base_unis), 1)
+    eps = 1e-6
+
+    scorer: dict[str, list[dict[str, float]]] = {}
+    for context, bucket in wm_map.items():
+        if wm_totals.get(context, 0) < min_context:
+            continue
+        context_total = wm_totals[context]
+        base_total = base_totals.get(context, 0)
+        base_bucket = base_map.get(context)
+        base_uni_total = sum(base_unis.values()) or 1
+        scored: list[tuple[str, float]] = []
+        for tok, cnt in bucket.items():
+            p_wm = _prob(cnt, context_total, wm_vocab, alpha)
+            if base_bucket is not None:
+                p_base = _prob(base_bucket.get(tok, 0), base_total, base_vocab, alpha)
+            else:
+                p_base = _prob(base_unis.get(tok, 0), base_uni_total, base_vocab, alpha)
+            scored.append((tok, math.log((p_wm + eps) / (p_base + eps))))
+        scored.sort(key=lambda item: item[1], reverse=True)
+        top = scored[:topk]
+        if top:
+            scorer[" ".join(context)] = [
+                {"token": tok, "score": round(score, 5)} for tok, score in top
+            ]
+
+    return {
+        "config": {
+            "context_len": context_len,
+            "topk": topk,
+            "alpha": alpha,
+            "min_context": min_context,
+            "baseline_fallback": "unigram",
+        },
+        "scorer": scorer,
+    }
+
+
+def load_scorer(path) -> dict:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def score_sequence(scorer: dict, tokens: list[str], context_len: int) -> dict:
+    """Aggregate ``s*`` over a token sequence (a candidate text).
+
+    Returns ``{"score", "applied"}``: the summed ``s*`` for every (context,
+    token) pair found in the table and how many lookups hit.  A higher mean
+    means the text leans toward tokens the watermark boosts.
+    """
+
+    table = scorer.get("scorer", {})
+    total = 0.0
+    applied = 0
+    for i in range(context_len, len(tokens)):
+        context = " ".join(tokens[i - context_len : i])
+        tok = tokens[i]
+        entry = table.get(context)
+        if not entry:
+            continue
+        for item in entry:
+            if item["token"] == tok:
+                total += item["score"]
+                applied += 1
+                break
+    return {"score": round(total, 5), "applied": applied}
+
+
+def apply_delta(
+    scorer: dict, context: tuple[str, ...], logits: dict[str, float], delta: float
+) -> dict[str, float]:
+    """Return ``logits`` with ``delta * s*`` subtracted for green tokens.
+
+    ``delta > 0`` demotes the tokens the stolen scorer thinks are green
+    (scrubbing); ``delta < 0`` promotes them (spoofing).  Only tokens present
+    in the context's stored top-k have a nonzero ``s*``; the rest are unchanged.
+    """
+
+    entry = scorer.get("scorer", {}).get(" ".join(context), [])
+    by_token = {item["token"]: item["score"] for item in entry}
+    adjusted = dict(logits)
+    for tok in adjusted:
+        score = by_token.get(tok)
+        if score is not None:
+            adjusted[tok] = adjusted[tok] - delta * score
+    return adjusted

--- a/stealer/scorer.py
+++ b/stealer/scorer.py
@@ -20,6 +20,17 @@ def _prob(count: int, total: int, vocab: int, alpha: float) -> float:
     return (count + alpha) / max(total + alpha * max(vocab, 1), 1.0)
 
 
+def context_key(context) -> str:
+    """Collision-free key for a context token tuple.
+
+    A JSON array keeps token boundaries unambiguous even when a tokenizer emits
+    whitespace-containing tokens: ``("a b", "c")`` and ``("a", "b c")`` no longer
+    serialize to the same key.
+    """
+
+    return json.dumps(list(context), ensure_ascii=False, separators=(",", ":"))
+
+
 def build_scorer(
     wm,
     base,
@@ -45,6 +56,7 @@ def build_scorer(
     base_map, base_totals, base_unis = base
     wm_vocab = max(len(wm_unis), 1)
     base_vocab = max(len(base_unis), 1)
+    base_uni_total = sum(base_unis.values()) or 1
     eps = 1e-6
 
     scorer: dict[str, list[dict[str, float]]] = {}
@@ -54,7 +66,6 @@ def build_scorer(
         context_total = wm_totals[context]
         base_total = base_totals.get(context, 0)
         base_bucket = base_map.get(context)
-        base_uni_total = sum(base_unis.values()) or 1
         scored: list[tuple[str, float]] = []
         for tok, cnt in bucket.items():
             p_wm = _prob(cnt, context_total, wm_vocab, alpha)
@@ -66,7 +77,7 @@ def build_scorer(
         scored.sort(key=lambda item: item[1], reverse=True)
         top = scored[:topk]
         if top:
-            scorer[" ".join(context)] = [
+            scorer[context_key(context)] = [
                 {"token": tok, "score": round(score, 5)} for tok, score in top
             ]
 
@@ -83,6 +94,8 @@ def build_scorer(
 
 
 def load_scorer(path) -> dict:
+    """Load a saved ``s*`` JSON table from disk."""
+
     return json.loads(Path(path).read_text(encoding="utf-8"))
 
 
@@ -98,7 +111,7 @@ def score_sequence(scorer: dict, tokens: list[str], context_len: int) -> dict:
     total = 0.0
     applied = 0
     for i in range(context_len, len(tokens)):
-        context = " ".join(tokens[i - context_len : i])
+        context = context_key(tokens[i - context_len : i])
         tok = tokens[i]
         entry = table.get(context)
         if not entry:
@@ -121,7 +134,7 @@ def apply_delta(
     in the context's stored top-k have a nonzero ``s*``; the rest are unchanged.
     """
 
-    entry = scorer.get("scorer", {}).get(" ".join(context), [])
+    entry = scorer.get("scorer", {}).get(context_key(context), [])
     by_token = {item["token"]: item["score"] for item in entry}
     adjusted = dict(logits)
     for tok in adjusted:

--- a/stealer/steal.py
+++ b/stealer/steal.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Black-box watermark stealing: query a model, build s*, and score text.
+
+Subcommands:
+  query   send the downloaded prompt corpus to a model, collecting replies
+  build   derive the stolen scorer s*(token | context) from replies (+ baseline)
+  detect  score a candidate text with an already-built s*
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import scorer as scorer_mod
+from tokens import count_ngrams, default_tokenize
+
+DRY_REPLY_HEAD = "This is a dry-run reply to the prompt: "
+
+
+def read_corpus(path: Path, field: str = "text") -> list[str]:
+    """Read a JSONL corpus (one object per line) or a plain newline-delimited file."""
+
+    if not path.exists():
+        raise SystemExit(f"not found: {path}")
+    lines = path.read_text(encoding="utf-8").splitlines()
+    items: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("{"):
+            try:
+                items.append(json.loads(stripped).get(field))
+            except json.JSONDecodeError:
+                items.append(stripped)
+        else:
+            items.append(stripped)
+    return [it for it in items if isinstance(it, str) and it]
+
+
+def read_replies(path: Path) -> list[str]:
+    return read_corpus(path, field="reply")
+
+
+def write_replies(path: Path, rows: list[dict]):
+    with path.open("a", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def _dry_reply(prompt: str) -> str:
+    return DRY_REPLY_HEAD + prompt[:200]
+
+
+def _openai_reply(prompt: str, base_url: str, api_key: str, model: str, max_new_tokens: int) -> str:
+    url = base_url.rstrip("/") + "/chat/completions"
+    payload = json.dumps(
+        {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": max_new_tokens,
+            "temperature": 1.0,
+        }
+    ).encode("utf-8")
+    req = urllib.request.Request(  # noqa: S310
+        url,
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "User-Agent": "watermarks-remover/stealer",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=120) as resp:  # noqa: S310
+        data = json.load(resp)
+    return data["choices"][0]["message"]["content"]
+
+
+def cmd_query(args) -> int:
+    prompts = read_corpus(Path(args.prompts))
+    if args.backend == "dry-run":
+        reply_fn = _dry_reply
+    else:
+        base_url = os.environ.get("WATERMARKS_STEAL_BASE_URL", args.base_url) or args.base_url
+        api_key = os.environ.get("WATERMARKS_STEAL_API_KEY", args.api_key) or args.api_key
+        model = os.environ.get("WATERMARKS_STEAL_MODEL", args.model) or args.model
+        allow_remote = (
+            os.environ.get("WATERMARKS_STEAL_ALLOW_REMOTE", "0") == "1" or args.allow_remote
+        )
+        host = urllib.parse.urlparse(base_url).hostname or "127.0.0.1"
+        if host not in ("127.0.0.1", "localhost", "::1") and not allow_remote:
+            raise SystemExit(
+                "refusing to send content to a non-loopback endpoint; "
+                "set --allow-remote or WATERMARKS_STEAL_ALLOW_REMOTE=1"
+            )
+        if not api_key:
+            raise SystemExit("missing API key; set WATERMARKS_STEAL_API_KEY")
+        if not model:
+            raise SystemExit("missing model; set WATERMARKS_STEAL_MODEL or --model")
+        reply_fn = lambda p: _openai_reply(p, base_url, api_key, model, args.max_new_tokens)  # noqa: E731
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    concurrency = max(1, args.concurrency)
+    print(f"querying {len(prompts)} prompts -> {out} (backend={args.backend})")
+
+    if concurrency == 1:
+        for i, prompt in enumerate(prompts, 1):
+            reply = reply_fn(prompt)
+            write_replies(out, [{"prompt": prompt, "reply": reply}])
+            if i % max(1, len(prompts) // 10) == 0 or i == len(prompts):
+                print(f"  {i}/{len(prompts)}")
+    else:
+        with ThreadPoolExecutor(max_workers=concurrency) as pool:
+            results = pool.map(reply_fn, prompts)
+            for i, reply in enumerate(results, 1):
+                write_replies(out, [{"prompt": prompts[i - 1], "reply": reply}])
+                if i % max(1, len(prompts) // 10) == 0 or i == len(prompts):
+                    print(f"  {i}/{len(prompts)}")
+    print(f"done: {out}")
+    return 0
+
+
+def cmd_build(args) -> int:
+    replies = read_replies(Path(args.replies))
+    baseline = read_replies(Path(args.baseline)) if args.baseline else []
+    if not replies:
+        raise SystemExit(f"no watermarked replies read from {args.replies}")
+    print(f"building s* from {len(replies)} watermarked replies, {len(baseline)} baseline replies")
+
+    wm = count_ngrams(replies, args.ctx, default_tokenize)
+    if baseline:
+        base = count_ngrams(baseline, args.ctx, default_tokenize)
+    else:
+        base = ({}, {}, {})
+        print("  note: no baseline supplied -> unigram fallback only", file=sys.stderr)
+
+    built = scorer_mod.build_scorer(
+        wm, base, args.ctx, topk=args.topk, alpha=args.alpha, min_context=args.min_context
+    )
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(built, ensure_ascii=False), encoding="utf-8")
+    print(f"wrote {out} ({len(built['scorer'])} contexts, top-{args.topk})")
+    return 0
+
+
+def cmd_detect(args) -> int:
+    scorer = scorer_mod.load_scorer(Path(args.s_star))
+    ctx = int(scorer.get("config", {}).get("context_len", args.ctx))
+    text = args.text if args.text is not None else Path(args.file).read_text(encoding="utf-8")
+    tokens = default_tokenize(text)
+    result = scorer_mod.score_sequence(scorer, tokens, ctx)
+    result["tokens"] = len(tokens)
+    result["mean"] = round(result["score"] / result["applied"], 5) if result["applied"] else 0.0
+    print(json.dumps(result, ensure_ascii=False))
+    return 0
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    sub = p.add_subparsers(dest="command", required=True)
+
+    q = sub.add_parser("query", help="send prompts to a model and collect replies")
+    q.add_argument("--prompts", required=True, help="prompt corpus (JSONL or plain lines)")
+    q.add_argument("--out", required=True, help="JSONL of prompt/reply rows")
+    q.add_argument("--backend", default="dry-run", choices=["dry-run", "openai-compatible"])
+    q.add_argument("--base-url", default="https://api.openai.com/v1")
+    q.add_argument("--api-key", default=None, help="key (env WATERMARKS_STEAL_API_KEY preferred)")
+    q.add_argument("--model", default=None, help="model (env WATERMARKS_STEAL_MODEL preferred)")
+    q.add_argument("--max-new-tokens", type=int, default=512)
+    q.add_argument("--concurrency", type=int, default=1)
+    q.add_argument("--allow-remote", action="store_true", help="allow non-loopback endpoints")
+    q.set_defaults(func=cmd_query)
+
+    b = sub.add_parser("build", help="derive s* from replies and a baseline")
+    b.add_argument("--replies", required=True, help="watermarked replies (JSONL)")
+    b.add_argument("--baseline", default=None, help="non-watermarked baseline replies (JSONL)")
+    b.add_argument("--ctx", type=int, default=8, help="context length in tokens")
+    b.add_argument("--topk", type=int, default=50, help="keep top-k tokens per context")
+    b.add_argument("--alpha", type=float, default=0.4, help="add-alpha smoothing")
+    b.add_argument("--min-context", type=int, default=1, help="min occurrences per context")
+    b.add_argument("--out", required=True, help="output s*.json")
+    b.set_defaults(func=cmd_build)
+
+    d = sub.add_parser("detect", help="score a candidate text with an s* table")
+    d.add_argument("--text", default=None, help="text to score")
+    d.add_argument("--file", default=None, help="read text from a file")
+    d.add_argument("--s-star", required=True, help="s*.json")
+    d.add_argument("--ctx", type=int, default=0, help="override context length")
+    d.set_defaults(func=cmd_detect)
+
+    args = p.parse_args(argv)
+    if args.command == "detect" and args.text is None and args.file is None:
+        print("detect requires --text or --file", file=sys.stderr)
+        return 2
+    try:
+        return args.func(args)
+    except urllib.error.HTTPError as exc:
+        print(f"HTTP error {exc.code}: {exc.reason}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/stealer/steal.py
+++ b/stealer/steal.py
@@ -47,20 +47,27 @@ def read_corpus(path: Path, field: str = "text") -> list[str]:
 
 
 def read_replies(path: Path) -> list[str]:
+    """Read a JSONL reply corpus (the ``reply`` field of each row)."""
+
     return read_corpus(path, field="reply")
 
 
 def write_replies(path: Path, rows: list[dict]):
+    """Append prompt/reply rows to a JSONL file."""
+
     with path.open("a", encoding="utf-8") as fh:
         for row in rows:
             fh.write(json.dumps(row, ensure_ascii=False) + "\n")
 
 
 def _dry_reply(prompt: str) -> str:
+    """Deterministic placeholder reply so the pipeline runs without a model."""
+
     return DRY_REPLY_HEAD + prompt[:200]
 
 
 def _openai_reply(prompt: str, base_url: str, api_key: str, model: str, max_new_tokens: int) -> str:
+    """Send one prompt to an OpenAI-compatible chat endpoint and return the text."""
     url = base_url.rstrip("/") + "/chat/completions"
     payload = json.dumps(
         {
@@ -86,12 +93,14 @@ def _openai_reply(prompt: str, base_url: str, api_key: str, model: str, max_new_
 
 
 def cmd_query(args) -> int:
+    """Query the configured target (or baseline) model and collect replies."""
+
     prompts = read_corpus(Path(args.prompts))
     if args.backend == "dry-run":
         reply_fn = _dry_reply
     else:
         base_url = os.environ.get("WATERMARKS_STEAL_BASE_URL", args.base_url) or args.base_url
-        api_key = os.environ.get("WATERMARKS_STEAL_API_KEY", args.api_key) or args.api_key
+        api_key = os.environ.get("WATERMARKS_STEAL_API_KEY")
         model = os.environ.get("WATERMARKS_STEAL_MODEL", args.model) or args.model
         allow_remote = (
             os.environ.get("WATERMARKS_STEAL_ALLOW_REMOTE", "0") == "1" or args.allow_remote
@@ -131,6 +140,8 @@ def cmd_query(args) -> int:
 
 
 def cmd_build(args) -> int:
+    """Derive the stolen scorer ``s*`` from replies and an optional baseline."""
+
     replies = read_replies(Path(args.replies))
     baseline = read_replies(Path(args.baseline)) if args.baseline else []
     if not replies:
@@ -155,8 +166,10 @@ def cmd_build(args) -> int:
 
 
 def cmd_detect(args) -> int:
+    """Score a candidate text against a saved ``s*`` table."""
+
     scorer = scorer_mod.load_scorer(Path(args.s_star))
-    ctx = int(scorer.get("config", {}).get("context_len", args.ctx))
+    ctx = int(args.ctx) if args.ctx else int(scorer.get("config", {}).get("context_len") or 8)
     text = args.text if args.text is not None else Path(args.file).read_text(encoding="utf-8")
     tokens = default_tokenize(text)
     result = scorer_mod.score_sequence(scorer, tokens, ctx)
@@ -167,6 +180,8 @@ def cmd_detect(args) -> int:
 
 
 def main(argv=None) -> int:
+    """CLI entry point: dispatch query / build / detect subcommands."""
+
     p = argparse.ArgumentParser(description=__doc__)
     sub = p.add_subparsers(dest="command", required=True)
 
@@ -175,7 +190,6 @@ def main(argv=None) -> int:
     q.add_argument("--out", required=True, help="JSONL of prompt/reply rows")
     q.add_argument("--backend", default="dry-run", choices=["dry-run", "openai-compatible"])
     q.add_argument("--base-url", default="https://api.openai.com/v1")
-    q.add_argument("--api-key", default=None, help="key (env WATERMARKS_STEAL_API_KEY preferred)")
     q.add_argument("--model", default=None, help="model (env WATERMARKS_STEAL_MODEL preferred)")
     q.add_argument("--max-new-tokens", type=int, default=512)
     q.add_argument("--concurrency", type=int, default=1)

--- a/stealer/tokens.py
+++ b/stealer/tokens.py
@@ -1,0 +1,52 @@
+"""Tokenization and (context, next-token) counting for watermark stealing."""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from collections.abc import Callable, Iterable
+
+_WORD_RE = re.compile(r"\w+|[^\w\s]")
+
+
+def default_tokenize(text: str) -> list[str]:
+    """Split into lowercase word / punctuation tokens (stdlib fallback).
+
+    A real black-box attack uses the target model's tokenizer; the scorer's
+    ``--ctx`` and lookups are keyed on whatever tokenizer produced the counts,
+    so a caller can substitute its own tokenizer for both build and detect.
+    """
+
+    return [tok.lower() for tok in _WORD_RE.findall(text)]
+
+
+def count_ngrams(
+    texts: Iterable[str],
+    context_len: int,
+    tokenize: Callable[[str], list[str]] = default_tokenize,
+) -> tuple[dict[tuple[str, ...], dict[str, int]], Counter, Counter]:
+    """Count how often each next token follows each short context.
+
+    Returns ``(context_map, context_totals, unigram_counts)`` where
+    ``context_map[ctx][tok]`` is the number of times ``tok`` directly follows the
+    token tuple ``ctx``, ``context_totals[ctx]`` counts every (ctx, next) pair,
+    and ``unigram_counts[tok]`` is the raw token frequency.  Contexts shorter
+    than ``context_len`` tokens (start of a reply) are skipped.
+    """
+
+    context_map: dict[tuple[str, ...], dict[str, int]] = {}
+    context_totals: Counter = Counter()
+    unigrams: Counter = Counter()
+    for text in texts:
+        toks = tokenize(text)
+        for tok in toks:
+            unigrams[tok] += 1
+        for i in range(context_len, len(toks)):
+            context = tuple(toks[i - context_len : i])
+            tok = toks[i]
+            bucket = context_map.get(context)
+            if bucket is None:
+                bucket = context_map[context] = {}
+            bucket[tok] = bucket.get(tok, 0) + 1
+            context_totals[context] += 1
+    return context_map, context_totals, unigrams

--- a/tests/test_stealer.py
+++ b/tests/test_stealer.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import argparse
+import json
 import sys
 from pathlib import Path
 
@@ -13,6 +15,7 @@ sys.path.insert(0, str(STEALER))
 
 import download_prompts
 import scorer
+import steal
 import tokens
 
 WM_TEXTS = [
@@ -26,11 +29,15 @@ BASE_TEXTS = [
 
 
 def test_default_tokenize_handles_words_and_punctuation():
+    """The default tokenizer keeps words, punctuation, and number segments."""
+
     toks = tokens.default_tokenize("Hello, World! 3.5")
     assert toks == ["hello", ",", "world", "!", "3", ".", "5"]
 
 
 def test_count_ngrams_counts_next_tokens():
+    """(context, next-token) counts respect token order and boundaries."""
+
     wm, totals, unis = tokens.count_ngrams(["a b a b"], 1, tokens.default_tokenize)
     # sequence: tokens = [a, b, a, b]; pairs (a->b), (b->a), (a->b)
     assert wm[("a",)]["b"] == 2
@@ -39,19 +46,29 @@ def test_count_ngrams_counts_next_tokens():
     assert unis["a"] == 2 and unis["b"] == 2
 
 
+def test_context_key_is_collision_free():
+    """Whitespace-containing tokens must not collapse into one context key."""
+
+    assert scorer.context_key(("a b", "c")) != scorer.context_key(("a", "b c"))
+
+
 def test_build_scorer_ranks_boosted_tokens_above_others():
+    """Tokenisms boosted in the watermarked corpus score higher than baseline tokens."""
+
     wm = tokens.count_ngrams(WM_TEXTS, 3)
     base = tokens.count_ngrams(BASE_TEXTS, 3)
     s = scorer.build_scorer(wm, base, context_len=3, topk=20)
     # "fox" appears in the watermarked corpus, not the baseline, so its score for
     # the context "the quick brown" should be positive and beat an unrelated token.
-    entry = s["scorer"].get("the quick brown", [])
+    entry = s["scorer"].get(scorer.context_key(("the", "quick", "brown")), [])
     scores = {item["token"]: item["score"] for item in entry}
     assert "fox" in scores
     assert scores["fox"] > 0
 
 
 def test_apply_delta_demotes_green_token():
+    """Positive delta lowers the logit of watermarked-boosted (green) tokens."""
+
     wm = tokens.count_ngrams(WM_TEXTS, 3)
     base = tokens.count_ngrams(BASE_TEXTS, 3)
     s = scorer.build_scorer(wm, base, context_len=3, topk=20)
@@ -62,11 +79,33 @@ def test_apply_delta_demotes_green_token():
 
 
 def test_score_sequence_applies_lookups():
+    """score_sequence hits the scorer table for at least one (context, token) pair."""
+
     wm = tokens.count_ngrams(WM_TEXTS, 3)
     base = tokens.count_ngrams(BASE_TEXTS, 3)
     s = scorer.build_scorer(wm, base, context_len=3, topk=20)
     result = scorer.score_sequence(s, tokens.default_tokenize("the quick brown fox jumps"), 3)
     assert result["applied"] > 0
+
+
+def test_detect_ctx_override_is_honored(tmp_path, capsys):
+    """A nonzero detect --ctx overrides the stored context length."""
+
+    wm = tokens.count_ngrams(WM_TEXTS, 2)
+    base = tokens.count_ngrams(BASE_TEXTS, 2)
+    s = scorer.build_scorer(wm, base, context_len=2, topk=20)
+    path = tmp_path / "s.json"
+    path.write_text(json.dumps(s), encoding="utf-8")
+
+    def run(ctx):
+        args = argparse.Namespace(s_star=str(path), text="the quick brown fox", file=None, ctx=ctx)
+        assert steal.cmd_detect(args) == 0
+        return json.loads(capsys.readouterr().out.strip())
+
+    stored = run(0)  # stored context_len == 2
+    overridden = run(4)  # explicit --ctx 4 must win
+    # A different context length changes how many lookups are applied.
+    assert stored["applied"] != overridden["applied"]
 
 
 @pytest.fixture
@@ -86,6 +125,8 @@ def fake_pages():
 
 
 def test_downloader_writes_counted_rows_and_filters(monkeypatch, tmp_path, fake_pages):
+    """The downloader writes exactly --count rows to prompts.jsonl."""
+
     monkeypatch.setattr(download_prompts, "fetch_rows_retrying", lambda *a, **k: fake_pages(100))
     out = tmp_path / "prompts"
     rc = download_prompts.main(
@@ -104,5 +145,63 @@ def test_downloader_writes_counted_rows_and_filters(monkeypatch, tmp_path, fake_
     assert rc == 0
     lines = (out / "prompts.jsonl").read_text(encoding="utf-8").splitlines()
     assert len(lines) == 3
-    # The ``--count 3`` keeps the first three rows; filtering is applied separately.
     assert '"prompt-100"' in lines[0]
+
+
+def test_downloader_resume_after_interrupt_does_not_duplicate(monkeypatch, tmp_path):
+    """An interrupt must leave a consistent cursor + file so resume adds rows, not dups."""
+
+    def page(*a, **k):  # offset is the 5th positional arg to fetch_rows_retrying
+        offset = a[4]
+        return {
+            "num_rows_per_page": 2,
+            "rows": [
+                {"row": {"text": f"r{offset}"}},
+                {"row": {"text": f"r{offset + 1}"}},
+            ],
+        }
+
+    monkeypatch.setattr(download_prompts, "fetch_rows_retrying", page)
+    # The first data page commits, then the follow-up sleep is interrupted.
+    monkeypatch.setattr(
+        download_prompts.time,
+        "sleep",
+        lambda _s: (_ for _ in ()).throw(KeyboardInterrupt),
+    )
+    out = tmp_path / "prompts"
+    rc = download_prompts.main(
+        [
+            "--count",
+            "1000",
+            "--out",
+            str(out),
+            "--base-url",
+            "https://example.invalid",
+            "--delay",
+            "0",
+            "--start-over",
+        ]
+    )
+    assert rc == 130
+    lines = (out / "prompts.jsonl").read_text(encoding="utf-8").splitlines()
+    assert [json.loads(line)["text"] for line in lines] == ["r0", "r1"]
+    state = json.loads((out / ".download-state.json").read_text(encoding="utf-8"))
+    assert state == {"next_offset": 2, "written": 2}
+
+    # Resume continues from offset 2 and appends r2/r3 — no "r0"/"r1" duplicates.
+    monkeypatch.setattr(download_prompts.time, "sleep", lambda _s: None)
+    rc = download_prompts.main(
+        [
+            "--count",
+            "4",
+            "--out",
+            str(out),
+            "--base-url",
+            "https://example.invalid",
+            "--delay",
+            "0",
+        ]
+    )
+    assert rc == 0
+    final = (out / "prompts.jsonl").read_text(encoding="utf-8").splitlines()
+    assert [json.loads(line)["text"] for line in final] == ["r0", "r1", "r2", "r3"]

--- a/tests/test_stealer.py
+++ b/tests/test_stealer.py
@@ -1,0 +1,108 @@
+"""Tests for the black-box watermark-stealing module (scorer core + downloader)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+STEALER = ROOT / "stealer"
+sys.path.insert(0, str(STEALER))
+
+import download_prompts
+import scorer
+import tokens
+
+WM_TEXTS = [
+    "the quick brown fox jumps over the lazy dog . " * 20,
+    "a red fox ran through the green field . " * 20,
+]
+BASE_TEXTS = [
+    "the lazy dog sleeps by the fire all day . " * 20,
+    "a blue car drove across the bridge slowly . " * 20,
+]
+
+
+def test_default_tokenize_handles_words_and_punctuation():
+    toks = tokens.default_tokenize("Hello, World! 3.5")
+    assert toks == ["hello", ",", "world", "!", "3", ".", "5"]
+
+
+def test_count_ngrams_counts_next_tokens():
+    wm, totals, unis = tokens.count_ngrams(["a b a b"], 1, tokens.default_tokenize)
+    # sequence: tokens = [a, b, a, b]; pairs (a->b), (b->a), (a->b)
+    assert wm[("a",)]["b"] == 2
+    assert wm[("b",)]["a"] == 1
+    assert totals[("a",)] == 2
+    assert unis["a"] == 2 and unis["b"] == 2
+
+
+def test_build_scorer_ranks_boosted_tokens_above_others():
+    wm = tokens.count_ngrams(WM_TEXTS, 3)
+    base = tokens.count_ngrams(BASE_TEXTS, 3)
+    s = scorer.build_scorer(wm, base, context_len=3, topk=20)
+    # "fox" appears in the watermarked corpus, not the baseline, so its score for
+    # the context "the quick brown" should be positive and beat an unrelated token.
+    entry = s["scorer"].get("the quick brown", [])
+    scores = {item["token"]: item["score"] for item in entry}
+    assert "fox" in scores
+    assert scores["fox"] > 0
+
+
+def test_apply_delta_demotes_green_token():
+    wm = tokens.count_ngrams(WM_TEXTS, 3)
+    base = tokens.count_ngrams(BASE_TEXTS, 3)
+    s = scorer.build_scorer(wm, base, context_len=3, topk=20)
+    logits = {"fox": 0.0, "cat": 0.0}
+    adjusted = scorer.apply_delta(s, ("the", "quick", "brown"), logits, delta=1.0)
+    assert adjusted["fox"] < 0.0  # green token demoted
+    assert adjusted["cat"] == 0.0  # unknown token untouched
+
+
+def test_score_sequence_applies_lookups():
+    wm = tokens.count_ngrams(WM_TEXTS, 3)
+    base = tokens.count_ngrams(BASE_TEXTS, 3)
+    s = scorer.build_scorer(wm, base, context_len=3, topk=20)
+    result = scorer.score_sequence(s, tokens.default_tokenize("the quick brown fox jumps"), 3)
+    assert result["applied"] > 0
+
+
+@pytest.fixture
+def fake_pages():
+    """Two datasets-server pages for the downloader test."""
+
+    def make(offset):
+        return {
+            "num_rows_per_page": 2,
+            "rows": [
+                {"row": {"text": f"prompt-{offset}", "timestamp": 1, "url": "u"}},
+                {"row": {"text": f"prompt-{offset + 1}", "timestamp": 1, "url": "u"}},
+            ],
+        }
+
+    return make
+
+
+def test_downloader_writes_counted_rows_and_filters(monkeypatch, tmp_path, fake_pages):
+    monkeypatch.setattr(download_prompts, "fetch_rows_retrying", lambda *a, **k: fake_pages(100))
+    out = tmp_path / "prompts"
+    rc = download_prompts.main(
+        [
+            "--count",
+            "3",
+            "--out",
+            str(out),
+            "--base-url",
+            "https://example.invalid",
+            "--delay",
+            "0",
+            "--start-over",
+        ]
+    )
+    assert rc == 0
+    lines = (out / "prompts.jsonl").read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 3
+    # The ``--count 3`` keeps the first three rows; filtering is applied separately.
+    assert '"prompt-100"' in lines[0]


### PR DESCRIPTION
## What

Adds a stdlib-only `stealer/` module implementing the one-time black-box watermark-stealing step from the ETH SRI line of work on SynthID-Text: query a watermarked model with a prompt corpus, compare next-token frequencies after each short context against a non-watermarked baseline, and emit a reusable scorer `s*(token | context)`. A downstream cleaner can then demote the "green" tokens the watermark favors (or, sign-flipped, spoof).

## Why

Supplies the steal-then-scrub pipeline from the shared conversation. The baseline may be a different model than the watermarked content. Also includes `download_prompts.py`, which fetches 30k C4 RealNewsLike passages into `stealer/prompts/prompts.jsonl` via the datasets-server `rows` API (stdlib only; checkpoint/resume + `HF_TOKEN` bearer auth).

## Checklist

- [x] Behaviour matches `SKILL.md` / `references/removal-matrix.md` when relevant — new research module; honest-use caveat documented in `stealer/README.md`, aligned with `references/ethics.md`
- [x] Unit tests updated or added under `tests/` — `tests/test_stealer.py`
- [x] `python3 -m pytest -q` passes
- [x] Docs updated — `stealer/README.md`
- [x] No drive-by refactors unrelated to the fix or feature

## Notes for the reviewer

- New module, deliberately outside the `service/` and `skills/` trees. CI's `ruff check service tests` covers `tests/test_stealer.py` but not the new module.
- The downloaded corpus (`stealer/prompts/*`, ~77 MB generated data) is git-ignored and not in the diff.
- `s*` is a black-box estimate: same-family / same-config only, not a vendor oracle — the same honesty caveat as the repo's other same-scheme harnesses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a watermark analysis toolkit for querying, building scoring models, detecting patterns, and adjusting generated text.
  * Added prompt downloading with filtering, pagination, optional authentication, retry handling, and resumable progress.
  * Added tokenization, n-gram analysis, sequence scoring, and configurable JSON/JSONL outputs.
* **Documentation**
  * Added setup instructions, workflow guidance, configuration details, and authorized-use limitations.
* **Tests**
  * Added coverage for tokenization, scoring, watermark adjustments, sequence analysis, and resumable prompt downloading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->