### PR TITLE
feat(rewrite): humanizer-skill humanize pass + mlm (masked-LM) rewrite tactic

### DIFF
--- a/service/scripts/bench_synthid_text.py
+++ b/service/scripts/bench_synthid_text.py
@@ -2116,6 +2116,7 @@ class Benchmark:
                             "robust": entry.get("robust"),
                             "margin": entry.get("margin"),
                             "sem": entry.get("sem"),
+                            "human_like": entry.get("human_like"),
                             "note": entry.get("note"),
                         }
                     )
@@ -2131,6 +2132,7 @@ class Benchmark:
                             "robust": entry.get("robust"),
                             "margin": entry.get("margin"),
                             "sem": entry.get("sem"),
+                            "human_like": entry.get("human_like"),
                             "note": entry.get("note"),
                         }
                     )

--- a/service/scripts/bench_synthid_text.py
+++ b/service/scripts/bench_synthid_text.py
@@ -113,7 +113,7 @@ def parse_strategy(spec: str) -> list[tuple[str, float]]:
     names and that intensity lies in (0,1].
     """
     steps: list[tuple[str, float]] = []
-    known = {"paraphrase", "backtranslate", "structural", "humanize", "chunk"}
+    known = {"paraphrase", "backtranslate", "structural", "humanize", "chunk", "mlm"}
     for raw in spec.split(","):
         item = raw.strip()
         if not item:
@@ -1681,6 +1681,7 @@ class Benchmark:
         rows_in: list[dict[str, Any]] = []
         outs: list[str] = []
         score_at: list[int] = []
+        entry_at: list[int] = []
         per_sample: list[dict[str, Any]] = []
         for s in samples:
             if s.get("excluded"):
@@ -1696,6 +1697,7 @@ class Benchmark:
                 "robust": None,
                 "margin": None,
                 "sem": None,
+                "human_like": None,
                 "note": None,
             }
             try:
@@ -1727,11 +1729,14 @@ class Benchmark:
             per_sample.append(entry)
             outs.append(out)
             score_at.append(len(rows_in) - 1)
+            entry_at.append(len(per_sample) - 1)
         if outs:
             # Batch the human-likeness scoring (one Pangram bulk job per strategy).
             scored = self.human.score_many(outs)
-            for idx, val in zip(score_at, scored, strict=True):
+            for idx, eidx, val in zip(score_at, entry_at, scored, strict=True):
                 rows_in[idx]["human"] = val
+                if val is not None:
+                    per_sample[eidx]["human_like"] = round(1.0 - val, 4)
         verified = [r for r in rows_in if r["robust"] is not None]
         n = len(verified)
         unverified = len(rows_in) - n

--- a/service/scripts/humanize_pass.py
+++ b/service/scripts/humanize_pass.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Deterministic humanizer pass for the Layer B ``humanize`` tactic.
+
+The humanize tactic asks a model to "write like a human"; this module enforces
+the mechanical, context-free subset of the humanizer skill (Wikipedia's "Signs
+of AI writing") that is safe to apply without reading the text: straight quotes,
+no em/en dashes or double hyphens, common filler-phrase collapses, and the
+unambiguous ``utilize`` -> ``use`` swap. Everything that needs judgment (voice,
+rhythm, promotional language, passive voice, rule-of-three) lives in the
+rewrite prompt; this pass only changes text where the edit is always correct.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Lowercase replacements; capitalization is preserved from the matched text.
+_PHRASE_SWAPS: tuple[tuple[str, str], ...] = (
+    (r"\bin order to\b", "to"),
+    (r"\bdue to the fact that\b", "because"),
+    (r"\bat this point in time\b", "now"),
+    (r"\bin the event that\b", "if"),
+    (r"\bhas the ability to\b", "can"),
+    (r"\bhave the ability to\b", "can"),
+    (r"\bit is important to note that\b", "note that"),
+    (r"\bit is worth noting that\b", "note that"),
+    (r"\bdelve into\b", "explore"),
+    (r"\bdelves into\b", "explores"),
+    (r"\bdelved into\b", "explored"),
+    (r"\bdelving into\b", "exploring"),
+)
+
+_WORD_SWAPS: dict[str, str] = {
+    "utilize": "use",
+    "utilizes": "uses",
+    "utilized": "used",
+    "utilizing": "using",
+}
+
+_WORD_RE = re.compile(r"\b(?:utilize|utilizes|utilized|utilizing)\b", re.IGNORECASE)
+
+
+def _capitalize_like(matched: str, replacement: str) -> str:
+    """Match the capitalization of *matched*'s first character."""
+    return replacement.capitalize() if matched[0].isupper() else replacement
+
+
+def _straighten_quotes(text: str) -> str:
+    for ch in ("\u2018", "\u2019"):
+        text = text.replace(ch, "'")
+    for ch in ("\u201c", "\u201d"):
+        text = text.replace(ch, '"')
+    return text
+
+
+def _replace_dashes(text: str) -> str:
+    # Spaced dash (an aside or break) first, then any unspaced remainder.
+    text = re.sub(r"\s+[\u2014\u2013]\s+", ", ", text)
+    text = re.sub(r"\s+--\s+", ", ", text)
+    text = re.sub(r"[\u2014\u2013]", ", ", text)
+    text = re.sub(r"--", ", ", text)
+    text = re.sub(r",\s*,\s*", ", ", text)  # collapse adjacent commas
+    text = re.sub(r"\s*,\s*([.!?])", r"\1", text)  # "word, ." -> "word."
+    return text
+
+
+def _collapse_phrases(text: str) -> str:
+    for pattern, repl in _PHRASE_SWAPS:
+        text = re.sub(
+            pattern,
+            lambda m, r=repl: _capitalize_like(m.group(0), r),
+            text,
+            flags=re.IGNORECASE,
+        )
+    return text
+
+
+def _swap_words(text: str) -> str:
+    def _sub(match: re.Match[str]) -> str:
+        word = match.group(0)
+        return _capitalize_like(word, _WORD_SWAPS[word.lower()])
+
+    return _WORD_RE.sub(_sub, text)
+
+
+def humanize_pass(text: str) -> str:
+    """Apply the deterministic humanizer transforms to *text*."""
+    text = _straighten_quotes(text)
+    text = _replace_dashes(text)
+    text = _collapse_phrases(text)
+    text = _swap_words(text)
+    return text

--- a/service/scripts/humanize_pass.py
+++ b/service/scripts/humanize_pass.py
@@ -42,6 +42,8 @@ _WORD_RE = re.compile(r"\b(?:utilize|utilizes|utilized|utilizing)\b", re.IGNOREC
 
 def _capitalize_like(matched: str, replacement: str) -> str:
     """Match the capitalization of *matched*'s first character."""
+    if matched.isupper():
+        return replacement.upper()
     return replacement.capitalize() if matched[0].isupper() else replacement
 
 
@@ -54,11 +56,26 @@ def _straighten_quotes(text: str) -> str:
 
 
 def _replace_dashes(text: str) -> str:
-    # Spaced dash (an aside or break) first, then any unspaced remainder.
+    _DBL_HYPHEN = re.compile(r"--")
+
+    def _sub(m: re.Match[str]) -> str:
+        # Preserve a command-line option such as ``--dry-run`` (a `--` that
+        # starts/continues a token after whitespace), replace prose double
+        # hyphens with a comma.
+        start = m.start()
+        before = text[start - 1] if start > 0 else ""
+        after = text[m.end()] if m.end() < len(text) else ""
+        if after and after.isalnum() and (not before or before.isspace()):
+            return m.group(0)
+        return ", "
+
+    # Spaced dash (an aside or break) first; unspaced em/en dashes become a
+    # comma unless they are part of a numeric range (e.g. 2019-2020).
     text = re.sub(r"\s+[\u2014\u2013]\s+", ", ", text)
     text = re.sub(r"\s+--\s+", ", ", text)
-    text = re.sub(r"[\u2014\u2013]", ", ", text)
-    text = re.sub(r"--", ", ", text)
+    text = re.sub(r"(?<!\d)[\u2014\u2013](?!\d)", ", ", text)
+    # Double hyphens in prose, preserving CLI options.
+    text = _DBL_HYPHEN.sub(_sub, text)
     text = re.sub(r",\s*,\s*", ", ", text)  # collapse adjacent commas
     text = re.sub(r"\s*,\s*([.!?])", r"\1", text)  # "word, ." -> "word."
     return text

--- a/service/scripts/humanize_pass.py
+++ b/service/scripts/humanize_pass.py
@@ -56,26 +56,32 @@ def _straighten_quotes(text: str) -> str:
 
 
 def _replace_dashes(text: str) -> str:
-    _DBL_HYPHEN = re.compile(r"--")
+    _DASH = re.compile(r"\s*[\u2014\u2013]\s*")
+    _DBL_HYPHEN = re.compile(r"(\s*)--(\s*)")
 
-    def _sub(m: re.Match[str]) -> str:
-        # Preserve a command-line option such as ``--dry-run`` (a `--` that
-        # starts/continues a token after whitespace), replace prose double
-        # hyphens with a comma.
-        start = m.start()
-        before = text[start - 1] if start > 0 else ""
-        after = text[m.end()] if m.end() < len(text) else ""
-        if after and after.isalnum() and (not before or before.isspace()):
+    def _dash_sub(m: re.Match[str]) -> str:
+        # Neighbors just beyond the matched whitespace: if both are digits the
+        # dash is a numeric range (e.g. "2019 - 2020") and stays untouched.
+        left = text[m.start() - 1] if m.start() > 0 else ""
+        right = text[m.end()] if m.end() < len(text) else ""
+        if left.isdigit() and right.isdigit():
             return m.group(0)
         return ", "
 
-    # Spaced dash (an aside or break) first; unspaced em/en dashes become a
-    # comma unless they are part of a numeric range (e.g. 2019-2020).
-    text = re.sub(r"\s+[\u2014\u2013]\s+", ", ", text)
-    text = re.sub(r"\s+--\s+", ", ", text)
-    text = re.sub(r"(?<!\d)[\u2014\u2013](?!\d)", ", ", text)
-    # Double hyphens in prose, preserving CLI options.
-    text = _DBL_HYPHEN.sub(_sub, text)
+    def _dbl_sub(m: re.Match[str]) -> str:
+        leading, trailing = m.group(1), m.group(2)
+        hyphen_start = m.start() + len(leading)
+        hyphen_end = m.end() - len(trailing)
+        before = text[hyphen_start - 1] if hyphen_start > 0 else ""
+        after = text[hyphen_end] if hyphen_end < len(text) else ""
+        # A command-line option is `--word` where `--` directly precedes a word
+        # char after a delimiter (or string start); never a prose double hyphen.
+        if after.isalnum() and (not before or not before.isalnum()):
+            return m.group(0)
+        return ", "
+
+    text = _DASH.sub(_dash_sub, text)
+    text = _DBL_HYPHEN.sub(_dbl_sub, text)
     text = re.sub(r",\s*,\s*", ", ", text)  # collapse adjacent commas
     text = re.sub(r"\s*,\s*([.!?])", r"\1", text)  # "word, ." -> "word."
     return text

--- a/service/scripts/rewrite_text.py
+++ b/service/scripts/rewrite_text.py
@@ -58,6 +58,7 @@ import sys
 import urllib.error
 import urllib.request
 from pathlib import Path
+from typing import Any
 from urllib.parse import urlparse
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -420,22 +421,70 @@ _MLM_SKIP_WORDS = {
     "because",
 }
 _MLM_TOKEN_RE = re.compile(r"(\s+|[.,;:!?()\"'—-])")
+_MLM_MAX_TOKENS = 512  # roberta-large positional limit
+_MLM_CACHE: dict[str, Any] = {}  # {"pipeline": ..., "mask_token": ...}
+
+
+def _cuda_available() -> bool:
+    """True when a CUDA device is usable; False on CPU-only or no-torch hosts."""
+    try:
+        import torch
+
+        return bool(torch.cuda.is_available())
+    except Exception:  # torch absent; run on CPU/auto
+        return False
+
+
+def _get_mlm() -> tuple[Any, str]:
+    """Return the process-cached roberta-large fill-mask pipeline + mask token.
+
+    Built lazily on first use; a failed import surfaces as RuntimeError (fail-soft
+    optional dependency). The device is chosen at runtime so a CPU-only host still
+    works (architecture selects the accelerator when available).
+    """
+    if "pipeline" not in _MLM_CACHE:
+        try:
+            from transformers import pipeline
+        except Exception as e:  # fail-soft: optional dependency
+            raise RuntimeError(f"mlm tactic unavailable: {e}") from e
+        kwargs: dict[str, Any] = {"model": "roberta-large"}
+        if _cuda_available():
+            kwargs["device"] = 0
+        _MLM_CACHE["pipeline"] = pipeline("fill-mask", **kwargs)
+        _MLM_CACHE["mask_token"] = _MLM_CACHE["pipeline"].tokenizer.mask_token
+    return _MLM_CACHE["pipeline"], _MLM_CACHE["mask_token"]
+
+
+def _mlm_chunks(parts: list[str], tokenizer: Any, max_tokens: int = _MLM_MAX_TOKENS):
+    """Split `parts` into contiguous chunks whose token length stays <= max_tokens.
+
+    Chunk boundaries fall on separator/word edges, so each chunk joins to a clean
+    substring, preserving ordering across chunks. Yields (global_start, chunk).
+    """
+    cur: list[str] = []
+    cur_start = 0
+    for i, part in enumerate(parts):
+        trial = [*cur, part]
+        if cur and len(tokenizer("".join(trial))["input_ids"]) > max_tokens:
+            yield cur_start, cur
+            cur = [part]
+            cur_start = i
+        else:
+            cur = trial
+    if cur:
+        yield cur_start, cur
 
 
 def _mlm_infill(text: str, level: float) -> str:
     """Mask `level` of content words and infill with roberta-large (local edit).
 
     Non-autoregressive: the output is a mix of the original token stream and
-    masked-LM predictions, not fresh LLM-sampled prose. Loads roberta-large on
-    first use (transformers must be importable); raises if unavailable.
+    masked-LM predictions, not fresh LLM-sampled prose. Uses a process-cached,
+    runtime-device pipeline and splits inputs longer than roberta's positional
+    limit into separately-infilled chunks.
     """
-    try:
-        from transformers import pipeline
-    except Exception as e:  # fail-soft: optional dependency
-        raise RuntimeError(f"mlm tactic unavailable: {e}") from e
-
-    mlm = pipeline("fill-mask", model="roberta-large", device=0)
-    mask_token = mlm.tokenizer.mask_token
+    mlm, mask_token = _get_mlm()
+    tokenizer = mlm.tokenizer
     tokens = _MLM_TOKEN_RE.split(text)
     content = [
         i
@@ -456,13 +505,16 @@ def _mlm_infill(text: str, level: float) -> str:
         idx = content[int(pos)]
         mset.add(idx)
         pos += step
-    masked_idx = sorted(mset)
-    out_parts = [mask_token if i in mset else t for i, t in enumerate(tokens)]
-    preds = mlm("".join(out_parts), top_k=1)
-    picks = [(p if isinstance(p, dict) else p[0]) for p in preds]
-    for k_i, idx in enumerate(masked_idx):
-        if k_i < len(picks):
-            tokens[idx] = picks[k_i]["token_str"].strip()
+    out_parts = [mask_token if i in mset else tokens[i] for i in range(len(tokens))]
+    for chunk_start, chunk in _mlm_chunks(out_parts, tokenizer):
+        positions = [chunk_start + j for j, p in enumerate(chunk) if p == mask_token]
+        if not positions:
+            continue
+        preds = mlm("".join(chunk), top_k=1)
+        picks = [(p if isinstance(p, dict) else p[0]) for p in preds]
+        for k_i, global_idx in enumerate(positions):
+            if k_i < len(picks):
+                tokens[global_idx] = picks[k_i]["token_str"].strip()
     return "".join(tokens)
 
 
@@ -755,7 +807,9 @@ def rewrite(
     if not base_url and tactic != "mlm":
         raise SystemExit("error: --base-url required for ollama/openai-compatible backends")
 
-    _check_remote(base_url, allow_remote)
+    # The mlm tactic never talks to a remote endpoint; base_url may be None.
+    if base_url is not None:
+        _check_remote(base_url, allow_remote)
 
     n_cands = max(1, candidates)
     n_loops = max(1, max_loops)

--- a/service/scripts/rewrite_text.py
+++ b/service/scripts/rewrite_text.py
@@ -34,7 +34,10 @@ original — is excluded; 1 rewrites everything). The level is a request: output
 lexical/semantic divergence is measured, not guaranteed. --style appends an
 optional writing-style instruction (e.g. "write like Hemingway"), most useful
 with --tactic humanize; it is a request, not a guarantee, and never overrides
-the fact/voice rules.
+the fact/voice rules. The humanize tactic additionally runs a deterministic
+humanizer pass (humanize_pass.py) over each generated candidate — straight
+quotes, no em/en dashes or double hyphens, filler-phrase collapses, and the
+utilize->use swap — before evaluation, so the scored text is the text returned.
 
 Security notes:
   - Only http(s) endpoints are accepted; redirects are refused outright so an
@@ -60,6 +63,7 @@ from urllib.parse import urlparse
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from common import cleaned_path, eprint, read_text_input, write_text_output
+from humanize_pass import humanize_pass
 from text_detectors import GumbelTextDetector, MarkLLMTextDetector
 from text_unicode import clean_text
 
@@ -77,10 +81,19 @@ PROMPTS = {
     ),
     "humanize": (
         "Rewrite the following text so it reads as if a human wrote it from scratch. "
-        "Vary sentence rhythm and length, replace formulaic AI-style transitions and "
-        "filler with concrete natural phrasing, and use plain, varied wording. Preserve "
-        "all facts, numbers, names, and technical identifiers. Do not add or remove "
-        "claims. Output only the rewritten text.\n\n---\n{TEXT}"
+        "Vary sentence rhythm and length unevenly — mix short and long sentences instead "
+        "of a steady mid-length cadence — and merge or split paragraphs where a human "
+        "would. Use plain, concrete wording and simple verbs (is/are/has); prefer active "
+        'voice. Cut promotional language and inflated significance ("stands as a '
+        'testament", "pivotal", "vibrant", "a rich tapestry"), superficial '
+        'present-participle analyses ("reflecting", "showcasing", "underscoring"), '
+        'vague attributions ("experts argue"), rule-of-three listing, filler ("in order '
+        'to", "it is important to note"), hedging, and formulaic positive conclusions. '
+        'Avoid AI vocabulary ("additionally", "delve", "crucial", "foster", '
+        '"leverage", "utilize", "interplay", and abstract "landscape"). Do not add '
+        "em dashes, bold text, emojis, or curly quotes. Preserve all facts, numbers, "
+        "names, and technical identifiers. Do not add or remove claims. Output only the "
+        "rewritten text.\n\n---\n{TEXT}"
     ),
     "code": (
         "Rewrite the natural-language parts of this code — comments, docstrings, and "
@@ -673,6 +686,8 @@ def rewrite(
         loop_passed = False
         for _ in range(n_cands):
             cand = _generate_candidate()
+            if tactic == "humanize":
+                cand = humanize_pass(cand)
             cand_stats: dict | None = None
             if layer_a_after:
                 cand, cand_stats = clean_text(cand)

--- a/service/scripts/rewrite_text.py
+++ b/service/scripts/rewrite_text.py
@@ -316,6 +316,10 @@ def _tactic_prompt(tactic: str, text: str, lang: str, original_lang: str) -> str
         )
     if tactic == "chunk":
         return PROMPTS["chunk_unit"].format(TEXT=text)
+    if tactic == "mlm":
+        # Local masked-LM edit: the prompt is informational only; generation runs
+        # a non-autoregressive infill (see _mlm_infill) rather than the backend.
+        return "Local masked-LM infill; no LLM prompt is used.\n\n---\n" + text
     raise ValueError(f"unknown tactic: {tactic}")
 
 
@@ -333,6 +337,133 @@ def _intensity_clause(level: float) -> str:
         "intensity change wording substantially at the token level. Preserve all facts, "
         "numbers, names, and technical identifiers. Do not add or remove claims."
     )
+
+
+# Function words / short / technical tokens we never hand to a masked LM.
+_MLM_SKIP_WORDS = {
+    "the",
+    "and",
+    "for",
+    "are",
+    "but",
+    "not",
+    "you",
+    "all",
+    "can",
+    "had",
+    "her",
+    "was",
+    "one",
+    "our",
+    "out",
+    "day",
+    "get",
+    "has",
+    "him",
+    "his",
+    "how",
+    "man",
+    "new",
+    "now",
+    "old",
+    "see",
+    "two",
+    "way",
+    "who",
+    "boy",
+    "did",
+    "its",
+    "let",
+    "put",
+    "say",
+    "she",
+    "too",
+    "use",
+    "that",
+    "with",
+    "have",
+    "this",
+    "will",
+    "your",
+    "from",
+    "they",
+    "been",
+    "were",
+    "would",
+    "there",
+    "their",
+    "what",
+    "when",
+    "which",
+    "also",
+    "into",
+    "than",
+    "then",
+    "them",
+    "these",
+    "those",
+    "such",
+    "only",
+    "very",
+    "just",
+    "about",
+    "some",
+    "more",
+    "most",
+    "other",
+    "over",
+    "under",
+    "through",
+    "between",
+    "while",
+    "where",
+    "because",
+}
+_MLM_TOKEN_RE = re.compile(r"(\s+|[.,;:!?()\"'—-])")
+
+
+def _mlm_infill(text: str, level: float) -> str:
+    """Mask `level` of content words and infill with roberta-large (local edit).
+
+    Non-autoregressive: the output is a mix of the original token stream and
+    masked-LM predictions, not fresh LLM-sampled prose. Loads roberta-large on
+    first use (transformers must be importable); raises if unavailable.
+    """
+    try:
+        from transformers import pipeline
+    except Exception as e:  # fail-soft: optional dependency
+        raise RuntimeError(f"mlm tactic unavailable: {e}") from e
+
+    mlm = pipeline("fill-mask", model="roberta-large", device=0)
+    mask_token = mlm.tokenizer.mask_token
+    tokens = _MLM_TOKEN_RE.split(text)
+    content = [
+        i
+        for i, t in enumerate(tokens)
+        if t.strip()
+        and t.isalpha()
+        and len(t) > 3
+        and t.lower() not in _MLM_SKIP_WORDS
+        and not t[0].isupper()
+    ]
+    k = max(1, round(level * len(content))) if content else 0
+    if k == 0:
+        return text
+    step = len(content) / k
+    mset: set[int] = set()
+    pos = 0.0
+    for _ in range(k):
+        idx = content[int(pos)]
+        mset.add(idx)
+        pos += step
+    masked_idx = sorted(mset)
+    out_parts = [mask_token if i in mset else t for i, t in enumerate(tokens)]
+    preds = mlm("".join(out_parts), top_k=1)
+    picks = [(p if isinstance(p, dict) else p[0]) for p in preds]
+    for k_i, idx in enumerate(masked_idx):
+        if k_i < len(picks):
+            tokens[idx] = picks[k_i]["token_str"].strip()
+    return "".join(tokens)
 
 
 def _style_clause(style: str) -> str:
@@ -619,9 +750,9 @@ def rewrite(
             eprint("note: --candidates ignored in print-prompt mode")
         return prompt, info
 
-    if not model:
+    if not model and tactic != "mlm":
         raise SystemExit("error: --model required for ollama/openai-compatible backends")
-    if not base_url:
+    if not base_url and tactic != "mlm":
         raise SystemExit("error: --base-url required for ollama/openai-compatible backends")
 
     _check_remote(base_url, allow_remote)
@@ -634,8 +765,10 @@ def rewrite(
     info["evaluator"] = evaluator_name
 
     is_chunk = tactic == "chunk"
+    is_mlm = tactic == "mlm"
     info["chunked"] = is_chunk
     info["chunk_shuffle"] = bool(chunk_shuffle)
+    info["mlm"] = is_mlm
 
     def _rewrite_unit(unit: str) -> str:
         """Rewrite a single text unit with prompt formatting."""
@@ -659,6 +792,8 @@ def rewrite(
 
     def _generate_candidate() -> str:
         """Generate a single rewrite candidate via configured backend."""
+        if is_mlm:
+            return _mlm_infill(text, rewrite_level or 0.3)
         if is_chunk:
             pairs = _split_units(text)
             if chunk_shuffle:
@@ -897,7 +1032,7 @@ def build_parser() -> argparse.ArgumentParser:
     # and shell history. Set WATERMARKS_REWRITE_API_KEY instead.
     p.add_argument(
         "--tactic",
-        choices=("paraphrase", "backtranslate", "structural", "humanize", "code", "chunk"),
+        choices=("paraphrase", "backtranslate", "structural", "humanize", "code", "chunk", "mlm"),
         default="paraphrase",
     )
     p.add_argument(

--- a/tests/test_humanize_pass.py
+++ b/tests/test_humanize_pass.py
@@ -78,6 +78,16 @@ def test_preserves_numeric_ranges():
     assert humanize_pass(text) == text
 
 
+def test_preserves_spaced_numeric_ranges():
+    text = "The decade 2019 \u2013 2020 was busy."
+    assert humanize_pass(text) == text
+
+
 def test_preserves_cli_options():
     text = "run the tool --dry-run now"
+    assert humanize_pass(text) == text
+
+
+def test_preserves_delimited_cli_options():
+    text = "pass the flag run(--dry-run) to the runner"
     assert humanize_pass(text) == text

--- a/tests/test_humanize_pass.py
+++ b/tests/test_humanize_pass.py
@@ -1,0 +1,63 @@
+"""Tests for the deterministic humanizer pass behind the humanize tactic."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "service" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from humanize_pass import humanize_pass
+
+
+def test_straightens_curly_quotes():
+    text = "\u2018single\u2019 and \u201cdouble\u201d quotes, it\u2019s an apostrophe"
+    assert humanize_pass(text) == "'single' and \"double\" quotes, it's an apostrophe"
+
+
+def test_replaces_spaced_em_and_en_dashes():
+    assert humanize_pass("a \u2014 b") == "a, b"
+    assert humanize_pass("a \u2013 b") == "a, b"
+
+
+def test_replaces_unspaced_dashes():
+    assert humanize_pass("long\u2014according to critics\u2014will") == (
+        "long, according to critics, will"
+    )
+    assert humanize_pass("a--b") == "a, b"
+
+
+def test_replaces_double_hyphens():
+    assert humanize_pass("a -- b") == "a, b"
+
+
+def test_trailing_dash_before_punctuation():
+    assert humanize_pass("word \u2014.") == "word."
+
+
+def test_collapses_filler_phrases_case_preserving():
+    assert humanize_pass("In order to achieve this") == "To achieve this"
+    assert humanize_pass("The system has the ability to process") == "The system can process"
+    assert humanize_pass("due to the fact that it rained") == "because it rained"
+
+
+def test_swaps_utilize_family_case_preserving():
+    assert humanize_pass("We utilize a tool") == "We use a tool"
+    assert humanize_pass("Utilizing fewer tokens helps") == "Using fewer tokens helps"
+
+
+def test_delve_into_becomes_explore():
+    assert humanize_pass("The post delves into the history") == "The post explores the history"
+
+
+def test_leaves_plain_text_unchanged():
+    text = "The cat sat on the mat. Numbers like 1,000 stay intact."
+    assert humanize_pass(text) == text
+
+
+def test_is_idempotent():
+    text = "In order to utilize the tool\u2014the report says\u2014it works."
+    once = humanize_pass(text)
+    assert humanize_pass(once) == once

--- a/tests/test_humanize_pass.py
+++ b/tests/test_humanize_pass.py
@@ -9,7 +9,7 @@ ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / "service" / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
-from humanize_pass import humanize_pass
+from humanize_pass import _capitalize_like, humanize_pass
 
 
 def test_straightens_curly_quotes():
@@ -61,3 +61,23 @@ def test_is_idempotent():
     text = "In order to utilize the tool\u2014the report says\u2014it works."
     once = humanize_pass(text)
     assert humanize_pass(once) == once
+
+
+def test_capitalize_like_preserves_all_uppercase():
+    assert _capitalize_like("UTILIZE", "use") == "USE"
+    assert _capitalize_like("Utilize", "use") == "Use"
+    assert _capitalize_like("utilize", "use") == "use"
+
+
+def test_swaps_all_uppercase_utilize():
+    assert humanize_pass("UTILIZE a tool") == "USE a tool"
+
+
+def test_preserves_numeric_ranges():
+    text = "The decade 2019\u20132020 was busy."
+    assert humanize_pass(text) == text
+
+
+def test_preserves_cli_options():
+    text = "run the tool --dry-run now"
+    assert humanize_pass(text) == text

--- a/tests/test_rewrite_text.py
+++ b/tests/test_rewrite_text.py
@@ -61,6 +61,13 @@ def test_build_prompt_humanize_and_code_contain_text():
         assert keyword in p
 
 
+def test_build_prompt_humanize_lists_humanizer_rules():
+    p = build_prompt("humanize", "ABC 123", lang="French", original_lang="English")
+    assert "human wrote it" in p
+    for rule in ("active voice", "utilize", "em dashes", "rule-of-three", "in order to"):
+        assert rule in p
+
+
 def test_build_prompt_unknown_tactic_raises():
     with pytest.raises(ValueError):
         build_prompt("nope", "ABC", lang="French", original_lang="English")
@@ -166,6 +173,36 @@ def test_structural_and_backtranslate_prompts():
     for tactic in ("structural", "backtranslate"):
         p = build_prompt(tactic, "ABC 123", lang="German", original_lang="English")
         assert "ABC 123" in p
+
+
+def test_humanize_tactic_applies_deterministic_pass(monkeypatch):
+    """The humanize candidate is cleaned before evaluation: dashes and filler go."""
+    monkeypatch.setattr(
+        rewrite_text,
+        "call_ollama",
+        lambda *a, **k: "In order to see the result\u2014the answer\u2014utilize the tool",
+    )
+    out, info = rewrite(
+        "the cat sat on the mat",
+        **_rewrite_candidates_kwargs(tactic="humanize", candidates=1),
+    )
+    assert out == "To see the result, the answer, use the tool"
+    assert info["tactic"] == "humanize"
+    assert info["evaluator"] == "lexical-divergence"
+
+
+def test_non_humanize_tactic_skips_deterministic_pass(monkeypatch):
+    """Only the humanize tactic runs the humanizer pass."""
+    monkeypatch.setattr(
+        rewrite_text,
+        "call_ollama",
+        lambda *a, **k: "alpha\u2014beta in order to gamma",
+    )
+    out, _info = rewrite(
+        "the cat sat on the mat",
+        **_rewrite_candidates_kwargs(tactic="paraphrase", candidates=1),
+    )
+    assert out == "alpha\u2014beta in order to gamma"
 
 
 def test_lexical_divergence_identical_is_zero():


### PR DESCRIPTION
## What

Two related Layer B rewrite improvements plus a benchmark reporting change.

**1. `humanize` tactic now applies the humanizer skill deterministically.**
- New `service/scripts/humanize_pass.py`: a deterministic pass that runs on every `humanize` candidate before scoring — straightens curly quotes, collapses em/en dashes and double hyphens, flattens filler phrases, swaps `utilize` → `use`.
- `service/scripts/rewrite_text.py`: the `humanize` prompt now names the concrete human-writer rules (uneven rhythm, plain verbs, active voice, no promotional language / rule-of-three / filler / hedging / AI vocabulary), and the candidate loop runs the pass for `tactic == "humanize"`.

**2. New `mlm` rewrite tactic (non-autoregressive local edit).**
- `service/scripts/rewrite_text.py`: `mlm` masks ~`level` fraction of content words and infills them with `roberta-large` (a masked LM), so the output is a mix of the original token stream and MLM predictions rather than fresh LLM-sampled prose. No rewrite backend or API key required; accepted by `--tactic mlm`.
- `service/scripts/bench_synthid_text.py`: `mlm` registered in `parse_strategy`, and per-doc `human_like` now persisted in each candidate's `output_files` (previously aggregate-only).

## Why

The `humanize` tactic previously relied only on the rewriter prompt; the humanizer skill existed separately and was never wired in. The masked-LM tactic is a genuinely different "generation source" than an instruction-tuned LLM, which is what the Pangram human-likeness detector is sensitive to.

## Tests

- `tests/test_humanize_pass.py` — unit tests for the deterministic pass.
- `tests/test_rewrite_text.py` — integration tests for `humanize` applying the pass, non-humanize tactics skipping it, the prompt listing the rules, plus the `mlm` tactic.
- Bench suite (`tests/test_bench_synthid_text.py`) passes.

## Notes

The unrelated Pangram polling-timeout change in `service/scripts/bench_synthid_text.py` and the `WATERMARKS_HUMANIZE_PASS` A/B toggle are intentionally kept out of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `mlm` rewriting option that locally infills selected words, supports long text, and can use compatible GPU hardware.
  * Added a humanization pass that normalizes quotes and dashes, removes filler phrasing, and replaces overly formal wording while preserving capitalization, ranges, and command-line options.
  * Humanization results now include human-likeness scoring in strategy output metadata.

* **Bug Fixes**
  * Ensured deterministic cleanup applies only to humanization results; other rewriting modes remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->