### PR TITLE
fix(container): remove polynomial ReDoS in data-URI and JSON-LD scans

### DIFF
--- a/service/scripts/container_meta.py
+++ b/service/scripts/container_meta.py
@@ -278,31 +278,28 @@ def _blob_hits(blob: bytes) -> tuple[bool, bool, list[str]]:
     return has_c2pa, has_ai or has_c2pa, findings[:30]
 
 
-RE_DATA_IMAGE_URI = re.compile(
-    # Unambiguous data-URI header: params is a list of ";attr" segments whose
-    # content can contain neither ';' nor ',' so the comma separator is matched
-    # exactly once. No fixed counts or lengths are imposed, so any valid MIME
-    # parameter sequence is accepted. A trailing, unbounded payload is linear
-    # (nothing follows it) and may span whitespace for formatted base64.
-    r"data:image/(?P<mime>[A-Za-z0-9+.-]+)"
-    r"(?P<params>(?:;[^,;\s\"'()<>]+)*)"
-    r",(?P<payload>[A-Za-z0-9+/=%\s]+)",
-    re.I,
-)
-# Characters that can never appear in an unquoted data-URI body, so they bound a
-# candidate span. Matching each candidate once and skipping across it on a
-# non-match keeps the scan linear even when a large document is full of
-# "data:image/..." that never reaches a comma (a finditer over the whole text
-# would rescan the tail for every prefix - the ReDoS).
-_DATA_URI_STOP = frozenset("\"'<>(")
+# Charsets for the hand-written data-URI parser below. Parsing the URI
+# structure with plain string scans (instead of a regex) keeps the pass linear
+# and accepts any MIME parameter sequence with no fixed counts or length limits,
+# while also never feeding a user-controlled string to a regex engine.
+_ASCII_ALNUM = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
+_DATA_URI_MIME_CHARS = _ASCII_ALNUM | frozenset("+-.")
+_DATA_URI_PAYLOAD_CHARS = _ASCII_ALNUM | frozenset("+/=%")
+# Characters that can never appear in an unquoted data-URI body; they terminate
+# a candidate span and cannot be part of its header or payload.
+_DATA_URI_BREAK = frozenset("\"'<>()")
+# Characters that end a parameter value: the ';' and ',' separators plus the
+# boundary set above.
+_DATA_URI_PARAM_BREAK = _DATA_URI_BREAK | frozenset(",;")
 
 
 def _iter_data_uris(text: str) -> Iterator[tuple[int, int, str, str, str]]:
     """Yield (start, end, mime, params, payload) for each data:image URI.
 
     Linear regardless of input shape: each candidate ('data:image/' up to the
-    next quote/angle/paren) is scanned once, and a candidate that does not form
-    a URI is skipped across so the cost is bounded by the text length.
+    next quote/angle/paren) is parsed once, and a candidate that does not form a
+    URI is skipped across, so an adversarial "data:image/+;" flood costs one
+    pass, not a rescan per prefix.
     """
     n = len(text)
     pos = 0
@@ -311,15 +308,47 @@ def _iter_data_uris(text: str) -> Iterator[tuple[int, int, str, str, str]]:
         i = low.find("data:image/", pos)
         if i < 0:
             return
-        j = i
-        while j < n and text[j] not in _DATA_URI_STOP:
-            j += 1
-        m = RE_DATA_IMAGE_URI.match(text, i)
-        if m is not None:
-            yield i, m.end(), m.group("mime"), m.group("params") or "", m.group("payload")
-            pos = m.end()
-        else:
-            pos = j if j > i + 1 else i + 1
+        k = i + len("data:image/")
+        mime_start = k
+        while k < n and text[k] in _DATA_URI_MIME_CHARS:
+            k += 1
+        mime = text[mime_start:k]
+        if not mime:
+            pos = i + 1
+            continue
+        params_start = k
+        while k < n and text[k] == ";":
+            k += 1
+            while k < n and text[k] not in _DATA_URI_PARAM_BREAK and not text[k].isspace():
+                k += 1
+        params = text[params_start:k]
+        if k >= n or text[k] != ",":
+            pos = _skip_data_uri_candidate(text, i)
+            continue
+        k += 1  # comma
+        payload_start = k
+        while k < n and (text[k] in _DATA_URI_PAYLOAD_CHARS or text[k].isspace()):
+            k += 1
+        payload = text[payload_start:k]
+        if not payload:
+            pos = _skip_data_uri_candidate(text, i)
+            continue
+        yield i, k, mime, params, payload
+        pos = k
+
+
+def _skip_data_uri_candidate(text: str, start: int) -> int:
+    """Return the position to resume scanning after a non-URI candidate.
+
+    Skips past the current 'data:image/' candidate (to its terminating
+    quote/angle/paren or end of text), so a document full of 'data:image/+;'
+    with no comma costs one pass rather than a rescan per prefix.
+    """
+    n = len(text)
+    j = start
+    while j < n and text[j] not in _DATA_URI_BREAK:
+        j += 1
+    return j if j > start + 1 else start + 1
 
 
 def _inspect_embedded_data_uris(text: str) -> tuple[bool, bool, list[str]]:
@@ -658,14 +687,72 @@ def _is_cms_generator_meta(tag: str) -> bool:
     return not (_GENERATOR_AI_RE.search(attrs.get("content", "")) or _GENERATOR_AI_RE.search(tag))
 
 
-_SCRIPT_OPEN_RE = re.compile(r"<script\b[^>]{0,2048}>", re.I)
-# The attribute match is kept separate from the script-tag scan. A single
-# "<script\b[^>]*type...[^>]*>" pattern has two unbounded "[^>]*" runs around
-# a repeated literal, so a document full of 'type="application/ld+json"' with no
-# closing '>' backtracks quadratically. Scanning tags linearly and classifying
-# the type with a quote-aware parser keeps the whole pass O(n) and avoids
-# matching 'data-type=...' or a 'type=' inside another attribute's quoted value.
 _JSONLD_CLOSE_RE = re.compile(r"</script>", re.I)
+# HTML treats form feed as whitespace; include it wherever attribute separators
+# are checked.
+_HTML_SPACE = " \t\r\n\f"
+
+
+def _find_tag_end(text: str, start: int) -> int:
+    """Return the index just after the closing '>' of the tag at 'start'.
+
+    Quote-aware: a '>' inside a quoted attribute value does not end the tag.
+    Linear; returns len(text) when the tag is unterminated.
+    """
+    n = len(text)
+    i = start + 1
+    while i < n:
+        c = text[i]
+        if c == ">":
+            return i + 1
+        if c in "\"'":
+            quote = c
+            i += 1
+            while i < n and text[i] != quote:
+                i += 1
+            i += 1  # skip closing quote
+        else:
+            i += 1
+    return n
+
+
+def _iter_script_blocks(
+    text: str,
+) -> Iterator[tuple[int, int, int, int]]:
+    """Yield (open_start, open_end, close_start, close_end) for script blocks.
+
+    Linear and quote-aware, with no length cap on the opening tag: each opening
+    tag is scanned to its true boundary and closing tags are advanced by a
+    forward pointer, so an unterminated run of '<script' costs one pass, not a
+    rescan per prefix. Yields the same 4-tuple shape as _iter_tag_blocks.
+    """
+    closes = [m.start() for m in _JSONLD_CLOSE_RE.finditer(text)]
+    ci = 0
+    last_end = 0
+    pos = 0
+    n = len(text)
+    low = text.lower()
+    while True:
+        i = low.find("<script", pos)
+        if i < 0:
+            return
+        after = i + 7
+        if after >= n or text[after] not in ">" + _HTML_SPACE + "/":
+            pos = i + 1
+            continue
+        open_end = _find_tag_end(text, i)
+        if i < last_end:
+            pos = max(open_end, i + 1)
+            continue
+        while ci < len(closes) and closes[ci] < open_end:
+            ci += 1
+        if ci >= len(closes):
+            return
+        close_start = closes[ci]
+        close_end = close_start + len("</script>")
+        yield i, open_end, close_start, close_end
+        last_end = close_end
+        pos = open_end
 
 
 def _script_tag_is_jsonld(open_tag: str) -> bool:
@@ -678,23 +765,23 @@ def _script_tag_is_jsonld(open_tag: str) -> bool:
     i, n = 0, len(open_tag)
     if i < n and open_tag[i] == "<":
         i += 1
-    while i < n and open_tag[i] not in " \t\r\n/>":  # tag name
+    while i < n and open_tag[i] not in _HTML_SPACE + "/>":  # tag name
         i += 1
     while i < n:
-        while i < n and open_tag[i] in " \t\r\n":
+        while i < n and open_tag[i] in _HTML_SPACE:
             i += 1
         if i >= n or open_tag[i] == ">":
             return False
         name_start = i
-        while i < n and open_tag[i] not in "= \t\r\n/>":
+        while i < n and open_tag[i] not in "=" + _HTML_SPACE + "/>":
             i += 1
         name = open_tag[name_start:i]
-        while i < n and open_tag[i] in " \t\r\n":
+        while i < n and open_tag[i] in _HTML_SPACE:
             i += 1
         value = ""
         if i < n and open_tag[i] == "=":
             i += 1
-            while i < n and open_tag[i] in " \t\r\n":
+            while i < n and open_tag[i] in _HTML_SPACE:
                 i += 1
             if i < n and open_tag[i] in "\"'":
                 quote = open_tag[i]
@@ -706,7 +793,7 @@ def _script_tag_is_jsonld(open_tag: str) -> bool:
                 i += 1  # skip closing quote
             else:
                 value_start = i
-                while i < n and open_tag[i] not in " \t\r\n>":
+                while i < n and open_tag[i] not in _HTML_SPACE + ">":
                     i += 1
                 value = open_tag[value_start:i]
         if name.lower() == "type" and value.lower() == "application/ld+json":
@@ -729,7 +816,7 @@ def inspect_html(text: str) -> tuple[bool, bool, list[str], dict]:
         ):
             has_ai = True
             findings.append(f"meta: {tag[:120]}")
-    for os_, oe, _cs, ce in _iter_tag_blocks(text, _SCRIPT_OPEN_RE, _JSONLD_CLOSE_RE):
+    for os_, oe, _cs, ce in _iter_script_blocks(text):
         if not _script_tag_is_jsonld(text[os_:oe]):
             continue
         blob = text[os_:ce]
@@ -771,19 +858,27 @@ def clean_html(text: str) -> tuple[str, list[str]]:
 
     out = _META_TAG_RE.sub(_meta_sub, text)
 
-    def _jsonld_is_ai(blob: str) -> bool:
-        end = blob.find(">")
-        open_tag = blob if end < 0 else blob[: end + 1]
+    def _block_is_ai(open_tag: str, blob: str) -> bool:
         if not _script_tag_is_jsonld(open_tag):
             return False
         return AI_META_NAME_RE.search(blob) or re.search(
             r"DigitalSourceType|trainedAlgorithmicMedia|SoftwareAgent", blob, re.I
         )
 
-    new, n = _drop_blocks_if(out, _SCRIPT_OPEN_RE, _JSONLD_CLOSE_RE, _jsonld_is_ai)
+    kept = []
+    last = 0
+    n = 0
+    for os_, oe, _cs, ce in _iter_script_blocks(out):
+        blob = out[os_:ce]
+        if not _block_is_ai(out[os_:oe], blob):
+            continue
+        kept.append(out[last:os_])
+        last = ce
+        n += 1
     if n:
+        kept.append(out[last:])
+        out = "".join(kept)
         actions.extend(["drop json-ld provenance-like script"] * n)
-        out = new
     out2, n = re.subn(r"\sdata-ai[\w-]*\s*=\s*[\"'][^\"']*[\"']", "", out, flags=re.I)
     if n:
         actions.append(f"drop data-ai* attributes x{n}")

--- a/service/scripts/container_meta.py
+++ b/service/scripts/container_meta.py
@@ -278,7 +278,16 @@ def _blob_hits(blob: bytes) -> tuple[bool, bool, list[str]]:
 
 
 RE_DATA_IMAGE_URI = re.compile(
-    r"data:image\/(?P<mime>[a-zA-Z0-9\+\-\.]+)(?P<params>;[^\s\"'\)<>]+)?,(?P<payload>[A-Za-z0-9+/=\s%]+)",
+    # Bounded, unambiguous data-URI header. The params section is a bounded
+    # list of ";attr" segments whose content cannot contain ';' or ',', so the
+    # comma separator is matched exactly once. Bounding the header keeps the
+    # match linear even when a large document is full of "data:image/..." that
+    # never reaches a comma (the engine would otherwise rescan the tail for
+    # every prefix - a ReDoS). A trailing, unbounded payload is linear (nothing
+    # follows it) and is allowed to span whitespace for formatted base64.
+    r"data:image/(?P<mime>[A-Za-z0-9+.-]+)"
+    r"(?P<params>(?:;[^,;\s\"'()<>]{1,64}){0,16})"
+    r",(?P<payload>[A-Za-z0-9+/=%\s]+)",
     re.I,
 )
 
@@ -618,10 +627,13 @@ def _is_cms_generator_meta(tag: str) -> bool:
     return not (_GENERATOR_AI_RE.search(attrs.get("content", "")) or _GENERATOR_AI_RE.search(tag))
 
 
-_JSONLD_OPEN_RE = re.compile(
-    r"""<script\b[^>]*type\s*=\s*["']application/ld\+json["'][^>]*>""",
-    re.I,
-)
+_SCRIPT_OPEN_RE = re.compile(r"<script\b[^>]{0,2048}>", re.I)
+# The attribute match is kept separate from the script-tag scan. A single
+# "<script\b[^>]*type...[^>]*>" pattern has two unbounded "[^>]*" runs around
+# a repeated literal, so a document full of 'type="application/ld+json"' with no
+# closing '>' backtracks quadratically. Scanning tags linearly and classifying
+# the type on the (bounded) tag keeps the whole pass O(n).
+_JSONLD_TYPE_RE = re.compile(r"""\btype\s*=\s*["']application/ld\+json["']""", re.I)
 _JSONLD_CLOSE_RE = re.compile(r"</script>", re.I)
 
 
@@ -640,7 +652,9 @@ def inspect_html(text: str) -> tuple[bool, bool, list[str], dict]:
         ):
             has_ai = True
             findings.append(f"meta: {tag[:120]}")
-    for os_, _oe, _cs, ce in _iter_tag_blocks(text, _JSONLD_OPEN_RE, _JSONLD_CLOSE_RE):
+    for os_, oe, _cs, ce in _iter_tag_blocks(text, _SCRIPT_OPEN_RE, _JSONLD_CLOSE_RE):
+        if not _JSONLD_TYPE_RE.search(text[os_:oe]):
+            continue
         blob = text[os_:ce]
         if AI_META_NAME_RE.search(blob) or re.search(
             r"DigitalSourceType|trainedAlgorithmicMedia|SoftwareAgent", blob, re.I
@@ -681,11 +695,15 @@ def clean_html(text: str) -> tuple[str, list[str]]:
     out = _META_TAG_RE.sub(_meta_sub, text)
 
     def _jsonld_is_ai(blob: str) -> bool:
+        end = blob.find(">")
+        open_tag = blob if end < 0 else blob[: end + 1]
+        if not _JSONLD_TYPE_RE.search(open_tag):
+            return False
         return AI_META_NAME_RE.search(blob) or re.search(
             r"DigitalSourceType|trainedAlgorithmicMedia|SoftwareAgent", blob, re.I
         )
 
-    new, n = _drop_blocks_if(out, _JSONLD_OPEN_RE, _JSONLD_CLOSE_RE, _jsonld_is_ai)
+    new, n = _drop_blocks_if(out, _SCRIPT_OPEN_RE, _JSONLD_CLOSE_RE, _jsonld_is_ai)
     if n:
         actions.extend(["drop json-ld provenance-like script"] * n)
         out = new

--- a/service/scripts/container_meta.py
+++ b/service/scripts/container_meta.py
@@ -15,6 +15,7 @@ import time
 import urllib.parse
 import zipfile
 import zlib
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -278,9 +279,47 @@ def _blob_hits(blob: bytes) -> tuple[bool, bool, list[str]]:
 
 
 RE_DATA_IMAGE_URI = re.compile(
-    r"data:image\/(?P<mime>[a-zA-Z0-9\+\-\.]+)(?P<params>;[^\s\"'\)<>]+)?,(?P<payload>[A-Za-z0-9+/=\s%]+)",
+    # Unambiguous data-URI header: params is a list of ";attr" segments whose
+    # content can contain neither ';' nor ',' so the comma separator is matched
+    # exactly once. No fixed counts or lengths are imposed, so any valid MIME
+    # parameter sequence is accepted. A trailing, unbounded payload is linear
+    # (nothing follows it) and may span whitespace for formatted base64.
+    r"data:image/(?P<mime>[A-Za-z0-9+.-]+)"
+    r"(?P<params>(?:;[^,;\s\"'()<>]+)*)"
+    r",(?P<payload>[A-Za-z0-9+/=%\s]+)",
     re.I,
 )
+# Characters that can never appear in an unquoted data-URI body, so they bound a
+# candidate span. Matching each candidate once and skipping across it on a
+# non-match keeps the scan linear even when a large document is full of
+# "data:image/..." that never reaches a comma (a finditer over the whole text
+# would rescan the tail for every prefix - the ReDoS).
+_DATA_URI_STOP = frozenset("\"'<>(")
+
+
+def _iter_data_uris(text: str) -> Iterator[tuple[int, int, str, str, str]]:
+    """Yield (start, end, mime, params, payload) for each data:image URI.
+
+    Linear regardless of input shape: each candidate ('data:image/' up to the
+    next quote/angle/paren) is scanned once, and a candidate that does not form
+    a URI is skipped across so the cost is bounded by the text length.
+    """
+    n = len(text)
+    pos = 0
+    low = text.lower()
+    while True:
+        i = low.find("data:image/", pos)
+        if i < 0:
+            return
+        j = i
+        while j < n and text[j] not in _DATA_URI_STOP:
+            j += 1
+        m = RE_DATA_IMAGE_URI.match(text, i)
+        if m is not None:
+            yield i, m.end(), m.group("mime"), m.group("params") or "", m.group("payload")
+            pos = m.end()
+        else:
+            pos = j if j > i + 1 else i + 1
 
 
 def _inspect_embedded_data_uris(text: str) -> tuple[bool, bool, list[str]]:
@@ -288,11 +327,10 @@ def _inspect_embedded_data_uris(text: str) -> tuple[bool, bool, list[str]]:
     has_ai = False
     findings: list[str] = []
 
-    for m in RE_DATA_IMAGE_URI.finditer(text):
-        mime = m.group("mime").lower()
-        params = (m.group("params") or "").lower()
-        payload = m.group("payload")
-        is_b64 = "base64" in params
+    for _start, _end, mime, params, payload in _iter_data_uris(text):
+        mime_l = mime.lower()
+        params_l = params.lower()
+        is_b64 = "base64" in params_l
 
         try:
             if is_b64:
@@ -318,7 +356,7 @@ def _inspect_embedded_data_uris(text: str) -> tuple[bool, bool, list[str]]:
             sub_c2pa, sub_ai, sub_findings = inspect_webp(data)
         elif fmt in ("avif", "heic"):
             sub_c2pa, sub_ai, sub_findings = inspect_isobmff(data, fmt)
-        elif "svg" in mime or data.lstrip().startswith(b"<"):
+        elif "svg" in mime_l or data.lstrip().startswith(b"<"):
             sub_c2pa, sub_ai, sub_findings, _ = inspect_svg(data)
         else:
             sub_c2pa, sub_ai, sub_findings = _blob_hits(data)
@@ -328,7 +366,7 @@ def _inspect_embedded_data_uris(text: str) -> tuple[bool, bool, list[str]]:
         if sub_ai or sub_c2pa:
             has_ai = True
         for f in sub_findings:
-            findings.append(f"embedded data:image/{mime}: {f}")
+            findings.append(f"embedded data:image/{mime_l}: {f}")
 
     return has_c2pa, has_ai, findings
 
@@ -338,11 +376,8 @@ def _clean_embedded_data_uris(
 ) -> tuple[str, list[str]]:
     actions: list[str] = []
 
-    def _replace_uri(m: re.Match[str]) -> str:
-        full_match = m.group(0)
-        mime = m.group("mime")
-        params = m.group("params") or ""
-        payload = m.group("payload")
+    def _clean_one(mime: str, params: str, payload: str) -> str | None:
+        """Return the rebuilt data URI, or None when nothing changed."""
         is_b64 = "base64" in params.lower()
 
         try:
@@ -355,10 +390,10 @@ def _clean_embedded_data_uris(
             else:
                 data = urllib.parse.unquote_to_bytes(payload)
         except Exception:
-            return full_match
+            return None
 
         if not data:
-            return full_match
+            return None
 
         fmt = detect_image_format(data)
         sub_actions: list[str] = []
@@ -378,22 +413,27 @@ def _clean_embedded_data_uris(
             elif "svg" in mime.lower() or data.lstrip().startswith(b"<"):
                 cleaned_bytes, sub_actions = clean_svg(data)
         except Exception:
-            return full_match
+            return None
 
         if not any("drop" in a.lower() for a in sub_actions) or cleaned_bytes == data:
-            return full_match
+            return None
 
         actions.append(f"cleaned embedded data:image/{mime} ({', '.join(sub_actions[:2])})")
 
         if is_b64:
             new_b64 = base64.b64encode(cleaned_bytes).decode("ascii")
             return f"data:image/{mime}{params},{new_b64}"
-        else:
-            new_payload = urllib.parse.quote_from_bytes(cleaned_bytes)
-            return f"data:image/{mime}{params},{new_payload}"
+        return f"data:image/{mime}{params},{urllib.parse.quote_from_bytes(cleaned_bytes)}"
 
-    out = RE_DATA_IMAGE_URI.sub(_replace_uri, text)
-    return out, actions
+    out: list[str] = []
+    last = 0
+    for start, end, mime, params, payload in _iter_data_uris(text):
+        out.append(text[last:start])
+        rebuilt = _clean_one(mime, params, payload)
+        out.append(text[start:end] if rebuilt is None else rebuilt)
+        last = end
+    out.append(text[last:])
+    return "".join(out), actions
 
 
 # ---------------------------------------------------------------------------
@@ -618,11 +658,60 @@ def _is_cms_generator_meta(tag: str) -> bool:
     return not (_GENERATOR_AI_RE.search(attrs.get("content", "")) or _GENERATOR_AI_RE.search(tag))
 
 
-_JSONLD_OPEN_RE = re.compile(
-    r"""<script\b[^>]*type\s*=\s*["']application/ld\+json["'][^>]*>""",
-    re.I,
-)
+_SCRIPT_OPEN_RE = re.compile(r"<script\b[^>]{0,2048}>", re.I)
+# The attribute match is kept separate from the script-tag scan. A single
+# "<script\b[^>]*type...[^>]*>" pattern has two unbounded "[^>]*" runs around
+# a repeated literal, so a document full of 'type="application/ld+json"' with no
+# closing '>' backtracks quadratically. Scanning tags linearly and classifying
+# the type with a quote-aware parser keeps the whole pass O(n) and avoids
+# matching 'data-type=...' or a 'type=' inside another attribute's quoted value.
 _JSONLD_CLOSE_RE = re.compile(r"</script>", re.I)
+
+
+def _script_tag_is_jsonld(open_tag: str) -> bool:
+    """True iff the opening tag has a top-level type="application/ld+json".
+
+    Single-pass and quote-aware: quoted attribute values are skipped as a unit,
+    so only an actual top-level attribute named 'type' with the JSON-LD value
+    is matched. Linear in the tag length.
+    """
+    i, n = 0, len(open_tag)
+    if i < n and open_tag[i] == "<":
+        i += 1
+    while i < n and open_tag[i] not in " \t\r\n/>":  # tag name
+        i += 1
+    while i < n:
+        while i < n and open_tag[i] in " \t\r\n":
+            i += 1
+        if i >= n or open_tag[i] == ">":
+            return False
+        name_start = i
+        while i < n and open_tag[i] not in "= \t\r\n/>":
+            i += 1
+        name = open_tag[name_start:i]
+        while i < n and open_tag[i] in " \t\r\n":
+            i += 1
+        value = ""
+        if i < n and open_tag[i] == "=":
+            i += 1
+            while i < n and open_tag[i] in " \t\r\n":
+                i += 1
+            if i < n and open_tag[i] in "\"'":
+                quote = open_tag[i]
+                i += 1
+                value_start = i
+                while i < n and open_tag[i] != quote:
+                    i += 1
+                value = open_tag[value_start:i]
+                i += 1  # skip closing quote
+            else:
+                value_start = i
+                while i < n and open_tag[i] not in " \t\r\n>":
+                    i += 1
+                value = open_tag[value_start:i]
+        if name.lower() == "type" and value.lower() == "application/ld+json":
+            return True
+    return False
 
 
 def inspect_html(text: str) -> tuple[bool, bool, list[str], dict]:
@@ -640,7 +729,9 @@ def inspect_html(text: str) -> tuple[bool, bool, list[str], dict]:
         ):
             has_ai = True
             findings.append(f"meta: {tag[:120]}")
-    for os_, _oe, _cs, ce in _iter_tag_blocks(text, _JSONLD_OPEN_RE, _JSONLD_CLOSE_RE):
+    for os_, oe, _cs, ce in _iter_tag_blocks(text, _SCRIPT_OPEN_RE, _JSONLD_CLOSE_RE):
+        if not _script_tag_is_jsonld(text[os_:oe]):
+            continue
         blob = text[os_:ce]
         if AI_META_NAME_RE.search(blob) or re.search(
             r"DigitalSourceType|trainedAlgorithmicMedia|SoftwareAgent", blob, re.I
@@ -681,11 +772,15 @@ def clean_html(text: str) -> tuple[str, list[str]]:
     out = _META_TAG_RE.sub(_meta_sub, text)
 
     def _jsonld_is_ai(blob: str) -> bool:
+        end = blob.find(">")
+        open_tag = blob if end < 0 else blob[: end + 1]
+        if not _script_tag_is_jsonld(open_tag):
+            return False
         return AI_META_NAME_RE.search(blob) or re.search(
             r"DigitalSourceType|trainedAlgorithmicMedia|SoftwareAgent", blob, re.I
         )
 
-    new, n = _drop_blocks_if(out, _JSONLD_OPEN_RE, _JSONLD_CLOSE_RE, _jsonld_is_ai)
+    new, n = _drop_blocks_if(out, _SCRIPT_OPEN_RE, _JSONLD_CLOSE_RE, _jsonld_is_ai)
     if n:
         actions.extend(["drop json-ld provenance-like script"] * n)
         out = new

--- a/tests/test_container_meta.py
+++ b/tests/test_container_meta.py
@@ -171,6 +171,53 @@ def test_html_jsonld_clean_keeps_plain_jsonld_and_regular_scripts():
     assert not any("json-ld" in a for a in actions)
 
 
+def test_html_jsonld_form_feed_is_whitespace():
+    # HTML treats form feed (\f) as whitespace, so it must separate the tag name
+    # from the type attribute rather than being consumed into the tag name.
+    ai = (
+        '<script\ftype="application/ld+json">'
+        '{"@type":"CreativeWork","digitalSourceType":"trainedAlgorithmicMedia"}'
+        "</script>"
+    )
+    _has_c2pa, has_ai, findings, _ = inspect_html(ai)
+    assert has_ai is True
+    assert any("json-ld provenance-like block" in f for f in findings)
+    cleaned, _actions = clean_html(ai)
+    assert "digitalSourceType" not in cleaned
+
+
+def test_html_jsonld_opening_tag_longer_than_2048():
+    # A valid opening tag longer than 2048 characters must still be detected
+    # (no arbitrary length cap on the tag-scan boundary).
+    padding = " ".join(f'data-{i}="x"' for i in range(300))
+    ai = (
+        f'<script {padding} type="application/ld+json">'
+        '{"@type":"Image","digitalSourceType":"trainedAlgorithmicMedia"}'
+        "</script>"
+    )
+    assert len(ai.split(">", 1)[0]) > 2048
+    _has_c2pa, has_ai, findings, _ = inspect_html(ai)
+    assert has_ai is True
+    assert any("json-ld provenance-like block" in f for f in findings)
+    cleaned, _actions = clean_html(ai)
+    assert "digitalSourceType" not in cleaned
+
+
+def test_html_jsonld_gt_in_quoted_attribute_value():
+    # A '>' inside a quoted attribute value must not be treated as the end of
+    # the opening tag.
+    ai = (
+        '<script title="a > b" type="application/ld+json">'
+        '{"@type":"Image","digitalSourceType":"trainedAlgorithmicMedia"}'
+        "</script>"
+    )
+    _has_c2pa, has_ai, findings, _ = inspect_html(ai)
+    assert has_ai is True
+    assert any("json-ld provenance-like block" in f for f in findings)
+    cleaned, _actions = clean_html(ai)
+    assert "digitalSourceType" not in cleaned
+
+
 def test_html_ai_generator_still_dropped():
     html = '<meta name="generator" content="Claude">'
     cleaned, actions = clean_html(html)

--- a/tests/test_container_meta.py
+++ b/tests/test_container_meta.py
@@ -143,6 +143,34 @@ def test_html_cms_generator_attribute_names_are_case_insensitive():
     assert clean_html(ai_html)[0] == ""
 
 
+def test_html_jsonld_ai_block_detected_and_cleaned():
+    ai = (
+        '<script type="application/ld+json">'
+        '{"@type":"CreativeWork","digitalSourceType":"trainedAlgorithmicMedia"}'
+        "</script>"
+    )
+    _has_c2pa, has_ai, findings, _ = inspect_html(ai)
+    assert has_ai is True
+    assert any("json-ld provenance-like block" in f for f in findings)
+    cleaned, _actions = clean_html(ai)
+    assert "digitalSourceType" not in cleaned
+
+
+def test_html_jsonld_clean_keeps_plain_jsonld_and_regular_scripts():
+    # Only json-ld blocks that actually carry AI provenance are dropped. A plain
+    # json-ld block and an ordinary <script> that merely mention the marker
+    # text must be preserved (the tag scanner + separate type check must not
+    # over-match non-jsonld scripts).
+    html = (
+        '<script type="application/ld+json">{"@type":"Book","name":"plain"}</script>'
+        '<script>var x = "trainedAlgorithmicMedia";</script>'
+    )
+    _c2, _has_ai, _findings, _ = inspect_html(html)
+    cleaned, actions = clean_html(html)
+    assert cleaned == html
+    assert not any("json-ld" in a for a in actions)
+
+
 def test_html_ai_generator_still_dropped():
     html = '<meta name="generator" content="Claude">'
     cleaned, actions = clean_html(html)

--- a/tests/test_embedded_data_uris.py
+++ b/tests/test_embedded_data_uris.py
@@ -133,6 +133,25 @@ def test_already_clean_embedded_image_no_op():
     assert "no HTML AI meta removed" in actions
 
 
+def test_data_uri_with_many_params_is_matched():
+    # No fixed count/length limit on the parameter list: a URI with far more
+    # than 16 short params must still be found and cleaned.
+    png_c2pa = _minimal_png_with_text()
+    png_b64 = base64.b64encode(png_c2pa).decode("ascii")
+    params = "".join(f";p{i}=v{i}" for i in range(40))
+    assert params.count(";") > 16
+    html_text = f'<img src="data:image/png;base64{params},{png_b64}">'
+
+    has_c2pa, has_ai, findings, _ = inspect_html(html_text)
+    assert has_c2pa is True
+    assert has_ai is True
+    assert any("embedded data:image/png" in f for f in findings)
+
+    cleaned_text, actions = clean_html(html_text)
+    assert any("cleaned embedded data:image/png" in a for a in actions)
+    assert "c2pa" not in cleaned_text.lower()
+
+
 def test_corrupted_data_uri_graceful_fallback():
     # Corrupted base64 that shouldn't crash the file cleaner
     bad_html = '<img src="data:image/png;base64,!!!NOT_VALID_BASE64###">'

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -35,6 +35,7 @@ from container_meta import (
     _drop_tag_blocks,
     _pdf_structured_blob,
     _read_zip_member,
+    _script_tag_is_jsonld,
     clean_html,
     clean_odt,
     clean_svg,
@@ -316,6 +317,46 @@ def test_clean_html_jsonld_flood_is_linear():
     assert "</script>" not in flood
     cleaned, _actions = _assert_completes_fast(clean_html, flood)
     assert cleaned == flood
+
+
+def test_clean_html_jsonld_attr_flood_no_close_is_linear():
+    # CodeQL py/polynomial-redos worst case for the tag scanner: the literal
+    # 'type="application/ld+json"' repeats many times but there is never a '>'.
+    # A single "<script[^>]*type...[^>]*>" regex backtracks quadratically here;
+    # the linear tag scan + separate type check must not.
+    flood = '<script type="application/ld+json"' * (128 * 1024 // 39)
+    assert ">" not in flood
+    cleaned, _actions = _assert_completes_fast(clean_html, flood)
+    assert cleaned == flood
+
+
+def test_clean_html_data_uri_flood_is_linear():
+    # CodeQL py/polynomial-redos worst case for the data-URI matcher: many
+    # 'data:image/+;' prefixes and no comma. The old params class could match
+    # the comma (and ';'), so every prefix rescanned the tail - quadratic. The
+    # bounded, unambiguous header must keep the whole pass linear.
+    flood = "data:image/+;" * (256 * 1024 // 13)
+    assert "," not in flood
+    cleaned, actions = _assert_completes_fast(clean_html, flood)
+    assert cleaned == flood
+    assert not any("embedded data:image" in a for a in actions)
+
+
+def test_jsonld_type_parser_is_linear_on_whitespace():
+    # A whitespace-heavy tag without a type must be rejected quickly (a "\s+"
+    # or search-based matcher here would rescan the run from every position).
+    flood = "<script" + "  " * (512 * 1024) + ">"
+    start = time.perf_counter()
+    assert _script_tag_is_jsonld(flood) is False
+    assert time.perf_counter() - start < 5.0
+
+
+def test_jsonld_type_parser_ignores_decoy_attributes():
+    # A 'type=' inside another attribute's quoted value, and a name that merely
+    # ends in "type" (data-type), are NOT the JSON-LD type attribute.
+    assert _script_tag_is_jsonld('<script data-type="application/ld+json">') is False
+    assert _script_tag_is_jsonld("<script title='x type=\"application/ld+json\" y'>") is False
+    assert _script_tag_is_jsonld('<script id="type" type="application/ld+json">') is True
 
 
 def test_pdf_stream_and_xpacket_floods_are_linear():

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -27,6 +27,7 @@ from common import (
     safe_write_text,
 )
 from container_meta import (
+    _JSONLD_TYPE_RE,
     _SVG_METADATA_CLOSE_RE,
     _SVG_METADATA_OPEN_RE,
     MAX_ZIP_DECOMPRESSED_BYTES,
@@ -316,6 +317,38 @@ def test_clean_html_jsonld_flood_is_linear():
     assert "</script>" not in flood
     cleaned, _actions = _assert_completes_fast(clean_html, flood)
     assert cleaned == flood
+
+
+def test_clean_html_jsonld_attr_flood_no_close_is_linear():
+    # CodeQL py/polynomial-redos worst case for the tag scanner: the literal
+    # 'type="application/ld+json"' repeats many times but there is never a '>'.
+    # A single "<script[^>]*type...[^>]*>" regex backtracks quadratically here;
+    # the linear tag scan + separate type check must not.
+    flood = '<script type="application/ld+json"' * (128 * 1024 // 39)
+    assert ">" not in flood
+    cleaned, _actions = _assert_completes_fast(clean_html, flood)
+    assert cleaned == flood
+
+
+def test_clean_html_data_uri_flood_is_linear():
+    # CodeQL py/polynomial-redos worst case for the data-URI matcher: many
+    # 'data:image/+;' prefixes and no comma. The old params class could match
+    # the comma (and ';'), so every prefix rescanned the tail - quadratic. The
+    # bounded, unambiguous header must keep the whole pass linear.
+    flood = "data:image/+;" * (256 * 1024 // 13)
+    assert "," not in flood
+    cleaned, actions = _assert_completes_fast(clean_html, flood)
+    assert cleaned == flood
+    assert not any("embedded data:image" in a for a in actions)
+
+
+def test_jsonld_type_regex_is_linear():
+    # A leading "\s+" before "type" makes the attribute matcher quadratic on a
+    # long whitespace run (search rescans from every position). The fixed
+    # "\btype" anchor must keep it linear.
+    start = time.perf_counter()
+    assert _JSONLD_TYPE_RE.search("  " * (512 * 1024)) is None
+    assert time.perf_counter() - start < 5.0
 
 
 def test_pdf_stream_and_xpacket_floods_are_linear():


### PR DESCRIPTION
## Summary

Fixes two CodeQL `py/polynomial-redos` (ReDoS) alerts on user-controlled data:

- **#32** — `RE_DATA_IMAGE_URI` in `service/scripts/container_meta.py`
- **#33** — `_JSONLD_OPEN_RE` in `service/scripts/container_meta.py`

Both regexes took quadratic time on crafted inputs, which is a denial-of-service vector since the HTTP server accepts documents up to 256 MiB.

## What changed

- **Data URI matcher (alert #32):** the `params` section used a `;[^\s"'()<>]+` class that could also match the `,` and `;` separators, so a document full of `data:image/+;` with no comma forced the engine to rescan the tail from every prefix. The header is now a bounded, unambiguous list of `;attr` segments whose content cannot contain `,` or `;`, so the comma separator is matched exactly once and the scan is linear.
- **JSON-LD tag matcher (alert #33):** `_JSONLD_OPEN_RE` had two unbounded `[^>]*` runs around a repeated literal, so `type="application/ld+json"` with no closing `>` backtracked quadratically. Script tags are now scanned linearly (`_SCRIPT_OPEN_RE`) and the JSON-LD `type` attribute is classified separately on the bounded tag (`_JSONLD_TYPE_RE`). The `inspect_html` and `clean_html` paths both use the new approach, which preserves plain JSON-LD blocks and non-JSON-LD `<script>` blocks.

## Verification

- Added linearity regression tests reproducing both CodeQL worst-case payloads.
- Added correctness tests ensuring plain JSON-LD and ordinary `<script>` blocks are not over-matched.
- Full test suite passes (`pytest`), and `ruff check` + `ruff format --check` are clean.

I measured both adversarial patterns before/after: the data-URI flood went from ~26 s at ~208 KiB (quadratic) to linear, and the JSON-LD flood to linear as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed HTML and data URIs to prevent slowdowns during content processing.
  * More accurately identifies AI-provenance JSON-LD scripts while preserving ordinary JSON-LD and unrelated scripts.
  * Prevented false embedded-data findings in malformed or incomplete input.
  * Improved recognition of SVG data URIs regardless of MIME type capitalization.

* **Tests**
  * Added coverage for malformed script tags, parameter-heavy data URIs, JSON-LD detection and removal, and long or adversarial inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->