### PR TITLE
fix(stealer): clear stale state on start-over probe failure

### DIFF
--- a/stealer/download_prompts.py
+++ b/stealer/download_prompts.py
@@ -157,8 +157,9 @@ def main(argv=None) -> int:
     offset, written = (0, 0) if args.start_over else load_state(state_path)
     if args.offset:
         offset = args.offset
-    if args.start_over and prompts_path.exists():
-        prompts_path.unlink()
+    if args.start_over:
+        prompts_path.unlink(missing_ok=True)
+        state_path.unlink(missing_ok=True)
 
     first = fetch_rows_retrying(
         args.base_url, args.dataset, args.config, args.split, offset, 1, token=token

--- a/tests/test_stealer.py
+++ b/tests/test_stealer.py
@@ -205,3 +205,61 @@ def test_downloader_resume_after_interrupt_does_not_duplicate(monkeypatch, tmp_p
     assert rc == 0
     final = (out / "prompts.jsonl").read_text(encoding="utf-8").splitlines()
     assert [json.loads(line)["text"] for line in final] == ["r0", "r1", "r2", "r3"]
+
+
+def test_downloader_start_over_clears_stale_state_before_probe(monkeypatch, tmp_path):
+    """A failed --start-over probe must not leave a stale cursor for the next run."""
+
+    out = tmp_path / "prompts"
+    out.mkdir()
+    (out / "prompts.jsonl").write_text('{"text":"old"}\n', encoding="utf-8")
+    (out / ".download-state.json").write_text(
+        json.dumps({"next_offset": 900, "written": 900}), encoding="utf-8"
+    )
+
+    def fail_probe(*args, **kwargs):
+        raise RuntimeError("offline")
+
+    monkeypatch.setattr(download_prompts, "fetch_rows_retrying", fail_probe)
+    with pytest.raises(RuntimeError, match="offline"):
+        download_prompts.main(
+            [
+                "--count",
+                "1",
+                "--out",
+                str(out),
+                "--base-url",
+                "https://example.invalid",
+                "--delay",
+                "0",
+                "--start-over",
+            ]
+        )
+
+    assert not (out / "prompts.jsonl").exists()
+    assert not (out / ".download-state.json").exists()
+
+    calls = []
+
+    def page(*args, **kwargs):
+        calls.append(args[4])
+        return {"num_rows_per_page": 1, "rows": [{"row": {"text": "fresh"}}]}
+
+    monkeypatch.setattr(download_prompts, "fetch_rows_retrying", page)
+    assert (
+        download_prompts.main(
+            [
+                "--count",
+                "1",
+                "--out",
+                str(out),
+                "--base-url",
+                "https://example.invalid",
+                "--delay",
+                "0",
+            ]
+        )
+        == 0
+    )
+    assert calls == [0, 0]
+    assert json.loads((out / "prompts.jsonl").read_text(encoding="utf-8")) == {"text": "fresh"}


### PR DESCRIPTION
## What

Clear both the downloaded prompt corpus and its resume checkpoint before the initial probe when `--start-over` is requested.

## Why

If the initial datasets-server probe fails or is interrupted, the old `.download-state.json` survived after `prompts.jsonl` was deleted. A later run could then reuse the stale cursor, report completion with exit code 0, and leave an empty corpus.

## Checklist

- [x] Behaviour matches `SKILL.md` / `references/removal-matrix.md` when relevant
- [x] Unit tests updated or added under `tests/`
- [x] `python3 -m pytest -q` passes
- [ ] Docs updated (README and/or skill references) if user-facing behaviour changes
- [x] No drive-by refactors unrelated to the fix

## Notes for the reviewer

- Reproduced on `origin/main` with both `RuntimeError` and `KeyboardInterrupt`: stale state remained and the next run falsely reported completion with an empty output.
- Added a regression test covering the failed probe, on-disk cleanup, and a subsequent resume from offset 0.
- Existing normal resume and interrupted-page rollback behavior is unchanged.
- Related upstream review finding: https://github.com/guillaumemeyer/watermarks-remover/pull/303#discussion_r3899244851


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The “Start over” option now clears both previously downloaded prompts and saved download progress before beginning again.
  - Failed initial probes no longer leave stale files behind, allowing subsequent downloads to restart from the beginning with fresh data.

- **Tests**
  - Added regression coverage for clearing stale output and download state before probing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->