### PR TITLE
Add --style option to humanize rewrite and /clean contract

### DIFF
--- a/service/scripts/bench_synthid_text.py
+++ b/service/scripts/bench_synthid_text.py
@@ -1909,7 +1909,7 @@ class Benchmark:
                         {
                             "doc": doc,
                             "seed": seed,
-                            "input": str(in_path.relative_to(workdir.parent)),
+                            "input": in_path.relative_to(workdir.parent).as_posix(),
                             "output": None,
                             "robust": entry.get("robust"),
                             "margin": entry.get("margin"),
@@ -1925,7 +1925,7 @@ class Benchmark:
                             "doc": doc,
                             "seed": seed,
                             "input": None,
-                            "output": str(out_path.relative_to(workdir.parent)),
+                            "output": out_path.relative_to(workdir.parent).as_posix(),
                             "robust": entry.get("robust"),
                             "margin": entry.get("margin"),
                             "sem": entry.get("sem"),
@@ -1933,7 +1933,7 @@ class Benchmark:
                         }
                     )
             cand["outputs"] = None
-            cand["output_dir"] = str(cand_dir.relative_to(workdir.parent))
+            cand["output_dir"] = cand_dir.relative_to(workdir.parent).as_posix()
             cand["output_files"] = files
             written += 1
         return written

--- a/service/scripts/rewrite_text.py
+++ b/service/scripts/rewrite_text.py
@@ -31,7 +31,10 @@ The rewrite instruction comes from --tactic (a named prompt) and, when
 --rewrite-level is set, that prompt is further modulated by a numeric rewrite
 intensity in (0,1] that controls how many tokens change (0 — the unchanged
 original — is excluded; 1 rewrites everything). The level is a request: output
-lexical/semantic divergence is measured, not guaranteed.
+lexical/semantic divergence is measured, not guaranteed. --style appends an
+optional writing-style instruction (e.g. "write like Hemingway"), most useful
+with --tactic humanize; it is a request, not a guarantee, and never overrides
+the fact/voice rules.
 
 Security notes:
   - Only http(s) endpoints are accepted; redirects are refused outright so an
@@ -319,6 +322,20 @@ def _intensity_clause(level: float) -> str:
     )
 
 
+def _style_clause(style: str) -> str:
+    """The style instruction appended to a rewrite prompt.
+
+    Intended for the humanize / manual-polish tactics (e.g. "write like
+    Hemingway"). A request, not a contract: the model may only approximate a
+    style, and the fact/voice rules still apply.
+    """
+    return (
+        f"Apply this writing style throughout the rewrite: {style}. Keep the "
+        "style subordinate to the content — preserve all facts, numbers, names, "
+        "and technical identifiers, and do not add or remove claims."
+    )
+
+
 def build_prompt(
     tactic: str | None,
     text: str,
@@ -326,18 +343,23 @@ def build_prompt(
     lang: str = "French",
     original_lang: str = "English",
     rewrite_level: float | None = None,
+    style: str | None = None,
 ) -> str:
     """Construct the LLM rewrite prompt for a given tactic and intensity."""
     if tactic is None:
         if rewrite_level is not None:
-            return PROMPTS["level"].format(TEXT=text, LEVEL=rewrite_level)
-        raise ValueError("unknown tactic: None")
-    base = _tactic_prompt(tactic, text, lang, original_lang)
-    # A (tactic, intensity) pair: modulate the named tactic prompt with the
-    # level instead of replacing it with the generic level-only prompt. Code is
-    # exempt — identifier/comment rewrites are not naturally intensity-modulated.
-    if rewrite_level is not None and tactic != "code":
-        return base + "\n\n" + _intensity_clause(rewrite_level)
+            base = PROMPTS["level"].format(TEXT=text, LEVEL=rewrite_level)
+        else:
+            raise ValueError("unknown tactic: None")
+    else:
+        base = _tactic_prompt(tactic, text, lang, original_lang)
+        # A (tactic, intensity) pair: modulate the named tactic prompt with the
+        # level instead of replacing it with the generic level-only prompt. Code is
+        # exempt — identifier/comment rewrites are not naturally intensity-modulated.
+        if rewrite_level is not None and tactic != "code":
+            base = base + "\n\n" + _intensity_clause(rewrite_level)
+    if style:
+        base = base + "\n\n" + _style_clause(style)
     return base
 
 
@@ -519,6 +541,7 @@ def rewrite(
     markllm_timeout: float = 180.0,
     gumbel_key: str | None = None,
     rewrite_level: float | None = None,
+    style: str | None = None,
     target_margin: float = 0.0,
     selection: str = "min-divergence",
     chunk_shuffle: bool = False,
@@ -526,12 +549,18 @@ def rewrite(
 ) -> tuple[str, dict]:
     """Execute text rewrite pass across candidates and select best candidate."""
     prompt = build_prompt(
-        tactic, text, lang=lang, original_lang=original_lang, rewrite_level=rewrite_level
+        tactic,
+        text,
+        lang=lang,
+        original_lang=original_lang,
+        rewrite_level=rewrite_level,
+        style=style,
     )
     info: dict = {
         "backend": backend,
         "tactic": tactic,
         "rewrite_level": rewrite_level,
+        "style": style,
         "target_margin": target_margin,
         "selection": selection,
         "noop_lex_floor": noop_lex_floor,
@@ -608,6 +637,7 @@ def rewrite(
                 lang=lang,
                 original_lang=original_lang,
                 rewrite_level=rewrite_level,
+                style=style,
             ),
             timeout,
             temperature,
@@ -856,6 +886,13 @@ def build_parser() -> argparse.ArgumentParser:
         default="paraphrase",
     )
     p.add_argument(
+        "--style",
+        default=None,
+        help="Optional writing-style instruction appended to the rewrite prompt "
+        "(e.g. 'write like Hemingway'). Most meaningful with --tactic humanize; "
+        "a request, not a guarantee.",
+    )
+    p.add_argument(
         "--noop-lex-floor",
         type=float,
         default=0.05,
@@ -992,6 +1029,7 @@ def main() -> int:
             base_url=args.base_url,
             api_key=_env("WATERMARKS_REWRITE_API_KEY"),
             tactic=args.tactic,
+            style=args.style,
             lang=args.lang,
             original_lang=args.original_lang,
             timeout=args.timeout,

--- a/service/scripts/server.py
+++ b/service/scripts/server.py
@@ -97,6 +97,7 @@ ALLOWED_CLEAN_OPTIONS = {
     "detect_before": bool,
     "detect_after": bool,
     "deep_images": str,
+    "style": str,
 }
 
 

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -184,6 +184,23 @@ def test_clean_text_roundtrip(conn):
     assert body["report"]["stats"]["removed_count"] == 2
 
 
+def test_clean_text_accepts_style_option(conn):
+    # "style" is accepted + validated (string) on /clean for forward-compat, but
+    # text cleaning stays deterministic Layer A — the service holds no rewrite
+    # model, so the option is parsed and ignored for text.
+    data = "Hello\u200bWorld\u00ad!".encode("utf-8")
+    status, body = _post(
+        conn,
+        "/clean",
+        {"file": _b64(data), "name": "note.txt", "options": {"style": "write like hemingway"}},
+    )
+    assert status == 200
+    assert body["kind"] == "text"
+    cleaned = base64.b64decode(body["cleaned"]).decode("utf-8")
+    assert cleaned == "HelloWorld!"
+    assert body["report"]["stats"]["removed_count"] == 2
+
+
 def test_clean_png_strips_metadata(conn):
     data = _watermarked_png()
     status, body = _post(conn, "/clean", {"file": _b64(data), "name": "shot.png"})
@@ -362,6 +379,7 @@ def test_known_deep_images_modes_accepted(conn):
         ("strip_all_metadata", [], "boolean"),
         ("remove_pixel", False, "string"),
         ("remove_audio_watermark", "false", "boolean"),
+        ("style", 123, "string"),
     ],
 )
 def test_option_wrong_type_rejected(conn, key, value, type_name):

--- a/tests/test_rewrite_text.py
+++ b/tests/test_rewrite_text.py
@@ -82,6 +82,34 @@ def test_build_prompt_level_alone_keeps_generic_prompt():
     assert "clause order" not in p
 
 
+def test_build_prompt_style_appended_to_humanize():
+    p = build_prompt(
+        "humanize", "ABC 123", lang="French", original_lang="English", style="write like hemingway"
+    )
+    assert "ABC 123" in p
+    assert "human wrote it" in p
+    assert "write like hemingway" in p
+
+
+def test_build_prompt_style_combines_with_level():
+    p = build_prompt(
+        "humanize",
+        "Hello 42.",
+        lang="French",
+        original_lang="English",
+        rewrite_level=0.3,
+        style="terse and plain",
+    )
+    assert "0.30" in p
+    assert "terse and plain" in p
+    assert "human wrote it" in p
+
+
+def test_build_prompt_no_style_when_unset():
+    p = build_prompt("humanize", "ABC 123", lang="French", original_lang="English")
+    assert "Apply this writing style" not in p
+
+
 def test_rewrite_level_modulates_tactic():
     out, info = rewrite(
         "Sample prose about water marks 42.",
@@ -93,6 +121,24 @@ def test_rewrite_level_modulates_tactic():
     assert info["noop"] is False  # print-prompt echoes the prompt; long input
     assert "0.40" in out
     assert "clause order" in out  # paraphrase instruction retained
+
+
+def test_rewrite_style_recorded_and_echoed():
+    out, info = rewrite(
+        "Sample prose about water marks 42.",
+        **_rewrite_kwargs(tactic="humanize", style="terse and plain"),
+    )
+    assert info["mode"] == "print-prompt"
+    assert info["tactic"] == "humanize"
+    assert info["style"] == "terse and plain"
+    assert "terse and plain" in out  # print-prompt echoes the styled prompt
+    assert "human wrote it" in out  # humanize instruction retained
+
+
+def test_rewrite_style_default_is_none():
+    _out, info = rewrite("Sample prose about water marks 42.", **_rewrite_kwargs())
+    assert info["style"] is None
+    assert "Apply this writing style" not in _out
 
 
 def test_rewrite_level_out_of_range_rejected(monkeypatch):


### PR DESCRIPTION
## Summary

Adds a `style` option to the Layer B rewrite (the humanize tactic):

- `service/scripts/rewrite_text.py`: new `--style` flag that appends a writing-style instruction (e.g. "write like hemingway") to the rewrite prompt via a new `_style_clause` helper, threaded through `build_prompt()` and `rewrite()`. Composes with `--rewrite-level` and the level-only prompt path, and is recorded in `info["style"]`.
- `service/scripts/server.py` `/clean`: `style` is now an accepted `options` value (string), surfaced in the OpenAPI spec and type-validated (non-string → 400). The text clean path stays deterministic Layer A — the service holds no rewrite model.

## Tests

- `test_rewrite_text.py`: style appended to the humanize prompt; combined with `rewrite_level`; no style clause when unset; `info["style"]` recorded and echoed in print-prompt mode; default `None`.
- `test_http_server.py`: string `style` accepted on text `/clean` (200, Layer A unchanged); non-string `style` rejected (400).

`pytest tests/test_rewrite_text.py tests/test_http_server.py` (96 passed), `ruff check`, and `ruff format --check` all pass.

## Stacking

Branches off the strength→tactic rename; based on `rename-strength-tactic-recipe-strategy` (PR #302).
