### PR TITLE
feat(clean): run benchmark-best Layer B strategy via /clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 !/.github/**
 !/benchmarks/
 !/benchmarks/**
+!/config/
+!/config/**
 !/docs/
 !/docs/**
 !/service/

--- a/README.md
+++ b/README.md
@@ -358,6 +358,13 @@ APIs unless you ask it to:
 - **`/clean`** accepts `"detect_before"` / `"detect_after"` options to
   score the input and the cleaned output, so you can measure what a clean
   actually changed.
+- **`/clean`** also accepts a **`"strategy"`** option (an ordered
+  `tactic@intensity` list, e.g. `"paraphrase@0.8,mlm@0.2"`) that runs the
+  Layer B text rewrite after Layer A. When omitted, the default strategy from
+  the strategy config file is used (see below). If the rewrite backend/model
+  for a step isn't configured, `/clean` returns a 400.
+
+Text detectors (see `/capabilities` → `text_detectors`):
 
 Text detectors (see `/capabilities` → `text_detectors`):
 
@@ -457,9 +464,12 @@ set -a; . ./.env; set +a; python3 service/scripts/rewrite_text.py /tmp/x.txt -o 
 | `WATERMARKS_REWRITE_API_KEY` | `rewrite_text.py` hook | API key — env only, never on argv |
 | `WATERMARKS_REWRITE_ALLOW_REMOTE` | `rewrite_text.py` hook | `1` to allow non-loopback endpoints |
 | `WATERMARKS_REWRITE_REASONING_EFFORT` | `rewrite_text.py` hook | `none` (default) / `low` / `medium` / `high` / `off` |
+| `WATERMARKS_CLEAN_STRATEGY_FILE` | `server.py` `/clean` | Path to the Layer B strategy config JSON (default `config/clean_strategy.json`) |
 | `WATERMARKS_GUMBEL_KEY` | `detect_gumbel.py` / `text_detectors.py` | Secret key for keyed-Gumbel (EXP) same-key replay (e.g. `0x…`); preferred over argv — never logged |
 
-Layer B is agent-orchestrated in the skill (it rewrites with its own model), so the `WATERMARKS_REWRITE_*` vars are only needed when driving `rewrite_text.py` directly.
+Layer B is agent-orchestrated in the skill (it rewrites with its own model), so the `WATERMARKS_REWRITE_*` vars are only needed when driving `rewrite_text.py` directly, or when `/clean` runs a Layer B strategy that includes an LLM step.
+
+The `/clean` Layer B default comes from `config/clean_strategy.json` (`{"default_strategy": "paraphrase@0.8,mlm@0.2"}`). It is applied to every text clean after Layer A, unless the request passes its own `"strategy"` option. A strategy step is `tactic@intensity`; `mlm` is a local masked-LM edit (requires `transformers` + `roberta-large`), other tactics need the `WATERMARKS_REWRITE_*` LLM config. If a step's backend/model is unavailable, `/clean` rejects with a 400.
 
 Images publish automatically on `v*` tags via [`.github/workflows/release-images.yml`](.github/workflows/release-images.yml).
 

--- a/README.md
+++ b/README.md
@@ -423,7 +423,12 @@ Checks `wr-core` via `GET /health` and runs each harness/heavy service with `--h
 
 ### Configuration (env vars for docker compose)
 
-**Nothing is required to clean arbitrary text** — the core service works out of the box:
+**Text cleaning requires Layer B configuration** — the Layer B rewrite is a
+required step for `POST /clean` on text, so the core service needs the rewrite
+backend set up, or text cleaning returns HTTP 400. Image/container metadata
+cleaning works out of the box. For text you must configure the Layer B strategy
+dependencies: `transformers` + `roberta-large` (for the default `mlm` step) and
+the `WATERMARKS_REWRITE_*` LLM config (for the `paraphrase` step):
 
 ```bash
 echo "Hello\u200bWorld\u00ad!" > /tmp/sample.txt

--- a/README.md
+++ b/README.md
@@ -358,11 +358,11 @@ APIs unless you ask it to:
 - **`/clean`** accepts `"detect_before"` / `"detect_after"` options to
   score the input and the cleaned output, so you can measure what a clean
   actually changed.
-- **`/clean`** also accepts a **`"strategy"`** option (an ordered
-  `tactic@intensity` list, e.g. `"paraphrase@0.8,mlm@0.2"`) that runs the
-  Layer B text rewrite after Layer A. When omitted, the default strategy from
-  the strategy config file is used (see below). If the rewrite backend/model
-  for a step isn't configured, `/clean` returns a 400.
+- **`/clean`** runs the Layer B text rewrite after Layer A **by default** (it
+  is a required step for text). A **`"strategy"`** option (an ordered
+  `tactic@intensity` list, e.g. `"paraphrase@0.8,mlm@0.2"`) overrides the
+  default from the strategy config file (see below). When the rewrite
+  backend/model for a step isn't configured, `/clean` returns a 400.
 
 Text detectors (see `/capabilities` → `text_detectors`):
 
@@ -467,9 +467,8 @@ set -a; . ./.env; set +a; python3 service/scripts/rewrite_text.py /tmp/x.txt -o 
 | `WATERMARKS_CLEAN_STRATEGY_FILE` | `server.py` `/clean` | Path to the Layer B strategy config JSON (default `config/clean_strategy.json`) |
 | `WATERMARKS_GUMBEL_KEY` | `detect_gumbel.py` / `text_detectors.py` | Secret key for keyed-Gumbel (EXP) same-key replay (e.g. `0x…`); preferred over argv — never logged |
 
-Layer B is agent-orchestrated in the skill (it rewrites with its own model), so the `WATERMARKS_REWRITE_*` vars are only needed when driving `rewrite_text.py` directly, or when `/clean` runs a Layer B strategy that includes an LLM step.
-
-The `/clean` Layer B default comes from `config/clean_strategy.json` (`{"default_strategy": "paraphrase@0.8,mlm@0.2"}`). It is applied to every text clean after Layer A, unless the request passes its own `"strategy"` option. A strategy step is `tactic@intensity`; `mlm` is a local masked-LM edit (requires `transformers` + `roberta-large`), other tactics need the `WATERMARKS_REWRITE_*` LLM config. If a step's backend/model is unavailable, `/clean` rejects with a 400.
+**Layer B is required for text cleaning.** `/clean` always applies the default
+strategy (from `config/clean_strategy.json`, `{"default_strategy": "paraphrase@0.8,mlm@0.2"}`) to a text file after Layer A, unless the request passes its own `"strategy"` option (an ordered `tactic@intensity` list). A strategy step is `tactic@intensity`; the `mlm` step needs `transformers` + `roberta-large`, and any LLM step (`paraphrase`, `humanize`, …) needs the `WATERMARKS_REWRITE_*` config. If the required backend/model isn't configured — or no strategy is available — `/clean` **rejects the request with a 400**. Precedence for the config path: `--strategy-config` CLI flag > `WATERMARKS_CLEAN_STRATEGY_FILE` env var > the default `config/clean_strategy.json`.
 
 Images publish automatically on `v*` tags via [`.github/workflows/release-images.yml`](.github/workflows/release-images.yml).
 

--- a/config/clean_strategy.json
+++ b/config/clean_strategy.json
@@ -1,0 +1,3 @@
+{
+  "default_strategy": "paraphrase@0.8,mlm@0.2"
+}

--- a/service/scripts/rewrite_text.py
+++ b/service/scripts/rewrite_text.py
@@ -1146,8 +1146,6 @@ def apply_strategy(
                 temperature,
                 reasoning_effort,
             )
-            if layer_a_after and cur:
-                cur = clean_text(cur)[0]
         step_stats.append(
             {
                 "tactic": tactic,
@@ -1156,6 +1154,9 @@ def apply_strategy(
                 "out_chars": len(cur),
             }
         )
+    # Layer A scrub once, on the complete strategy output (not per step).
+    if layer_a_after and cur:
+        cur = clean_text(cur)[0]
     return cur, {
         "backend": backend,
         "tactic": "strategy",
@@ -1357,6 +1358,10 @@ def main() -> int:
             return 2
     try:
         if steps is not None:
+            # Enforce the remote-endpoint policy for a strategy, same as the
+            # single-tactic rewrite path.
+            if any(t in LLM_TACTICS for t, _ in steps) and args.base_url:
+                _check_remote(args.base_url, allow_remote)
             result, info = apply_strategy(
                 text,
                 steps,

--- a/service/scripts/rewrite_text.py
+++ b/service/scripts/rewrite_text.py
@@ -1052,6 +1052,121 @@ def rewrite(
     return out, info
 
 
+# Tactics accepted by a strategy spec. `mlm` is a local masked-LM edit; the
+# rest go through the configured rewrite backend.
+KNOWN_TACTICS = frozenset(
+    {"paraphrase", "backtranslate", "structural", "humanize", "code", "chunk", "mlm"}
+)
+LLM_TACTICS = frozenset(KNOWN_TACTICS - {"mlm"})
+
+
+def parse_strategy(spec: str) -> list[tuple[str, float]]:
+    """Parse a strategy like ``"paraphrase@0.8,mlm@0.2"`` -> [(tactic, intensity)].
+
+    Validates tactic names and that intensity lies in (0,1]. Raises ValueError on
+    malformed input (callers treat a bad strategy as a request error).
+    """
+    if not spec or not spec.strip():
+        raise ValueError("strategy must be a non-empty list of tactic@intensity steps")
+    steps: list[tuple[str, float]] = []
+    for raw in spec.split(","):
+        item = raw.strip()
+        if not item:
+            raise ValueError(f"bad strategy step {item!r}; expected tactic@intensity")
+        if "@" not in item:
+            raise ValueError(f"bad strategy step {item!r}; expected tactic@intensity")
+        tactic, raw_level = item.rsplit("@", 1)
+        tactic = tactic.strip()
+        if tactic not in KNOWN_TACTICS:
+            raise ValueError(f"unknown strategy tactic {tactic!r}")
+        try:
+            level = float(raw_level)
+        except ValueError:
+            raise ValueError(f"bad intensity in strategy step {item!r}") from None
+        if not (0 < level <= 1):
+            raise ValueError(f"strategy intensity must be in (0,1], got {level} in {item!r}")
+        steps.append((tactic, level))
+    return steps
+
+
+def apply_strategy(
+    text: str,
+    steps: list[tuple[str, float]],
+    *,
+    backend: str,
+    model: str | None,
+    base_url: str | None,
+    api_key: str | None,
+    timeout: float = 120.0,
+    temperature: float = 0.9,
+    reasoning_effort: str | None = None,
+    lang: str = "French",
+    original_lang: str = "English",
+    style: str | None = None,
+    layer_a_after: bool = False,
+) -> tuple[str, dict[str, Any]]:
+    """Apply a strategy's steps sequentially to *text* (best-effort rewrite).
+
+    Unlike ``rewrite()`` this does not run a detection/evaluation loop — each
+    step is applied exactly once and feeds the next, so it suits an operation
+    that wants the rewrite regardless of a removal verdict. ``mlm`` steps use a
+    local masked-LM edit; every other tactic makes one backend generation via
+    ``build_prompt``/``_generate_once``. Returns (final_text, stats) where stats
+    carries per-step tactic/intensity/input-output lengths.
+    """
+    needs_llm = any(t in LLM_TACTICS for t, _ in steps)
+    if needs_llm:
+        if backend not in ("openai-compatible", "ollama"):
+            raise RuntimeError(f"strategy needs an LLM backend, got {backend!r}")
+        if not model or not base_url:
+            raise RuntimeError("strategy needs --model and --base-url for LLM steps")
+
+    cur = text
+    step_stats: list[dict[str, Any]] = []
+    for tactic, intensity in steps:
+        in_chars = len(cur)
+        if tactic == "mlm":
+            cur = _mlm_infill(cur, intensity)
+        else:
+            prompt = build_prompt(
+                tactic,
+                cur,
+                lang=lang,
+                original_lang=original_lang,
+                rewrite_level=intensity,
+                style=style,
+            )
+            cur = _generate_once(
+                backend,
+                base_url,
+                model,
+                api_key,
+                prompt,
+                timeout,
+                temperature,
+                reasoning_effort,
+            )
+            if layer_a_after and cur:
+                cur = clean_text(cur)[0]
+        step_stats.append(
+            {
+                "tactic": tactic,
+                "intensity": round(intensity, 4),
+                "in_chars": in_chars,
+                "out_chars": len(cur),
+            }
+        )
+    return cur, {
+        "backend": backend,
+        "tactic": "strategy",
+        "mode": "strategy",
+        "strategy": [f"{t}@{i:g}" for t, i in steps],
+        "steps": step_stats,
+        "input_chars": len(text),
+        "output_chars": len(cur),
+    }
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build CLI argument parser for text rewrite tool."""
     p = argparse.ArgumentParser(description=__doc__)
@@ -1088,6 +1203,14 @@ def build_parser() -> argparse.ArgumentParser:
         "--tactic",
         choices=("paraphrase", "backtranslate", "structural", "humanize", "code", "chunk", "mlm"),
         default="paraphrase",
+    )
+    p.add_argument(
+        "--strategy",
+        default=None,
+        help="Ordered tactic@intensity strategy to apply (e.g. "
+        "'paraphrase@0.8,mlm@0.2'). When set, applies the whole strategy "
+        "sequentially (each step feeds the next) instead of a single --tactic; "
+        "no detection/evaluation loop.",
     )
     p.add_argument(
         "--style",
@@ -1225,35 +1348,63 @@ def main() -> int:
         if args.allow_remote is not None
         else _flag_env("WATERMARKS_REWRITE_ALLOW_REMOTE")
     )
+    steps: list[tuple[str, float]] | None = None
+    if args.strategy:
+        try:
+            steps = parse_strategy(args.strategy)
+        except ValueError as e:
+            eprint(f"error: {e}")
+            return 2
     try:
-        result, info = rewrite(
-            text,
-            backend=args.backend,
-            model=args.model,
-            base_url=args.base_url,
-            api_key=_env("WATERMARKS_REWRITE_API_KEY"),
-            tactic=args.tactic,
-            style=args.style,
-            lang=args.lang,
-            original_lang=args.original_lang,
-            timeout=args.timeout,
-            layer_a_after=not args.no_layer_a_after,
-            temperature=args.temperature,
-            candidates=args.candidates,
-            max_loops=args.max_loops,
-            allow_remote=allow_remote,
-            reasoning_effort=(None if args.reasoning_effort == "off" else args.reasoning_effort),
-            markllm_scheme=args.markllm_scheme,
-            markllm_dir=args.markllm_dir,
-            markllm_model=args.markllm_model,
-            markllm_timeout=args.markllm_timeout,
-            gumbel_key=args.gumbel_key,
-            rewrite_level=args.rewrite_level,
-            target_margin=args.target_margin,
-            selection=args.select,
-            chunk_shuffle=args.chunk_shuffle,
-            noop_lex_floor=args.noop_lex_floor,
-        )
+        if steps is not None:
+            result, info = apply_strategy(
+                text,
+                steps,
+                backend=args.backend,
+                model=args.model,
+                base_url=args.base_url,
+                api_key=_env("WATERMARKS_REWRITE_API_KEY"),
+                timeout=args.timeout,
+                temperature=args.temperature,
+                reasoning_effort=(
+                    None if args.reasoning_effort == "off" else args.reasoning_effort
+                ),
+                lang=args.lang,
+                original_lang=args.original_lang,
+                style=args.style,
+                layer_a_after=not args.no_layer_a_after,
+            )
+        else:
+            result, info = rewrite(
+                text,
+                backend=args.backend,
+                model=args.model,
+                base_url=args.base_url,
+                api_key=_env("WATERMARKS_REWRITE_API_KEY"),
+                tactic=args.tactic,
+                style=args.style,
+                lang=args.lang,
+                original_lang=args.original_lang,
+                timeout=args.timeout,
+                layer_a_after=not args.no_layer_a_after,
+                temperature=args.temperature,
+                candidates=args.candidates,
+                max_loops=args.max_loops,
+                allow_remote=allow_remote,
+                reasoning_effort=(
+                    None if args.reasoning_effort == "off" else args.reasoning_effort
+                ),
+                markllm_scheme=args.markllm_scheme,
+                markllm_dir=args.markllm_dir,
+                markllm_model=args.markllm_model,
+                markllm_timeout=args.markllm_timeout,
+                gumbel_key=args.gumbel_key,
+                rewrite_level=args.rewrite_level,
+                target_margin=args.target_margin,
+                selection=args.select,
+                chunk_shuffle=args.chunk_shuffle,
+                noop_lex_floor=args.noop_lex_floor,
+            )
     except (urllib.error.URLError, TimeoutError, RuntimeError) as e:
         eprint(f"rewrite failed: {e}")
         return 1

--- a/service/scripts/server.py
+++ b/service/scripts/server.py
@@ -1045,18 +1045,22 @@ def _clean_payload(data: bytes, name: str, options: dict[str, Any]) -> dict[str,
                 aggressive_homoglyphs=bool(options.get("aggressive_homoglyphs")),
                 normalize_spaces=bool(options.get("normalize_spaces", True)),
             )
-            # Layer B: apply the default (or per-request) rewrite strategy. Raises
-            # ValueError (400) if the backend/model for a step is unavailable.
+            # Layer B is a required step for text cleaning: always apply the
+            # default (or per-request) rewrite strategy and reject (400) when no
+            # strategy is available or a step's backend/model can't run.
             strategy = options.get("strategy") or _DEFAULT_STRATEGY
-            layer_b: dict[str, Any] | None = None
-            if strategy:
-                cleaned, layer_b = _apply_layer_b(cleaned, strategy, options)
+            if not strategy:
+                raise ValueError(
+                    "Layer B rewrite is required for text cleaning; configure a "
+                    "default strategy (config/clean_strategy.json) or pass "
+                    "options.strategy"
+                )
+            cleaned, layer_b = _apply_layer_b(cleaned, strategy, options)
             if detect_after:
                 detector_reports["after"] = run_text_detectors(cleaned)
             cleaned_bytes = cleaned.encode("utf-8", errors="surrogateescape")
             report: dict[str, Any] = {"kind": "text", "stats": stats, "length": len(cleaned)}
-            if layer_b is not None:
-                report["layer_b"] = layer_b
+            report["layer_b"] = layer_b
             if detector_reports:
                 report["text_detectors"] = detector_reports
         elif kind == "image":

--- a/service/scripts/server.py
+++ b/service/scripts/server.py
@@ -98,7 +98,12 @@ ALLOWED_CLEAN_OPTIONS = {
     "detect_after": bool,
     "deep_images": str,
     "style": str,
+    "strategy": str,
 }
+
+# Default Layer B strategy loaded from the strategy config file (overridable by
+# env/CLI). None means no Layer B rewrite on text.
+_DEFAULT_STRATEGY: str | None = None
 
 
 @cache
@@ -729,7 +734,101 @@ def _parse_clean_options(options: Any) -> dict[str, Any]:
     deep_images = options.get("deep_images")
     if deep_images is not None and deep_images not in DEEP_IMAGE_MODES:
         raise ValueError(f"option 'deep_images' must be one of {sorted(DEEP_IMAGE_MODES)}")
+    # A per-request strategy overrides the default; validate it up front so a bad
+    # tactic/intensity is a 400 rather than a mid-clean failure.
+    if "strategy" in options:
+        from rewrite_text import parse_strategy
+
+        parse_strategy(options["strategy"])
     return options
+
+
+def _load_default_strategy(config_path: Path) -> str | None:
+    """Read the default Layer B strategy from the config file.
+
+    Returns None when the config file is absent (no Layer B on text). A file that
+    is present but malformed (bad JSON, unknown tactic, bad intensity) is a
+    startup error, since the config is explicit in-repo.
+    """
+    try:
+        data = json.loads(config_path.read_text())
+    except FileNotFoundError:
+        return None
+    except json.JSONDecodeError as e:
+        raise SystemExit(f"invalid strategy config {config_path}: {e}") from e
+    spec = data.get("default_strategy")
+    if spec is None:
+        return None
+    from rewrite_text import parse_strategy
+
+    parse_strategy(spec)  # raises ValueError on a bad strategy
+    return spec
+
+
+def _apply_layer_b(text: str, strategy: str, options: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    """Apply a Layer B rewrite strategy to *text*, rejecting if unavailable.
+
+    Raises ValueError for an unconfigured/unavailable backend or model so the
+    caller surfaces a 400 rather than a 500. Wraps runtime failures the same way.
+    """
+    from rewrite_text import LLM_TACTICS, apply_strategy, parse_strategy
+
+    steps = parse_strategy(strategy)
+    needs_llm = any(t in LLM_TACTICS for t, _ in steps)
+    backend = os.environ.get("WATERMARKS_REWRITE_BACKEND", "print-prompt")
+    if needs_llm:
+        if backend not in ("openai-compatible", "ollama"):
+            raise ValueError(
+                "Layer B strategy needs an LLM rewrite backend (WATERMARKS_REWRITE_BACKEND)"
+            )
+        if (
+            not os.environ.get("WATERMARKS_REWRITE_MODEL")
+            or not os.environ.get("WATERMARKS_REWRITE_BASE_URL")
+            or not os.environ.get("WATERMARKS_REWRITE_API_KEY")
+        ):
+            raise ValueError(
+                "Layer B strategy needs the rewrite backend configured "
+                "(WATERMARKS_REWRITE_MODEL/BASE_URL/API_KEY)"
+            )
+    if any(t == "mlm" for t, _ in steps):
+        import importlib.util
+
+        if importlib.util.find_spec("transformers") is None:
+            raise ValueError("Layer B 'mlm' step requires transformers")
+    base_url = os.environ.get("WATERMARKS_REWRITE_BASE_URL")
+    if needs_llm and base_url:
+        host = urlparse(base_url).hostname or ""
+        allow_remote = os.environ.get("WATERMARKS_REWRITE_ALLOW_REMOTE", "").strip().lower() in (
+            "1",
+            "true",
+            "yes",
+            "on",
+        )
+        if host not in ("127.0.0.1", "localhost", "::1") and not allow_remote:
+            raise ValueError(
+                "Layer B strategy uses a remote rewrite endpoint; set "
+                "WATERMARKS_REWRITE_ALLOW_REMOTE=1"
+            )
+    try:
+        out, stats = apply_strategy(
+            text,
+            steps,
+            backend=backend,
+            model=os.environ.get("WATERMARKS_REWRITE_MODEL"),
+            base_url=os.environ.get("WATERMARKS_REWRITE_BASE_URL"),
+            api_key=os.environ.get("WATERMARKS_REWRITE_API_KEY"),
+            temperature=float(os.environ.get("WATERMARKS_REWRITE_TEMPERATURE", "0.9")),
+            reasoning_effort=(
+                None
+                if os.environ.get("WATERMARKS_REWRITE_REASONING_EFFORT") == "off"
+                else os.environ.get("WATERMARKS_REWRITE_REASONING_EFFORT") or None
+            ),
+            style=options.get("style"),
+            layer_a_after=bool(options.get("also_layer_a_text")),
+        )
+    except (RuntimeError, TimeoutError) as e:
+        raise ValueError(f"Layer B rewrite failed: {e}") from e
+    return out, stats
 
 
 def _batch_items(
@@ -946,10 +1045,18 @@ def _clean_payload(data: bytes, name: str, options: dict[str, Any]) -> dict[str,
                 aggressive_homoglyphs=bool(options.get("aggressive_homoglyphs")),
                 normalize_spaces=bool(options.get("normalize_spaces", True)),
             )
+            # Layer B: apply the default (or per-request) rewrite strategy. Raises
+            # ValueError (400) if the backend/model for a step is unavailable.
+            strategy = options.get("strategy") or _DEFAULT_STRATEGY
+            layer_b: dict[str, Any] | None = None
+            if strategy:
+                cleaned, layer_b = _apply_layer_b(cleaned, strategy, options)
             if detect_after:
                 detector_reports["after"] = run_text_detectors(cleaned)
             cleaned_bytes = cleaned.encode("utf-8", errors="surrogateescape")
             report: dict[str, Any] = {"kind": "text", "stats": stats, "length": len(cleaned)}
+            if layer_b is not None:
+                report["layer_b"] = layer_b
             if detector_reports:
                 report["text_detectors"] = detector_reports
         elif kind == "image":
@@ -1256,6 +1363,13 @@ def main() -> int:
         "--port", type=int, default=int(os.environ.get("WATERMARKS_SERVER_PORT", "8765"))
     )
     p.add_argument("--api-key", default=API_KEY, help="require this bearer token (default: none)")
+    p.add_argument(
+        "--strategy-config",
+        default=os.environ.get("WATERMARKS_CLEAN_STRATEGY_FILE", "config/clean_strategy.json"),
+        help="Path to the Layer B strategy config JSON (default: "
+        "config/clean_strategy.json; WATERMARKS_CLEAN_STRATEGY_FILE). A strategy "
+        "step is 'tactic@intensity' (e.g. 'paraphrase@0.8,mlm@0.2').",
+    )
     p.add_argument("-V", "--version", action="store_true", help="print version and exit")
     args = p.parse_args()
 
@@ -1264,6 +1378,8 @@ def main() -> int:
         return 0
 
     API_KEY = args.api_key
+    global _DEFAULT_STRATEGY  # noqa: PLW0603 — loaded once at startup
+    _DEFAULT_STRATEGY = _load_default_strategy(Path(args.strategy_config))
 
     if args.host not in ("127.0.0.1", "localhost", "::1"):
         eprint(f"warning: binding {args.host} — intended for a trusted network only")

--- a/service/scripts/server.py
+++ b/service/scripts/server.py
@@ -42,6 +42,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import urllib.error
 from datetime import datetime
 from functools import cache
 from http import HTTPStatus
@@ -781,15 +782,17 @@ def _apply_layer_b(text: str, strategy: str, options: dict[str, Any]) -> tuple[s
             raise ValueError(
                 "Layer B strategy needs an LLM rewrite backend (WATERMARKS_REWRITE_BACKEND)"
             )
-        if (
-            not os.environ.get("WATERMARKS_REWRITE_MODEL")
-            or not os.environ.get("WATERMARKS_REWRITE_BASE_URL")
-            or not os.environ.get("WATERMARKS_REWRITE_API_KEY")
-        ):
-            raise ValueError(
-                "Layer B strategy needs the rewrite backend configured "
-                "(WATERMARKS_REWRITE_MODEL/BASE_URL/API_KEY)"
-            )
+        needs_key = backend == "openai-compatible"
+        missing = not os.environ.get("WATERMARKS_REWRITE_MODEL") or not os.environ.get(
+            "WATERMARKS_REWRITE_BASE_URL"
+        )
+        if needs_key:
+            missing = missing or not os.environ.get("WATERMARKS_REWRITE_API_KEY")
+        if missing:
+            required = "WATERMARKS_REWRITE_MODEL/BASE_URL"
+            if needs_key:
+                required += "/API_KEY"
+            raise ValueError(f"Layer B strategy needs the rewrite backend configured ({required})")
     if any(t == "mlm" for t, _ in steps):
         import importlib.util
 
@@ -826,7 +829,7 @@ def _apply_layer_b(text: str, strategy: str, options: dict[str, Any]) -> tuple[s
             style=options.get("style"),
             layer_a_after=bool(options.get("also_layer_a_text")),
         )
-    except (RuntimeError, TimeoutError) as e:
+    except (RuntimeError, TimeoutError, urllib.error.URLError) as e:
         raise ValueError(f"Layer B rewrite failed: {e}") from e
     return out, stats
 

--- a/skills/remove-ai-marks/SKILL.md
+++ b/skills/remove-ai-marks/SKILL.md
@@ -130,7 +130,7 @@ Intended for **your own** content (privacy, hygiene, research). Do not market re
 | --- | --- |
 | Pasted / clipboard text | temp file → `/inspect` then `/clean` (text) |
 | `.txt` / code | text Layer A (+ formatter for code) |
-| `.md` / `.html` | container clean (frontmatter/meta) + Layer A |
+| `.md` / `.html` | container clean (frontmatter/meta) + Layer A; Layer B to the prose via a `/clean` text pass or the agent rewrite model |
 | `.png` / `.jpg` / `.jpeg` / `.webp` / `.avif` / `.heic` / `.bmp` / `.gif` / `.tiff` | image metadata strip |
 | `.svg` / `.pdf` / `.docx` / `.epub` / `.odt` | container metadata strip |
 | Directory / website | aggregate audit via the service CLIs (see below) |
@@ -200,15 +200,18 @@ curl -s -X POST "$WM/clean" -H 'Content-Type: application/json' \
 
 After Layer A, **always propose** a statistical-mark reduction pass for natural-language content. Do not skip this step silently.
 
-For text, `/clean` **requires** Layer B: it applies the default strategy
-(`config/clean_strategy.json`, e.g. `paraphrase@0.8,mlm@0.2`) or the
-`options.strategy` override after Layer A, reports `report.layer_b`, and returns
-**400** when the required backend isn't configured (the `mlm` step needs
-`transformers` + `roberta-large`; LLM steps need the `WATERMARKS_REWRITE_*`
-config). If the service is unconfigured for Layer B, `/clean` on text rejects —
-so configure it, or run the prompts below yourself with a model **≠ suspected
-origin** (Claude text → not Claude; Gemini → not Gemini; etc.). Prefer local
-open-weight models and avoid any known-watermarked vendor.
+For **plain text** (pasted / `.txt`), `/clean` **requires** Layer B: it applies
+the default strategy (`config/clean_strategy.json`, e.g.
+`paraphrase@0.8,mlm@0.2`) or the `options.strategy` override after Layer A,
+reports `report.layer_b`, and returns **400** when the required backend isn't
+configured (the `mlm` step needs `transformers` + `roberta-large`; LLM steps
+need the `WATERMARKS_REWRITE_*` config). Markdown/HTML and other containers
+(`.md`, `.html`, `.pdf`, `.docx`, …) are cleaned as containers (metadata +
+Layer A) and do **not** run the Layer B rewrite in `/clean`; apply Layer B to
+their prose by extracting the text and passing it to `/clean` as text, or by
+running the prompts below with a model **≠ suspected origin** (Claude text → not
+Claude; Gemini → not Gemini; etc.). Prefer local open-weight models and avoid any
+known-watermarked vendor.
 
 Multi-pass recipe:
 

--- a/skills/remove-ai-marks/SKILL.md
+++ b/skills/remove-ai-marks/SKILL.md
@@ -200,11 +200,13 @@ curl -s -X POST "$WM/clean" -H 'Content-Type: application/json' \
 
 After Layer A, **always propose** a statistical-mark reduction pass for natural-language content. Do not skip this step silently.
 
-If the service is configured with a Layer B strategy (the default from
-`config/clean_strategy.json`, e.g. `paraphrase@0.8,mlm@0.2`, or an explicit
-`options.strategy`), `/clean` performs the rewrite itself and reports
-`report.layer_b` — prefer that when available. Otherwise **you** are the rewrite
-model: run the prompts below on the cleaned text with a model **≠ suspected
+For text, `/clean` **requires** Layer B: it applies the default strategy
+(`config/clean_strategy.json`, e.g. `paraphrase@0.8,mlm@0.2`) or the
+`options.strategy` override after Layer A, reports `report.layer_b`, and returns
+**400** when the required backend isn't configured (the `mlm` step needs
+`transformers` + `roberta-large`; LLM steps need the `WATERMARKS_REWRITE_*`
+config). If the service is unconfigured for Layer B, `/clean` on text rejects —
+so configure it, or run the prompts below yourself with a model **≠ suspected
 origin** (Claude text → not Claude; Gemini → not Gemini; etc.). Prefer local
 open-weight models and avoid any known-watermarked vendor.
 

--- a/skills/remove-ai-marks/SKILL.md
+++ b/skills/remove-ai-marks/SKILL.md
@@ -93,7 +93,10 @@ clients.
 (`auto` | `always` | `lossless` | `never`, PDF: how hard to chase metadata
 carried inside embedded images; anything else is rejected), `detect_before` / `detect_after` (text and
 images: run watermark detection on the input and on the cleaned output,
-included in the report).
+included in the report), and `strategy` (text: an ordered `tactic@intensity`
+list such as `"paraphrase@0.8,mlm@0.2"` that runs the Layer B rewrite after
+Layer A; when omitted the default from `config/clean_strategy.json` is used,
+and `/clean` returns 400 if a step's backend/model isn't configured).
 
 **Inspect first** (decide, don't guess):
 
@@ -197,10 +200,13 @@ curl -s -X POST "$WM/clean" -H 'Content-Type: application/json' \
 
 After Layer A, **always propose** a statistical-mark reduction pass for natural-language content. Do not skip this step silently.
 
-The service does **not** hold a rewrite model — **you** are the rewrite model.
-Run the prompts below on the cleaned text with a model **≠ suspected origin**
-(Claude text → not Claude; Gemini → not Gemini; etc.). Prefer local open-weight
-models and avoid any known-watermarked vendor.
+If the service is configured with a Layer B strategy (the default from
+`config/clean_strategy.json`, e.g. `paraphrase@0.8,mlm@0.2`, or an explicit
+`options.strategy`), `/clean` performs the rewrite itself and reports
+`report.layer_b` — prefer that when available. Otherwise **you** are the rewrite
+model: run the prompts below on the cleaned text with a model **≠ suspected
+origin** (Claude text → not Claude; Gemini → not Gemini; etc.). Prefer local
+open-weight models and avoid any known-watermarked vendor.
 
 Multi-pass recipe:
 

--- a/skills/remove-ai-marks/references/removal-matrix.md
+++ b/skills/remove-ai-marks/references/removal-matrix.md
@@ -37,7 +37,8 @@
 
 ## Code vs prose
 
-- **Prose / Markdown / HTML body:** full A + B.
+- **Plain-text prose (pasted / `.txt`):** full A + B — `/clean` (kind `text`) runs the Layer B strategy and requires the rewrite backend configured (rejects with 400 otherwise).
+- **Markdown / HTML body (container):** `/clean` runs container/metadata clean + Layer A; the Layer B rewrite applies to the prose when it is processed as a text pass (extract the prose or send the content to `/clean` as text), or via the agent rewrite model.
 - **Code:** Layer A + formatter; statistical marks are weak; offer `code` rewrite (comments/docstrings/string-literal wording + local identifier renames) with user OK.
 
 ## Layer B tactics

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,43 @@
+"""Shared pytest fixtures for the watermarks-remover test suite.
+
+The Layer B rewrite is a required step for text cleaning, but it needs a rewrite
+backend (WATERMARKS_REWRITE_*) and/or transformers for the `mlm` tactic that the
+test environment does not configure. Tests that are not about Layer B (options,
+detection, traversal, batch, images) use text cleaning as a vehicle, so we no-op
+the Layer B choke point for them; `tests/test_clean_strategy.py` is excluded and
+exercises the real apply/reject logic.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "service" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import server
+
+
+@pytest.fixture(autouse=True)
+def _noop_layer_b_for_non_strategy_tests(monkeypatch: pytest.MonkeyPatch, request):
+    """Replace `server._apply_layer_b` with a no-op except in test_clean_strategy.
+
+    The Layer B default strategy is loaded by `server.main()`, which the tests do
+    not run, so `_DEFAULT_STRATEGY` is None here and a text clean would reject.
+    Give tests a valid default and run Layer B as a pass-through.
+    """
+    if "test_clean_strategy" in request.node.nodeid:
+        return
+    monkeypatch.setattr(server, "_DEFAULT_STRATEGY", "mlm@0.3")
+    monkeypatch.setattr(
+        server,
+        "_apply_layer_b",
+        lambda text, strategy, options: (
+            text,
+            {"strategy": list(strategy.split(",")), "steps": []},
+        ),
+    )

--- a/tests/test_clean_strategy.py
+++ b/tests/test_clean_strategy.py
@@ -1,0 +1,180 @@
+"""Tests for Layer B strategy parsing/application and /clean wiring."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "service" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import rewrite_text
+from rewrite_text import apply_strategy, parse_strategy
+from server import _apply_layer_b, _load_default_strategy, _parse_clean_options
+
+# --- parse_strategy ---------------------------------------------------------
+
+
+def test_parse_strategy_valid():
+    assert parse_strategy("paraphrase@0.8,mlm@0.2") == [("paraphrase", 0.8), ("mlm", 0.2)]
+
+
+def test_parse_strategy_single_mlm():
+    assert parse_strategy("mlm@0.5") == [("mlm", 0.5)]
+
+
+def test_parse_strategy_unknown_tactic():
+    with pytest.raises(ValueError):
+        parse_strategy("nope@0.2")
+
+
+def test_parse_strategy_bad_intensity():
+    with pytest.raises(ValueError):
+        parse_strategy("paraphrase@1.5")
+
+
+def test_parse_strategy_missing_at():
+    with pytest.raises(ValueError):
+        parse_strategy("paraphrase")
+
+
+def test_parse_strategy_empty():
+    with pytest.raises(ValueError):
+        parse_strategy("")
+
+
+# --- apply_strategy ---------------------------------------------------------
+
+
+def test_apply_strategy_sequentially(monkeypatch):
+    calls: list[str] = []
+
+    def fake_gen(backend, base_url, model, api_key, prompt, timeout, temperature, reasoning_effort):
+        calls.append(prompt)
+        return "PARAPHRASED "
+
+    monkeypatch.setattr(rewrite_text, "_generate_once", fake_gen)
+    monkeypatch.setattr(rewrite_text, "_mlm_infill", lambda text, level: text + " [mlm]")
+
+    out, stats = apply_strategy(
+        "Hello world.",
+        [("paraphrase", 0.8), ("mlm", 0.2)],
+        backend="openai-compatible",
+        model="m",
+        base_url="https://example.test",
+        api_key="k",
+    )
+    assert out == "PARAPHRASED  [mlm]"
+    assert len(calls) == 1  # LLM step ran once
+    assert stats["strategy"] == ["paraphrase@0.8", "mlm@0.2"]
+    assert stats["steps"][0]["tactic"] == "paraphrase"
+    assert stats["steps"][0]["intensity"] == 0.8
+    assert stats["steps"][1]["tactic"] == "mlm"
+    assert stats["steps"][1]["intensity"] == 0.2
+    assert stats["input_chars"] == len("Hello world.")
+    assert stats["output_chars"] == len(out)
+
+
+def test_apply_strategy_llm_requires_config(monkeypatch):
+    monkeypatch.setattr(rewrite_text, "_generate_once", lambda *a, **k: "x")
+    with pytest.raises(RuntimeError):
+        apply_strategy(
+            "x",
+            [("paraphrase", 0.8)],
+            backend="openai-compatible",
+            model=None,
+            base_url=None,
+            api_key=None,
+        )
+
+
+def test_apply_strategy_mlm_only(monkeypatch):
+    monkeypatch.setattr(rewrite_text, "_mlm_infill", lambda text, level: text + " edited")
+    out, stats = apply_strategy(
+        "hi", [("mlm", 0.3)], backend="openai-compatible", model=None, base_url=None, api_key=None
+    )
+    assert out == "hi edited"
+    assert stats["steps"][0]["tactic"] == "mlm"
+
+
+# --- server: option validation ----------------------------------------------
+
+
+def test_clean_options_strategy_valid():
+    opts = _parse_clean_options({"strategy": "paraphrase@0.8,mlm@0.2", "nfkc": True})
+    assert opts["strategy"] == "paraphrase@0.8,mlm@0.2"
+
+
+def test_clean_options_strategy_invalid():
+    with pytest.raises(ValueError):
+        _parse_clean_options({"strategy": "bogus@9"})
+
+
+def test_clean_options_unknown_option_still_rejected():
+    with pytest.raises(ValueError):
+        _parse_clean_options({"not_an_option": "x"})
+
+
+# --- server: default strategy config load -----------------------------------
+
+
+def test_load_default_strategy_valid(tmp_path):
+    p = tmp_path / "clean_strategy.json"
+    p.write_text('{"default_strategy": "paraphrase@0.8,mlm@0.2"}')
+    assert _load_default_strategy(p) == "paraphrase@0.8,mlm@0.2"
+
+
+def test_load_default_strategy_missing(tmp_path):
+    assert _load_default_strategy(tmp_path / "nope.json") is None
+
+
+def test_load_default_strategy_bad_json(tmp_path):
+    p = tmp_path / "c.json"
+    p.write_text("{bad json")
+    with pytest.raises(SystemExit):
+        _load_default_strategy(p)
+
+
+def test_load_default_strategy_bad_strategy(tmp_path):
+    p = tmp_path / "c.json"
+    p.write_text('{"default_strategy": "nope@9"}')
+    with pytest.raises(ValueError):
+        _load_default_strategy(p)
+
+
+# --- server: reject when backend/model unavailable --------------------------
+
+
+def test_apply_layer_b_llm_backend_unconfigured(monkeypatch):
+    monkeypatch.delenv("WATERMARKS_REWRITE_BACKEND", raising=False)
+    monkeypatch.delenv("WATERMARKS_REWRITE_MODEL", raising=False)
+    monkeypatch.delenv("WATERMARKS_REWRITE_BASE_URL", raising=False)
+    monkeypatch.delenv("WATERMARKS_REWRITE_API_KEY", raising=False)
+    with pytest.raises(ValueError):
+        _apply_layer_b("x", "paraphrase@0.8", {})
+
+
+def test_apply_layer_b_mlm_needs_transformers(monkeypatch):
+    import importlib.util
+
+    monkeypatch.setenv("WATERMARKS_REWRITE_BACKEND", "openai-compatible")
+    monkeypatch.setenv("WATERMARKS_REWRITE_MODEL", "m")
+    monkeypatch.setenv("WATERMARKS_REWRITE_BASE_URL", "https://x")
+    monkeypatch.setenv("WATERMARKS_REWRITE_API_KEY", "k")
+    monkeypatch.setenv("WATERMARKS_REWRITE_ALLOW_REMOTE", "1")
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: None)
+    with pytest.raises(ValueError):
+        _apply_layer_b("x", "mlm@0.3", {})
+
+
+def test_apply_layer_b_remote_denied(monkeypatch):
+    monkeypatch.setenv("WATERMARKS_REWRITE_BACKEND", "openai-compatible")
+    monkeypatch.setenv("WATERMARKS_REWRITE_MODEL", "m")
+    monkeypatch.setenv("WATERMARKS_REWRITE_BASE_URL", "https://api.example.test")
+    monkeypatch.setenv("WATERMARKS_REWRITE_API_KEY", "k")
+    monkeypatch.delenv("WATERMARKS_REWRITE_ALLOW_REMOTE", raising=False)
+    with pytest.raises(ValueError):
+        _apply_layer_b("x", "paraphrase@0.8", {})

--- a/tests/test_clean_strategy.py
+++ b/tests/test_clean_strategy.py
@@ -167,6 +167,16 @@ def test_apply_layer_b_llm_backend_unconfigured(monkeypatch):
         _apply_layer_b("x", "paraphrase@0.8", {})
 
 
+def test_apply_layer_b_ollama_does_not_require_api_key(monkeypatch):
+    monkeypatch.setenv("WATERMARKS_REWRITE_BACKEND", "ollama")
+    monkeypatch.setenv("WATERMARKS_REWRITE_MODEL", "m")
+    monkeypatch.setenv("WATERMARKS_REWRITE_BASE_URL", "http://127.0.0.1:11434")
+    monkeypatch.delenv("WATERMARKS_REWRITE_API_KEY", raising=False)
+    monkeypatch.setattr(rewrite_text, "apply_strategy", lambda *a, **k: ("out", {"steps": []}))
+    out, _stats = _apply_layer_b("x", "paraphrase@0.8", {})
+    assert out == "out"
+
+
 def test_apply_layer_b_mlm_needs_transformers(monkeypatch):
     import importlib.util
 

--- a/tests/test_clean_strategy.py
+++ b/tests/test_clean_strategy.py
@@ -12,6 +12,7 @@ SCRIPTS = ROOT / "service" / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
 import rewrite_text
+import server
 from rewrite_text import apply_strategy, parse_strategy
 from server import _apply_layer_b, _load_default_strategy, _parse_clean_options
 
@@ -143,6 +144,15 @@ def test_load_default_strategy_bad_strategy(tmp_path):
     p.write_text('{"default_strategy": "nope@9"}')
     with pytest.raises(ValueError):
         _load_default_strategy(p)
+
+
+# --- server: Layer B is a required step for text ---------------------------
+
+
+def test_clean_text_requires_layer_b(monkeypatch):
+    monkeypatch.setattr(server, "_DEFAULT_STRATEGY", None)
+    with pytest.raises(ValueError, match="Layer B rewrite is required"):
+        server._clean_payload(b"hello world", "a.txt", {})
 
 
 # --- server: reject when backend/model unavailable --------------------------


### PR DESCRIPTION
## What

Wire the benchmark-discovered best rewrite strategy into the `/clean` operation as the Layer B (statistical text watermark) rewrite.

- **New `config/clean_strategy.json`** defines the default strategy: `"paraphrase@0.8,mlm@0.2"`. Loaded at startup; path overridable via `WATERMARKS_CLEAN_STRATEGY_FILE` / `--strategy-config`.
- **`rewrite_text.py`**: adds `parse_strategy` (validated `tactic@intensity` list) and `apply_strategy` (sequential best-effort rewrite with per-step stats, no detection/evaluation loop), plus a `--strategy` CLI path.
- **`server.py`**: loads the config, accepts a `"strategy"` option (strictly validated), applies it to text **after** Layer A, and adds a `layer_b` object (strategy + per-step stats) to the report. If a step's rewrite backend/model (LLM steps) or the `transformers` dependency (the `mlm` step) isn't available, the request is **rejected with a 400**.

## Why

The benchmark (same-config SynthID, 8-doc corpora) showed `paraphrase@0.8 → mlm@0.2` is the most balanced recipe: 7–8/8 clearing at the 0.015 practical bar, Pangram `human_like` ~0.76–0.79, semantic drift ~0.10–0.12. Layer B was previously only agent-orchestrated; the service itself never rewrote text.

## API

`POST /clean` with text now optionally runs the strategy:

```json
{ "file": "...", "name": "notes.md", "options": { "strategy": "paraphrase@0.8,mlm@0.2" } }
```

Omit `options.strategy` to use the config default. The response `report.layer_b` carries the applied strategy and per-step stats.

## Behavior notes

- **Rejects when unavailable (400):** an LLM step with `WATERMARKS_REWRITE_*` not configured, or an `mlm` step without `transformers`/`roberta-large`. This is deliberate (chosen over fail-soft).
- The `mlm` tactic needs `transformers` + `roberta-large`. The core service is otherwise **stdlib-only**, so on a stdlib-only deployment the default strategy's `mlm` step will reject a text clean until `transformers` is available — worth confirming against the runtime image.

## Tests

- `tests/test_clean_strategy.py`: `parse_strategy` (valid/invalid), `apply_strategy` (sequencing, stats, config-required), server option validation, config loading, and reject-when-unavailable cases.
- Full suite passes; lint (ruff) clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable `/clean` rewrite strategies with ordered tactics and intensity levels.
  - Added a default strategy combining paraphrasing and masked-language rewriting.
  - Cleaning reports now include Layer B rewrite statistics.
  - Added options for selecting a strategy and strategy configuration file.

- **Bug Fixes**
  - Invalid strategies and unavailable rewrite requirements now return clear HTTP 400 errors.

- **Documentation**
  - Clarified Layer B execution order, configuration, and backend requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->