### PR TITLE
fix(container): keep DOCX binary members byte-safe and report body Layer A (#312)

### DIFF
--- a/service/scripts/container_meta.py
+++ b/service/scripts/container_meta.py
@@ -1534,31 +1534,38 @@ def _inspect_odt_text(xml_text: str) -> tuple[int, list[dict]]:
     return total, hits
 
 
+def _layer_a_body_part(name: str, fmt: str) -> bool:
+    """True for the body parts a format's cleaner Layer-A scrubs.
+
+    Mirrors the case-sensitive ``startswith``/``endswith`` check used by the
+    OOXML/ODT cleaners, so /inspect selects exactly the archive entries /clean
+    touches (a case-variant name such as ``WORD/document.XML`` is left alone by
+    both) (#312).
+    """
+    if fmt == "odt":
+        return name == "content.xml"
+    if fmt == "docx":
+        return name.startswith("word/") and name.endswith(".xml")
+    if fmt == "xlsx":
+        return name.startswith("xl/") and name.endswith(".xml")
+    if fmt == "pptx":
+        return name.startswith("ppt/") and name.endswith(".xml")
+    return False
+
+
 def _inspect_container_body_layer_a(data: bytes, fmt: str) -> list[tuple[str, dict]]:
     """Per-part Layer A findings for the text runs clean_container() scrubs.
 
-    Only the body parts the cleaner touches are scanned (``word``/``xl``/``ppt``
-    XML parts, or ``content.xml`` for ODT) so /inspect predicts /clean rather
-    than contradicting it: the visible body legitimately mentions vendor names,
-    so only invisible/format carriers are relevant here (#312).
+    Scans the same body parts the cleaner touches (``word``/``xl``/``ppt`` XML
+    parts, or ``content.xml`` for ODT), so /inspect predicts /clean rather than
+    contradicting it (#312).
     """
-    if fmt == "odt":
-        part_re = re.compile(r"^content\.xml$", re.I)
-    elif fmt == "docx":
-        part_re = re.compile(r"^word/.+\.xml$", re.I)
-    elif fmt == "xlsx":
-        part_re = re.compile(r"^xl/.+\.xml$", re.I)
-    elif fmt == "pptx":
-        part_re = re.compile(r"^ppt/.+\.xml$", re.I)
-    else:
-        return []
-
     out: list[tuple[str, dict]] = []
     budget: list[int] = [0]
     try:
         with zipfile.ZipFile(io.BytesIO(data)) as zf:
             for info in zf.infolist():
-                if not part_re.match(info.filename):
+                if not _layer_a_body_part(info.filename, fmt):
                     continue
                 text = _read_zip_member(zf, info, budget).decode("utf-8", errors="replace")
                 if fmt == "docx":
@@ -1707,6 +1714,14 @@ def _prune_opf_manifest(raw: bytes, opf_name: str, dropped: set[str]) -> tuple[b
 def _scrub_ooxml_zip(
     data: bytes, fmt: str, *, also_layer_a_text: bool = True, normalize_spaces: bool = True
 ) -> tuple[bytes, list[str]]:
+    """Scrub provenance and Layer-A carriers from an OOXML zip container.
+
+    Rewrites the archive in place: metadata/provenance parts (docProps,
+    customXml, Content_Types overrides) are scrubbed or dropped, embedded media
+    under ``word``/``xl``/``ppt`` are cleaned, and text runs are Layer-A scrubbed
+    when requested. Binary docProps members (e.g. the thumbnail) are kept
+    byte-safe. Returns the rewritten bytes and a list of human-readable actions.
+    """
     actions: list[str] = []
     budget = [0]
     layer_removed = 0
@@ -2901,6 +2916,12 @@ def clean_pdf(path: Path, dest: Path, *, deep_images: str = "auto") -> tuple[lis
 
 
 def inspect_container(path: Path, *, data: bytes | None = None) -> ContainerInspectReport:
+    """Inspect a container for provenance, AI metadata, and Layer-A carriers.
+
+    Delegates to the format-specific inspector and unions in a Layer-A scan of
+    the visible text body for exactly the formats ``clean_container()`` scrubs,
+    so /inspect predicts what /clean removes rather than contradicting it.
+    """
     if data is None:
         data = path.read_bytes()
     fmt = detect_container_format(path, data)

--- a/service/scripts/container_meta.py
+++ b/service/scripts/container_meta.py
@@ -1917,12 +1917,11 @@ def clean_pptx(
     )
 
 
-def inspect_odt(data: bytes, budget: list[int] | None = None) -> tuple[bool, bool, list[str], dict]:
+def inspect_odt(data: bytes) -> tuple[bool, bool, list[str], dict]:
     findings: list[str] = []
     has_c2pa = False
     has_ai = False
-    if budget is None:
-        budget = [0]
+    budget = [0]
     try:
         with zipfile.ZipFile(io.BytesIO(data)) as zf:
             for info in zf.infolist():
@@ -2940,12 +2939,13 @@ def inspect_container(path: Path, *, data: bytes | None = None) -> ContainerInsp
     fmt = detect_container_format(path, data)
     tools: dict[str, Any] = {}
     details: dict[str, Any] = {}
-    # One shared ZIP decompression budget for the OOXML/ODT inspectors and the
-    # body Layer-A scan, so they cumulatively enforce the cap instead of each
+    # One shared ZIP decompression budget for the OOXML inspectors and the body
+    # Layer-A scan, so they cumulatively enforce the cap instead of each
     # resetting it: an archive with ~128 MiB of metadata/media plus ~128 MiB of
-    # body XML must not decompress both parts (#312 review). EPUB is left on its
-    # own budget because inspect_epub already reads every member, so sharing it
-    # with the Layer-A re-scan would double-charge the same body bytes.
+    # body XML must not decompress both parts (#312 review). ODT/EPUB use their
+    # own budgets because their inspectors already read every member, so sharing
+    # them with the body re-scan would charge content.xml twice and falsely
+    # reject a large but legitimate file.
     zip_budget: list[int] = [0]
 
     if fmt == "svg":
@@ -2960,7 +2960,11 @@ def inspect_container(path: Path, *, data: bytes | None = None) -> ContainerInsp
     elif fmt == "pptx":
         has_c2pa, has_ai, findings, details = inspect_pptx(data, zip_budget)
     elif fmt == "odt":
-        has_c2pa, has_ai, findings, details = inspect_odt(data, zip_budget)
+        # inspect_odt reads the whole archive (including content.xml), so it
+        # keeps its own budget: sharing the body-scan budget with it would
+        # charge content.xml twice (byte for byte) and falsely reject a large
+        # but legitimate ODT (#312 review).
+        has_c2pa, has_ai, findings, details = inspect_odt(data)
     elif fmt == "epub":
         has_c2pa, has_ai, findings, details = inspect_epub(data)
     elif fmt == "html":

--- a/service/scripts/container_meta.py
+++ b/service/scripts/container_meta.py
@@ -1494,6 +1494,94 @@ def _scrub_odt_text(xml_text: str, *, normalize_spaces: bool = True) -> tuple[st
     return "".join(out), removed, replaced
 
 
+def _inspect_text_runs(
+    xml_text: str, open_re: re.Pattern[str], close_re: re.Pattern[str]
+) -> tuple[int, list[dict]]:
+    """Layer A count/hits over text runs, mirroring _scrub_text_runs().
+
+    Character references are decoded exactly as the scrub decodes them (a
+    carrier written as ``&#x200B;`` is counted too), so /inspect reports the
+    same carriers that /clean will remove for the format (#312).
+    """
+    from text_unicode import inspect_text  # local import to avoid cycles
+
+    total = 0
+    hits: list[dict] = []
+    for _, oe, cs_, _ in _iter_tag_blocks(xml_text, open_re, close_re):
+        ta = inspect_text(_decode_xml_entities(xml_text[oe:cs_])).to_dict()
+        if ta["suspicious_total"]:
+            total += ta["suspicious_total"]
+            hits.extend(ta["hits"])
+    return total, hits
+
+
+def _inspect_odt_text(xml_text: str) -> tuple[int, list[dict]]:
+    """Layer A count/hits over ODF paragraph text, mirroring _scrub_odt_text()."""
+    from text_unicode import inspect_text  # local import to avoid cycles
+
+    total = 0
+    hits: list[dict] = []
+    for _, oe, cs_, _ in _iter_tag_blocks(
+        xml_text, re.compile(r"<text:p\b[^>]*>"), re.compile(r"</text:p>")
+    ):
+        for segment in re.split(r"(<[^>]+>)", xml_text[oe:cs_]):
+            if not segment or segment.startswith("<"):
+                continue
+            ta = inspect_text(_decode_xml_entities(segment)).to_dict()
+            if ta["suspicious_total"]:
+                total += ta["suspicious_total"]
+                hits.extend(ta["hits"])
+    return total, hits
+
+
+def _inspect_container_body_layer_a(data: bytes, fmt: str) -> list[tuple[str, dict]]:
+    """Per-part Layer A findings for the text runs clean_container() scrubs.
+
+    Only the body parts the cleaner touches are scanned (``word``/``xl``/``ppt``
+    XML parts, or ``content.xml`` for ODT) so /inspect predicts /clean rather
+    than contradicting it: the visible body legitimately mentions vendor names,
+    so only invisible/format carriers are relevant here (#312).
+    """
+    if fmt == "odt":
+        part_re = re.compile(r"^content\.xml$", re.I)
+    elif fmt == "docx":
+        part_re = re.compile(r"^word/.+\.xml$", re.I)
+    elif fmt == "xlsx":
+        part_re = re.compile(r"^xl/.+\.xml$", re.I)
+    elif fmt == "pptx":
+        part_re = re.compile(r"^ppt/.+\.xml$", re.I)
+    else:
+        return []
+
+    out: list[tuple[str, dict]] = []
+    budget: list[int] = [0]
+    try:
+        with zipfile.ZipFile(io.BytesIO(data)) as zf:
+            for info in zf.infolist():
+                if not part_re.match(info.filename):
+                    continue
+                text = _read_zip_member(zf, info, budget).decode("utf-8", errors="replace")
+                if fmt == "docx":
+                    total, hits = _inspect_text_runs(
+                        text, re.compile(r"<w:t\b[^>]*>"), re.compile(r"</w:t>")
+                    )
+                elif fmt == "xlsx":
+                    total, hits = _inspect_text_runs(
+                        text, re.compile(r"<t\b[^>]*>"), re.compile(r"</t>")
+                    )
+                elif fmt == "pptx":
+                    total, hits = _inspect_text_runs(
+                        text, re.compile(r"<a:t\b[^>]*>"), re.compile(r"</a:t>")
+                    )
+                else:  # odt
+                    total, hits = _inspect_odt_text(text)
+                if total:
+                    out.append((info.filename, {"suspicious_total": total, "hits": hits}))
+    except _ZIP_PARSE_ERRORS:
+        pass
+    return out
+
+
 def _prune_dangling_relationships(
     rels_name: str, raw: bytes, kept_names: set[str]
 ) -> tuple[bytes, int]:
@@ -1675,6 +1763,12 @@ def _scrub_ooxml_zip(
             if name in DOCX_META_PARTS or name.startswith("docProps/"):
                 if name.endswith("custom.xml"):
                     actions.append(f"drop part {name}")
+                    continue
+                if not name.lower().endswith(".xml"):
+                    # A binary docProps member (e.g. docProps/thumbnail.jpeg)
+                    # must stay byte-safe: decoding it as UTF-8 and re-encoding
+                    # corrupts it into U+FFFD replacement bytes (#312).
+                    kept.append((info, raw))
                     continue
                 text = raw.decode("utf-8", errors="replace")
                 new = text
@@ -2877,6 +2971,15 @@ def inspect_container(path: Path, *, data: bytes | None = None) -> ContainerInsp
                             )
         except zipfile.BadZipFile:
             pass
+    elif fmt in ("docx", "xlsx", "pptx", "odt"):
+        for part_name, ta in _inspect_container_body_layer_a(data, fmt):
+            layer_a_total += ta["suspicious_total"]
+            for h in ta["hits"]:
+                layer_a_hits.append(h)
+                findings.append(
+                    f"layer-a ({part_name}): {h['codepoint']} {h['label']} "
+                    f"x{h['count']} ({h['kind']})"
+                )
 
     notes: list[str] = []
     if fmt == "pdf":

--- a/service/scripts/container_meta.py
+++ b/service/scripts/container_meta.py
@@ -1239,12 +1239,15 @@ def _is_docx_meta_part(name: str) -> bool:
     return name.startswith(("docProps/", "customXml/"))
 
 
-def _inspect_ooxml_zip(data: bytes, fmt: str) -> tuple[bool, bool, list[str], dict]:
+def _inspect_ooxml_zip(
+    data: bytes, fmt: str, budget: list[int] | None = None
+) -> tuple[bool, bool, list[str], dict]:
     findings: list[str] = []
     has_c2pa = False
     has_ai = False
     parts: list[str] = []
-    budget = [0]
+    if budget is None:
+        budget = [0]
     try:
         with zipfile.ZipFile(io.BytesIO(data)) as zf:
             parts = zf.namelist()
@@ -1317,16 +1320,22 @@ def _inspect_ooxml_zip(data: bytes, fmt: str) -> tuple[bool, bool, list[str], di
     return has_c2pa, has_ai or has_c2pa, findings, {"parts": len(parts)}
 
 
-def inspect_docx(data: bytes) -> tuple[bool, bool, list[str], dict]:
-    return _inspect_ooxml_zip(data, "docx")
+def inspect_docx(
+    data: bytes, budget: list[int] | None = None
+) -> tuple[bool, bool, list[str], dict]:
+    return _inspect_ooxml_zip(data, "docx", budget)
 
 
-def inspect_xlsx(data: bytes) -> tuple[bool, bool, list[str], dict]:
-    return _inspect_ooxml_zip(data, "xlsx")
+def inspect_xlsx(
+    data: bytes, budget: list[int] | None = None
+) -> tuple[bool, bool, list[str], dict]:
+    return _inspect_ooxml_zip(data, "xlsx", budget)
 
 
-def inspect_pptx(data: bytes) -> tuple[bool, bool, list[str], dict]:
-    return _inspect_ooxml_zip(data, "pptx")
+def inspect_pptx(
+    data: bytes, budget: list[int] | None = None
+) -> tuple[bool, bool, list[str], dict]:
+    return _inspect_ooxml_zip(data, "pptx", budget)
 
 
 _XML_CHAR_REF_RE = re.compile(r"&#(?:x([0-9A-Fa-f]+)|([0-9]+));|&(amp|lt|gt|quot|apos);")
@@ -1553,7 +1562,9 @@ def _layer_a_body_part(name: str, fmt: str) -> bool:
     return False
 
 
-def _inspect_container_body_layer_a(data: bytes, fmt: str) -> list[tuple[str, dict]]:
+def _inspect_container_body_layer_a(
+    data: bytes, fmt: str, budget: list[int] | None = None
+) -> list[tuple[str, dict]]:
     """Per-part Layer A findings for the text runs clean_container() scrubs.
 
     Scans the same body parts the cleaner touches (``word``/``xl``/``ppt`` XML
@@ -1561,7 +1572,8 @@ def _inspect_container_body_layer_a(data: bytes, fmt: str) -> list[tuple[str, di
     contradicting it (#312).
     """
     out: list[tuple[str, dict]] = []
-    budget: list[int] = [0]
+    if budget is None:
+        budget = [0]
     try:
         with zipfile.ZipFile(io.BytesIO(data)) as zf:
             for info in zf.infolist():
@@ -1905,11 +1917,12 @@ def clean_pptx(
     )
 
 
-def inspect_odt(data: bytes) -> tuple[bool, bool, list[str], dict]:
+def inspect_odt(data: bytes, budget: list[int] | None = None) -> tuple[bool, bool, list[str], dict]:
     findings: list[str] = []
     has_c2pa = False
     has_ai = False
-    budget = [0]
+    if budget is None:
+        budget = [0]
     try:
         with zipfile.ZipFile(io.BytesIO(data)) as zf:
             for info in zf.infolist():
@@ -2927,6 +2940,13 @@ def inspect_container(path: Path, *, data: bytes | None = None) -> ContainerInsp
     fmt = detect_container_format(path, data)
     tools: dict[str, Any] = {}
     details: dict[str, Any] = {}
+    # One shared ZIP decompression budget for the OOXML/ODT inspectors and the
+    # body Layer-A scan, so they cumulatively enforce the cap instead of each
+    # resetting it: an archive with ~128 MiB of metadata/media plus ~128 MiB of
+    # body XML must not decompress both parts (#312 review). EPUB is left on its
+    # own budget because inspect_epub already reads every member, so sharing it
+    # with the Layer-A re-scan would double-charge the same body bytes.
+    zip_budget: list[int] = [0]
 
     if fmt == "svg":
         has_c2pa, has_ai, findings, details = inspect_svg(data)
@@ -2934,13 +2954,13 @@ def inspect_container(path: Path, *, data: bytes | None = None) -> ContainerInsp
         has_c2pa, has_ai, findings, details = inspect_pdf(path, data)
         tools = details.pop("tools", {})
     elif fmt == "docx":
-        has_c2pa, has_ai, findings, details = inspect_docx(data)
+        has_c2pa, has_ai, findings, details = inspect_docx(data, zip_budget)
     elif fmt == "xlsx":
-        has_c2pa, has_ai, findings, details = inspect_xlsx(data)
+        has_c2pa, has_ai, findings, details = inspect_xlsx(data, zip_budget)
     elif fmt == "pptx":
-        has_c2pa, has_ai, findings, details = inspect_pptx(data)
+        has_c2pa, has_ai, findings, details = inspect_pptx(data, zip_budget)
     elif fmt == "odt":
-        has_c2pa, has_ai, findings, details = inspect_odt(data)
+        has_c2pa, has_ai, findings, details = inspect_odt(data, zip_budget)
     elif fmt == "epub":
         has_c2pa, has_ai, findings, details = inspect_epub(data)
     elif fmt == "html":
@@ -2993,7 +3013,7 @@ def inspect_container(path: Path, *, data: bytes | None = None) -> ContainerInsp
         except zipfile.BadZipFile:
             pass
     elif fmt in ("docx", "xlsx", "pptx", "odt"):
-        for part_name, ta in _inspect_container_body_layer_a(data, fmt):
+        for part_name, ta in _inspect_container_body_layer_a(data, fmt, zip_budget):
             layer_a_total += ta["suspicious_total"]
             for h in ta["hits"]:
                 layer_a_hits.append(h)

--- a/tests/test_container_meta.py
+++ b/tests/test_container_meta.py
@@ -975,6 +975,33 @@ def test_inspect_container_shares_zip_budget_across_scans(monkeypatch):
     assert rep.layer_a_total == 0
 
 
+def test_inspect_odt_content_xml_not_rejected_at_budget_boundary(monkeypatch):
+    # ODT content.xml is the visible body. Its bytes must not be charged to the
+    # shared budget by both inspect_odt and the body Layer-A scan, or a
+    # content.xml just under the cap is falsely rejected with ZipBudgetExceeded
+    # (#312 review).
+    import container_meta
+
+    def make_odt(content_len: int) -> bytes:
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_STORED) as zf:
+            zf.writestr("mimetype", "application/vnd.oasis.opendocument.text")
+            zf.writestr("meta.xml", "<office:document-meta/>")
+            zf.writestr("META-INF/manifest.xml", "<manifest:manifest/>")
+            zf.writestr(
+                "content.xml",
+                b"<office:document-content>" + b" " * content_len + b"</office:document-content>",
+            )
+        return buf.getvalue()
+
+    cap = 1000
+    content = 600  # fits under the cap once; would exceed it if charged twice
+    assert content < cap and 2 * content > cap
+    monkeypatch.setattr(container_meta, "MAX_ZIP_DECOMPRESSED_BYTES", cap)
+    rep = inspect_container(Path("x.odt"), data=make_odt(content))
+    assert rep.format == "odt"
+
+
 def test_zip_budget_rejection_propagates_from_detect_container_format_mimetype(monkeypatch):
     import container_meta
 

--- a/tests/test_container_meta.py
+++ b/tests/test_container_meta.py
@@ -376,11 +376,19 @@ def test_docx_thumbnail_binary_member_preserved():
     with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
         zf.writestr(
             "word/document.xml",
-            '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>Hello</w:t></w:r></w:p></w:body></w:document>',
+            (
+                '<w:document xmlns:w="http://schemas.openxmlformats.org/'
+                'wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>Hello</w:t>'
+                "</w:r></w:p></w:body></w:document>"
+            ),
         )
         zf.writestr(
             "docProps/core.xml",
-            "<cp:coreProperties xmlns:cp='http://schemas.openxmlformats.org/package/2006/metadata/core-properties' xmlns:dc='http://purl.org/dc/elements/1.1/'><dc:creator>Bot</dc:creator></cp:coreProperties>",
+            (
+                "<cp:coreProperties xmlns:cp='http://schemas.openxmlformats.org/package/"
+                "2006/metadata/core-properties' xmlns:dc='http://purl.org/dc/elements/"
+                "1.1/'><dc:creator>Bot</dc:creator></cp:coreProperties>"
+            ),
         )
         zf.writestr("docProps/thumbnail.jpeg", jpeg)
 
@@ -402,11 +410,18 @@ def test_docx_inspect_reports_body_layer_a_carriers(tmp_path: Path):
     with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
         zf.writestr(
             "word/document.xml",
-            '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>Hello\u200bWorld</w:t></w:r></w:p></w:body></w:document>',
+            (
+                '<w:document xmlns:w="http://schemas.openxmlformats.org/'
+                'wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>Hello\u200bWorld</w:t>'
+                "</w:r></w:p></w:body></w:document>"
+            ),
         )
         zf.writestr(
             "word/footer1.xml",
-            '<w:ftr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:p><w:r><w:t>Foot\u200bnote</w:t></w:r></w:p></w:ftr>',
+            (
+                '<w:ftr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/'
+                '2006/main"><w:p><w:r><w:t>Foot\u200bnote</w:t></w:r></w:p></w:ftr>'
+            ),
         )
 
     path = tmp_path / "doc.docx"

--- a/tests/test_container_meta.py
+++ b/tests/test_container_meta.py
@@ -951,6 +951,30 @@ def test_zip_budget_rejection_propagates_from_inspect(monkeypatch):
         inspect_docx(buf.getvalue())
 
 
+def test_inspect_container_shares_zip_budget_across_scans(monkeypatch):
+    # The body Layer-A scan must share the format inspector's decompression
+    # budget, so an archive of ~half-cap metadata + ~half-cap body XML cannot
+    # decompress both past the processing cap (#312 review).
+    import container_meta
+
+    def make_docx(member_len: int) -> bytes:
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_STORED) as zf:
+            zf.writestr("docProps/core.xml", b" " * member_len)
+            zf.writestr("word/document.xml", b"<w:document>" + b" " * member_len + b"</w:document>")
+        return buf.getvalue()
+
+    cap = 1000
+    member = 600  # each member fits under the cap; the two together do not
+    assert member < cap and 2 * member > cap
+    monkeypatch.setattr(container_meta, "MAX_ZIP_DECOMPRESSED_BYTES", cap)
+    with pytest.raises(container_meta.ZipBudgetExceeded):
+        inspect_container(Path("x.docx"), data=make_docx(member))
+    # A single small member stays under the cumulative cap.
+    rep = inspect_container(Path("x.docx"), data=make_docx(100))
+    assert rep.layer_a_total == 0
+
+
 def test_zip_budget_rejection_propagates_from_detect_container_format_mimetype(monkeypatch):
     import container_meta
 

--- a/tests/test_container_meta.py
+++ b/tests/test_container_meta.py
@@ -368,6 +368,63 @@ def test_docx_dropped_customxml_prunes_dangling_relationships():
     assert any("prune dangling relationships" in a for a in actions)
 
 
+def test_docx_thumbnail_binary_member_preserved():
+    """docProps/thumbnail.jpeg must stay byte-safe: decoding it as UTF-8 text and
+    re-encoding corrupts a binary member into U+FFFD replacement bytes (#312)."""
+    jpeg = bytes.fromhex("FFD8FFE0") + b"\x00\x10JFIF\x00" + b"\xde\xad\xbe\xef" * 64
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(
+            "word/document.xml",
+            '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>Hello</w:t></w:r></w:p></w:body></w:document>',
+        )
+        zf.writestr(
+            "docProps/core.xml",
+            "<cp:coreProperties xmlns:cp='http://schemas.openxmlformats.org/package/2006/metadata/core-properties' xmlns:dc='http://purl.org/dc/elements/1.1/'><dc:creator>Bot</dc:creator></cp:coreProperties>",
+        )
+        zf.writestr("docProps/thumbnail.jpeg", jpeg)
+
+    cleaned, _actions = clean_docx(buf.getvalue())
+    with zipfile.ZipFile(io.BytesIO(cleaned)) as zf:
+        out = zf.read("docProps/thumbnail.jpeg")
+        core = zf.read("docProps/core.xml").decode("utf-8")
+    assert out == jpeg
+    assert out.startswith(b"\xff\xd8\xff\xe0")
+    assert b"\xef\xbf\xbd" not in out
+    # XML provenance scrubbing on the same tree still works
+    assert "Bot" not in core
+
+
+def test_docx_inspect_reports_body_layer_a_carriers(tmp_path: Path):
+    """/inspect must report the Layer A carriers /clean removes from the visible
+    body text runs (word/*.xml), not only provenance/media parts (#312)."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(
+            "word/document.xml",
+            '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>Hello\u200bWorld</w:t></w:r></w:p></w:body></w:document>',
+        )
+        zf.writestr(
+            "word/footer1.xml",
+            '<w:ftr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:p><w:r><w:t>Foot\u200bnote</w:t></w:r></w:p></w:ftr>',
+        )
+
+    path = tmp_path / "doc.docx"
+    path.write_bytes(buf.getvalue())
+
+    rep = inspect_container(path)
+    assert rep.layer_a_total == 2
+    assert rep.layer_a_hits
+    assert any("word/document.xml" in f for f in rep.findings)
+    assert any("word/footer1.xml" in f for f in rep.findings)
+
+    out = tmp_path / "doc_clean.docx"
+    clean_container(path, out)
+    after = inspect_container(out)
+    assert after.layer_a_total == 0
+    assert after.layer_a_hits == []
+
+
 def _make_docx_with_body_text(body_text: str = "Claude wrote this.") -> bytes:
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w") as zf:


### PR DESCRIPTION
Fixes #312.

## Problem

`/clean` on a DOCX with a `docProps/thumbnail.jpeg` corrupted the thumbnail: its header went from `FF D8 FF E0` (valid JPEG) to `EF BF BD EF` (UTF-8 for U+FFFD). Meanwhile `/inspect` reported `suspicious_total: 0` while `/clean` removed 11 U+200B characters from `word/document.xml` and `word/footer1.xml`.

## Root cause (both in `service/scripts/container_meta.py`)

1. **Binary corruption** — the `docProps/` scrub branch matched `docProps/thumbnail.jpeg` via the `docProps/` prefix, then unconditionally decoded the member as UTF-8 with `errors="replace"` and re-encoded it. Non-UTF-8 binary bytes became U+FFFD and were re-encoded to `EF BF BD`.
2. **Inspect/clean mismatch** — `inspect_container` ran the Layer A text scan only for markdown/HTML/EPUB. For OOXML/ODT it scanned only provenance/media parts and skipped the visible body, so `layer_a_total` stayed 0 while `clean_docx` removed carriers from the `<w:t>` runs.

## Fix

- **Binary safety**: non-`.xml` members under `docProps/` are now kept byte-identical instead of decoded/re-encoded. Verified the thumbnail is byte-for-byte preserved after cleaning.
- **Inspect parity**: added `_inspect_text_runs`, `_inspect_odt_text`, and `_inspect_container_body_layer_a`, wired into `inspect_container`. They scan exactly the text runs the cleaners scrub (`<w:t>`, `<t>`, `<a:t>`, `text:p`), decoding XML character references the same way, so `/inspect` now predicts what `/clean` removes. Confirmed for DOCX (U+200B), XLSX (U+200B), and PPTX (U+200D) via `inspect_container`.

## Notes

`dc:title` retention is intentional and already documented in `DOCX_SCRUB_FIELDS` (it is the document's own heading, not provenance; blanking it would produce schema-invalid output per #283).

## Verification

- Added regression tests: `test_docx_thumbnail_binary_member_preserved` and `test_docx_inspect_reports_body_layer_a_carriers`.
- `python -m pytest` — full suite passes.
- `ruff check` and `ruff format --check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added inspection support for visible text in DOCX, XLSX, PPTX, and ODT files.
  - Suspicious content is reported by document part, including matching characters and totals.
  - XML entities are decoded during inspection for more accurate results.
  - OOXML scans share a cumulative decompression limit, while ODT archive scanning retains a separate limit.

- **Bug Fixes**
  - Preserved binary document properties, including embedded thumbnails, without altering their contents.
  - Document cleaning now removes invisible-character carriers from DOCX body and footer text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->