### PR TITLE
feat(skills): enforce fail-closed contract when service is unreachable (#316)

### DIFF
--- a/install_skill.py
+++ b/install_skill.py
@@ -372,7 +372,41 @@ def build_parser() -> argparse.ArgumentParser:
         "--output",
         help="Bundle path for --target cowork (default: dist/<skill>.zip)",
     )
+    parser.add_argument(
+        "--check-service",
+        action="store_true",
+        default=True,
+        help="Probe service reachability at install time (default: enabled)",
+    )
+    parser.add_argument(
+        "--no-check-service",
+        dest="check_service",
+        action="store_false",
+        help="Do not probe service reachability at install time",
+    )
     return parser
+
+
+def check_service_reachability(url: str | None = None, timeout: float = 0.5) -> tuple[bool, str]:
+    """Check GET /health on WATERMARKS_SERVICE_URL (default http://127.0.0.1:8765)."""
+    import json
+    import urllib.request
+
+    endpoint = (url or os.environ.get("WATERMARKS_SERVICE_URL") or "http://127.0.0.1:8765").rstrip("/")
+    health_url = f"{endpoint}/health"
+    try:
+        req = urllib.request.Request(health_url, headers={"User-Agent": "watermarks-remover-install"})
+        api_key = os.environ.get("WATERMARKS_SERVICE_API_KEY")
+        if api_key:
+            req.add_header("Authorization", f"Bearer {api_key}")
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            if resp.status == 200:
+                data = json.loads(resp.read().decode("utf-8"))
+                version = data.get("version", "unknown")
+                return True, f"service reachable at {endpoint} (v{version})"
+    except Exception:
+        pass
+    return False, f"service unreachable at {endpoint} (start with 'make serve' or 'docker compose up -d')"
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -409,6 +443,10 @@ def main(argv: list[str] | None = None) -> int:
             "(or in the skills settings on claude.ai). Cowork, cloud and routine "
             "sessions load skills enabled for your account, not ~/.claude/skills."
         )
+        if args.check_service:
+            reachable, diag = check_service_reachability()
+            status_prefix = "Service:" if reachable else "Service notice:"
+            print(f"{status_prefix} {diag}")
         return 0
 
     try:
@@ -430,6 +468,10 @@ def main(argv: list[str] | None = None) -> int:
     verb = "linked" if args.link else "installed"
     print(f"{label}: {verb} {destination}")
     print(HOST_HINTS[args.target])
+    if args.check_service:
+        reachable, diag = check_service_reachability()
+        status_prefix = "Service:" if reachable else "Service notice:"
+        print(f"{status_prefix} {diag}")
     return 0
 
 

--- a/install_skill.py
+++ b/install_skill.py
@@ -16,11 +16,14 @@ target builds an upload bundle instead of writing to a directory.
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import re
 import shutil
 import sys
 import tempfile
+import urllib.parse
+import urllib.request
 import uuid
 import zipfile
 from pathlib import Path
@@ -387,11 +390,25 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+class _SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Strip Authorization header when following cross-origin redirects."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        new_req = super().redirect_request(req, fp, code, msg, headers, newurl)
+        if new_req is None:
+            return None
+        orig = urllib.parse.urlsplit(req.full_url)
+        dest = urllib.parse.urlsplit(newurl)
+        if (orig.scheme, orig.netloc) != (dest.scheme, dest.netloc):
+            new_req.headers = {k: v for k, v in new_req.headers.items() if k.lower() != "authorization"}
+            new_req.unredirected_hdrs = {
+                k: v for k, v in new_req.unredirected_hdrs.items() if k.lower() != "authorization"
+            }
+        return new_req
+
+
 def check_service_reachability(url: str | None = None, timeout: float = 0.5) -> tuple[bool, str]:
     """Check GET /health on WATERMARKS_SERVICE_URL (default http://127.0.0.1:8765)."""
-    import json
-    import urllib.request
-
     endpoint = (url or os.environ.get("WATERMARKS_SERVICE_URL") or "http://127.0.0.1:8765").rstrip("/")
     health_url = f"{endpoint}/health"
     try:
@@ -399,7 +416,8 @@ def check_service_reachability(url: str | None = None, timeout: float = 0.5) -> 
         api_key = os.environ.get("WATERMARKS_SERVICE_API_KEY")
         if api_key:
             req.add_header("Authorization", f"Bearer {api_key}")
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
+        opener = urllib.request.build_opener(_SafeRedirectHandler)
+        with opener.open(req, timeout=timeout) as resp:
             if resp.status == 200:
                 data = json.loads(resp.read().decode("utf-8"))
                 version = data.get("version", "unknown")

--- a/install_skill.py
+++ b/install_skill.py
@@ -22,6 +22,7 @@ import re
 import shutil
 import sys
 import tempfile
+import urllib.error
 import urllib.parse
 import urllib.request
 import uuid
@@ -400,7 +401,9 @@ class _SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
         orig = urllib.parse.urlsplit(req.full_url)
         dest = urllib.parse.urlsplit(newurl)
         if (orig.scheme, orig.netloc) != (dest.scheme, dest.netloc):
-            new_req.headers = {k: v for k, v in new_req.headers.items() if k.lower() != "authorization"}
+            new_req.headers = {
+                k: v for k, v in new_req.headers.items() if k.lower() != "authorization"
+            }
             new_req.unredirected_hdrs = {
                 k: v for k, v in new_req.unredirected_hdrs.items() if k.lower() != "authorization"
             }
@@ -409,11 +412,24 @@ class _SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
 
 def check_service_reachability(url: str | None = None, timeout: float = 0.5) -> tuple[bool, str]:
     """Check GET /health on WATERMARKS_SERVICE_URL (default http://127.0.0.1:8765)."""
-    endpoint = (url or os.environ.get("WATERMARKS_SERVICE_URL") or "http://127.0.0.1:8765").rstrip("/")
+    endpoint = (url or os.environ.get("WATERMARKS_SERVICE_URL") or "http://127.0.0.1:8765").rstrip(
+        "/"
+    )
     health_url = f"{endpoint}/health"
+    parsed = urllib.parse.urlsplit(health_url)
+    if parsed.scheme not in ("http", "https"):
+        return False, f"invalid service scheme: {parsed.scheme}"
+    is_local = parsed.hostname in ("localhost", "127.0.0.1", "::1")
+    api_key = os.environ.get("WATERMARKS_SERVICE_API_KEY")
+    if api_key and parsed.scheme != "https" and not is_local:
+        return (
+            False,
+            f"insecure endpoint: refusing to send API key over plain remote HTTP ({endpoint})",
+        )
     try:
-        req = urllib.request.Request(health_url, headers={"User-Agent": "watermarks-remover-install"})
-        api_key = os.environ.get("WATERMARKS_SERVICE_API_KEY")
+        req = urllib.request.Request(  # noqa: S310
+            health_url, headers={"User-Agent": "watermarks-remover-install"}
+        )
         if api_key:
             req.add_header("Authorization", f"Bearer {api_key}")
         opener = urllib.request.build_opener(_SafeRedirectHandler)
@@ -422,9 +438,12 @@ def check_service_reachability(url: str | None = None, timeout: float = 0.5) -> 
                 data = json.loads(resp.read().decode("utf-8"))
                 version = data.get("version", "unknown")
                 return True, f"service reachable at {endpoint} (v{version})"
-    except Exception:
+    except (urllib.error.URLError, OSError, TimeoutError, json.JSONDecodeError, UnicodeDecodeError):
         pass
-    return False, f"service unreachable at {endpoint} (start with 'make serve' or 'docker compose up -d')"
+    return (
+        False,
+        f"service unreachable at {endpoint} (start with 'make serve' or 'docker compose up -d')",
+    )
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/install_skill.py
+++ b/install_skill.py
@@ -400,7 +400,11 @@ class _SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
             return None
         orig = urllib.parse.urlsplit(req.full_url)
         dest = urllib.parse.urlsplit(newurl)
-        if (orig.scheme, orig.netloc) != (dest.scheme, dest.netloc):
+        orig_port = orig.port or (443 if orig.scheme.lower() == "https" else 80)
+        dest_port = dest.port or (443 if dest.scheme.lower() == "https" else 80)
+        orig_host = (orig.hostname or "").lower()
+        dest_host = (dest.hostname or "").lower()
+        if (orig.scheme.lower(), orig_host, orig_port) != (dest.scheme.lower(), dest_host, dest_port):
             new_req.headers = {
                 k: v for k, v in new_req.headers.items() if k.lower() != "authorization"
             }
@@ -436,8 +440,9 @@ def check_service_reachability(url: str | None = None, timeout: float = 0.5) -> 
         with opener.open(req, timeout=timeout) as resp:
             if resp.status == 200:
                 data = json.loads(resp.read().decode("utf-8"))
-                version = data.get("version", "unknown")
-                return True, f"service reachable at {endpoint} (v{version})"
+                if isinstance(data, dict):
+                    version = data.get("version", "unknown")
+                    return True, f"service reachable at {endpoint} (v{version})"
     except (urllib.error.URLError, OSError, TimeoutError, json.JSONDecodeError, UnicodeDecodeError):
         pass
     return (

--- a/service/scripts/audit_lib.py
+++ b/service/scripts/audit_lib.py
@@ -157,7 +157,9 @@ def scan_file(
 
 
 def is_actionable(item: dict[str, Any]) -> bool:
-    """A file is actionable when it has a confirmed/probable finding or C2PA."""
+    """A file is actionable when it has a confirmed/probable finding, C2PA, or service error."""
+    if item.get("status") == "service_unavailable" or item.get("error") == "service_unavailable":
+        return True
     if item.get("has_c2pa"):
         return True
     return any(c in ("confirmed", "probable") for c in item.get("confidence", []))

--- a/service/scripts/audit_lib.py
+++ b/service/scripts/audit_lib.py
@@ -35,6 +35,14 @@ def text_findings(report: Any) -> tuple[list[str], list[str], int]:
     return findings, confidences, report.suspicious_total
 
 
+def _propagate_service_status(item: dict[str, Any], report: Any) -> dict[str, Any]:
+    for field in ("status", "error", "detail"):
+        val = report.get(field) if isinstance(report, dict) else getattr(report, field, None)
+        if val is not None:
+            item[field] = val
+    return item
+
+
 def scan_file(
     path: Path,
     display_name: str | None = None,
@@ -78,33 +86,59 @@ def scan_file(
                 )
                 item["confidence"].append("probable")
                 item["suspicious_total"] += 1
-        return item
+        return _propagate_service_status(item, report)
 
     if kind == "image":
         report = inspect_image(path)
-        return {
+        format_val = report.get("format", "image") if isinstance(report, dict) else report.format
+        has_c2pa = report.get("has_c2pa", False) if isinstance(report, dict) else report.has_c2pa
+        has_ai = (
+            report.get("has_ai_metadata", False)
+            if isinstance(report, dict)
+            else report.has_ai_metadata
+        )
+        findings = report.get("findings", []) if isinstance(report, dict) else report.findings
+        notes = report.get("notes", []) if isinstance(report, dict) else report.notes
+        item = {
             "path": name,
-            "kind": report.format,
-            "has_c2pa": report.has_c2pa,
-            "has_ai_metadata": report.has_ai_metadata,
+            "kind": format_val,
+            "has_c2pa": has_c2pa,
+            "has_ai_metadata": has_ai,
             "suspicious_total": 0,
-            "findings": report.findings,
-            "confidence": [classify_finding_confidence(f) for f in report.findings],
-            "notes": report.notes,
+            "findings": findings,
+            "confidence": [classify_finding_confidence(f) for f in findings],
+            "notes": notes,
         }
+        return _propagate_service_status(item, report)
 
     if kind == "av":
         av_report = inspect_av(path)
-        return {
+        format_val = (
+            av_report.get("format", "av") if isinstance(av_report, dict) else av_report.format
+        )
+        has_c2pa = (
+            av_report.get("has_c2pa", False) if isinstance(av_report, dict) else av_report.has_c2pa
+        )
+        has_ai = (
+            av_report.get("has_ai_metadata", False)
+            if isinstance(av_report, dict)
+            else av_report.has_ai_metadata
+        )
+        findings = (
+            av_report.get("findings", []) if isinstance(av_report, dict) else av_report.findings
+        )
+        notes = av_report.get("notes", []) if isinstance(av_report, dict) else av_report.notes
+        item = {
             "path": name,
-            "kind": av_report.format,
-            "has_c2pa": av_report.has_c2pa,
-            "has_ai_metadata": av_report.has_ai_metadata,
+            "kind": format_val,
+            "has_c2pa": has_c2pa,
+            "has_ai_metadata": has_ai,
             "suspicious_total": 0,
-            "findings": av_report.findings,
-            "confidence": [classify_finding_confidence(f) for f in av_report.findings],
-            "notes": av_report.notes,
+            "findings": findings,
+            "confidence": [classify_finding_confidence(f) for f in findings],
+            "notes": notes,
         }
+        return _propagate_service_status(item, av_report)
 
     if kind == "unknown":
         return {
@@ -119,14 +153,25 @@ def scan_file(
         }
 
     report = inspect_container(path)
-    findings = list(report.findings)
-    confidences = [classify_finding_confidence(f) for f in report.findings]
+    findings = (
+        list(report.findings) if not isinstance(report, dict) else list(report.get("findings", []))
+    )
+    confidences = [classify_finding_confidence(f) for f in findings]
     # Layer A body-scan findings (and count) already come from
     # inspect_container() for markdown/html; it mirrors clean_container().
-    suspicious = report.layer_a_total
+    suspicious = (
+        getattr(report, "layer_a_total", 0)
+        if not isinstance(report, dict)
+        else report.get("layer_a_total", 0)
+    )
     stylometry_dict = None
 
-    if check_stylometry and report.format in ("html", "markdown"):
+    fmt = (
+        getattr(report, "format", "container")
+        if not isinstance(report, dict)
+        else report.get("format", "container")
+    )
+    if check_stylometry and fmt in ("html", "markdown"):
         try:
             text = path.read_text(encoding="utf-8", errors="surrogateescape")
         except OSError:
@@ -141,19 +186,33 @@ def scan_file(
                 confidences.append("probable")
                 suspicious += 1
 
+    notes = (
+        getattr(report, "notes", []) if not isinstance(report, dict) else report.get("notes", [])
+    )
+    has_c2pa = (
+        getattr(report, "has_c2pa", False)
+        if not isinstance(report, dict)
+        else report.get("has_c2pa", False)
+    )
+    has_ai = (
+        getattr(report, "has_ai_metadata", False)
+        if not isinstance(report, dict)
+        else report.get("has_ai_metadata", False)
+    )
+
     item = {
         "path": name,
-        "kind": report.format,
-        "has_c2pa": report.has_c2pa,
-        "has_ai_metadata": report.has_ai_metadata,
+        "kind": fmt,
+        "has_c2pa": has_c2pa,
+        "has_ai_metadata": has_ai,
         "suspicious_total": suspicious,
         "findings": findings,
         "confidence": confidences,
-        "notes": report.notes,
+        "notes": notes,
     }
     if stylometry_dict:
         item["stylometry"] = stylometry_dict
-    return item
+    return _propagate_service_status(item, report)
 
 
 def is_actionable(item: dict[str, Any]) -> bool:

--- a/service/scripts/check_staged.py
+++ b/service/scripts/check_staged.py
@@ -56,6 +56,9 @@ def main() -> int:
         eprint(f"  {item['path']}")
         for finding in item.get("findings", []):
             eprint(f"    - {finding}")
+        if item.get("status") == "service_unavailable" or item.get("error") == "service_unavailable":
+            detail = item.get("detail") or item.get("error") or "service unavailable"
+            eprint(f"    - service_unavailable: {detail}")
         if item.get("has_c2pa"):
             eprint("    - C2PA manifest present")
         if item.get("has_ai_metadata"):

--- a/service/scripts/check_staged.py
+++ b/service/scripts/check_staged.py
@@ -56,7 +56,10 @@ def main() -> int:
         eprint(f"  {item['path']}")
         for finding in item.get("findings", []):
             eprint(f"    - {finding}")
-        if item.get("status") == "service_unavailable" or item.get("error") == "service_unavailable":
+        if (
+            item.get("status") == "service_unavailable"
+            or item.get("error") == "service_unavailable"
+        ):
             detail = item.get("detail") or item.get("error") or "service unavailable"
             eprint(f"    - service_unavailable: {detail}")
         if item.get("has_c2pa"):

--- a/service/scripts/hook_written_file.py
+++ b/service/scripts/hook_written_file.py
@@ -114,6 +114,12 @@ def run_check(path: Path) -> int:
     # scan_file/is_actionable are audit_dir.py's own per-file logic, so this
     # hook, the pre-commit gate, and the CI SARIF export agree on what counts.
     item = scan_file(path)
+    if item.get("status") == "service_unavailable" or item.get("error") == "service_unavailable":
+        detail = item.get("detail") or "service unavailable"
+        _emit(f"watermarks-remover: {path.name}: service_unavailable ({detail})")
+        eprint(f"watermarks-remover: {path}: service_unavailable ({detail})")
+        return EXIT_HOOK_ERROR
+
     if item.get("kind") == "unknown" or not is_actionable(item):
         return EXIT_QUIET
 
@@ -172,6 +178,12 @@ def run_clean(path: Path) -> int:
         if not isinstance(result, dict) or proc.returncode not in (0, 1):
             detail = proc.stderr.strip() or "clean produced no usable report"
             eprint(f"watermarks-remover: {path}: {detail}")
+            return EXIT_HOOK_ERROR
+
+        if result.get("status") == "service_unavailable" or result.get("error") == "service_unavailable":
+            detail = result.get("detail") or "service unavailable"
+            _emit(f"watermarks-remover: {path.name}: service_unavailable ({detail})")
+            eprint(f"watermarks-remover: {path}: service_unavailable ({detail})")
             return EXIT_HOOK_ERROR
 
         residual = result.get("still_has_c2pa") or result.get("still_has_ai_metadata")

--- a/service/scripts/hook_written_file.py
+++ b/service/scripts/hook_written_file.py
@@ -180,7 +180,10 @@ def run_clean(path: Path) -> int:
             eprint(f"watermarks-remover: {path}: {detail}")
             return EXIT_HOOK_ERROR
 
-        if result.get("status") == "service_unavailable" or result.get("error") == "service_unavailable":
+        if (
+            result.get("status") == "service_unavailable"
+            or result.get("error") == "service_unavailable"
+        ):
             detail = result.get("detail") or "service unavailable"
             _emit(f"watermarks-remover: {path.name}: service_unavailable ({detail})")
             eprint(f"watermarks-remover: {path}: service_unavailable ({detail})")

--- a/skills/clean-user-facing-text/SKILL.md
+++ b/skills/clean-user-facing-text/SKILL.md
@@ -107,6 +107,10 @@ The scripts support plain text, source text, Markdown, and HTML source as text. 
 
 For a chat-only response that is not written to a file, perform the rewrite workflow directly. Do not claim that the chat response received a deterministic post-send Unicode filter.
 
+### Fail-closed execution notice
+
+If the Python runtime or vendored scripts (`clean_text.py`, `inspect_text.py`) are unavailable or error during execution, fail closed immediately: stop, report the execution failure clearly, and do not modify any files. NEVER substitute an unverified assistant-authored rewrite claiming the text has been cleaned (#196).
+
 ## Detector levers
 
 Statistical detectors score probability patterns: AI prose is too predictable (low

--- a/skills/remove-ai-marks/SKILL.md
+++ b/skills/remove-ai-marks/SKILL.md
@@ -44,18 +44,21 @@ published GHCR image) or locally (`make serve`).
 **Always run this preflight before any inspect, detect, or clean command:**
 
 ```bash
-curl -sf "$WM/health"
+HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 2 --max-time 5 \
+  ${WATERMARKS_SERVICE_API_KEY:+-H "Authorization: Bearer $WATERMARKS_SERVICE_API_KEY"} \
+  "$WM/health")
+test "$HTTP_STATUS" = "200"
 # {"ok": true, "version": "..."}
 ```
 
 ### Fail-Closed Refusal Contract
 
-If `curl -sf "$WM/health"` fails, times out, or returns a non-200 exit code:
+If the preflight health check fails, times out, or returns a non-200 exit code:
 **STOP immediately. Do not inspect, do not clean, and do not modify any files or text.**
 
 You MUST emit this exact refusal notice:
 
-> "The watermarks-remover service is offline or unreachable at $WATERMARKS_SERVICE_URL. No files or text have been modified. Start the service with `make serve` or `docker compose up -d` before retrying."
+> "The watermarks-remover service is offline or unreachable at $WM. No files or text have been modified. Start the service with `make serve` or `docker compose up -d` before retrying."
 
 **PROHIBITION (FAIL CLOSED):**
 NEVER attempt to substitute an assistant-authored rewrite or unverified model paraphrasing when the service is unreachable. Improvising a rewrite without deterministic Layer A stripping and metadata cleansing produces false confidence and violates privacy guarantees (#196). If the service is down, the operation is aborted.

--- a/skills/remove-ai-marks/SKILL.md
+++ b/skills/remove-ai-marks/SKILL.md
@@ -44,8 +44,12 @@ published GHCR image) or locally (`make serve`).
 **Always run this preflight before any inspect, detect, or clean command:**
 
 ```bash
+AUTH_ARGS=()
+if [[ -n "${WATERMARKS_SERVICE_API_KEY:-}" ]]; then
+  AUTH_ARGS=(-H "Authorization: Bearer $WATERMARKS_SERVICE_API_KEY")
+fi
 HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 2 --max-time 5 \
-  ${WATERMARKS_SERVICE_API_KEY:+-H "Authorization: Bearer $WATERMARKS_SERVICE_API_KEY"} \
+  "${AUTH_ARGS[@]}" \
   "$WM/health")
 test "$HTTP_STATUS" = "200"
 # {"ok": true, "version": "..."}

--- a/skills/remove-ai-marks/SKILL.md
+++ b/skills/remove-ai-marks/SKILL.md
@@ -46,6 +46,10 @@ published GHCR image) or locally (`make serve`).
 ```bash
 AUTH_ARGS=()
 if [[ -n "${WATERMARKS_SERVICE_API_KEY:-}" ]]; then
+  if [[ "$WM" =~ ^http:// && ! "$WM" =~ ^http://(localhost|127\.0\.0\.1|\[::1\])(:[0-9]+)?(/|$) ]]; then
+    echo "Refusing to send API key over plain remote HTTP: $WM" >&2
+    exit 1
+  fi
   AUTH_ARGS=(-H "Authorization: Bearer $WATERMARKS_SERVICE_API_KEY")
 fi
 HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 2 --max-time 5 \

--- a/skills/remove-ai-marks/SKILL.md
+++ b/skills/remove-ai-marks/SKILL.md
@@ -37,14 +37,28 @@ WM="${WATERMARKS_SERVICE_URL:-http://127.0.0.1:8765}"
 ```
 
 The service is started either by the operator (`docker compose up -d`, or a
-published GHCR image) or locally (`make serve`). **Always check it first**, and
-stop with a clear message if it is unreachable — never fall back to local
-cleaning:
+published GHCR image) or locally (`make serve`).
+
+### Mandatory Preflight Check
+
+**Always run this preflight before any inspect, detect, or clean command:**
 
 ```bash
 curl -sf "$WM/health"
 # {"ok": true, "version": "..."}
 ```
+
+### Fail-Closed Refusal Contract
+
+If `curl -sf "$WM/health"` fails, times out, or returns a non-200 exit code:
+**STOP immediately. Do not inspect, do not clean, and do not modify any files or text.**
+
+You MUST emit this exact refusal notice:
+
+> "The watermarks-remover service is offline or unreachable at $WATERMARKS_SERVICE_URL. No files or text have been modified. Start the service with `make serve` or `docker compose up -d` before retrying."
+
+**PROHIBITION (FAIL CLOSED):**
+NEVER attempt to substitute an assistant-authored rewrite or unverified model paraphrasing when the service is unreachable. Improvising a rewrite without deterministic Layer A stripping and metadata cleansing produces false confidence and violates privacy guarantees (#196). If the service is down, the operation is aborted.
 
 If `WATERMARKS_SERVER_API_KEY` is set on the service, every request needs
 `-H "Authorization: Bearer $WATERMARKS_SERVICE_API_KEY"`.
@@ -146,6 +160,8 @@ mostly just send the file.
 
 ### 2. Inspect first
 
+Check `$WM/health` first. If unreachable, emit the refusal contract and stop immediately.
+
 ```bash
 curl -s -X POST "$WM/inspect" -H 'Content-Type: application/json' \
   -d "{\"file\": \"$(base64 < path | tr -d '\n')\", \"name\": \"$(basename path)\"}"
@@ -180,6 +196,8 @@ the API in Aug 2026 — see `references/vendor-notes.md`.)
 
 ### 3. Deterministic clean (always for matching inputs)
 
+Check `$WM/health` first. If unreachable, emit the refusal contract and stop immediately.
+
 **Any supported file (unified):**
 
 ```bash
@@ -204,7 +222,7 @@ curl -s -X POST "$WM/clean" -H 'Content-Type: application/json' \
 
 ### 4. Layer B — always offer rewrite (prose)
 
-After Layer A, **always propose** a statistical-mark reduction pass for natural-language content. Do not skip this step silently.
+After Layer A, **always propose** a statistical-mark reduction pass for natural-language content. Do not skip this step silently. (If the service was unreachable for Layer A, remember that Layer B is never run as an unverified fallback).
 
 For **plain text** (pasted / `.txt`), `/clean` **requires** Layer B: it applies
 the default strategy (`config/clean_strategy.json`, e.g.

--- a/tests/test_service_contract.py
+++ b/tests/test_service_contract.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import http.server
 import json
-import subprocess
 import sys
 import threading
 from pathlib import Path
@@ -26,6 +25,7 @@ sys.path.insert(0, str(SCRIPTS))
 import audit_lib
 import check_staged
 import hook_written_file
+
 import install_skill
 
 

--- a/tests/test_service_contract.py
+++ b/tests/test_service_contract.py
@@ -64,7 +64,11 @@ def test_reachability_diagnostic_when_online(mock_service):
     assert "v0.7.0-test" in msg
 
 
-def test_reachability_diagnostic_when_offline():
+def test_reachability_diagnostic_when_offline(monkeypatch):
+    def mock_open(*args, **kwargs):
+        raise OSError("Connection refused")
+
+    monkeypatch.setattr("urllib.request.OpenerDirector.open", mock_open)
     reachable, msg = install_skill.check_service_reachability(
         url="http://127.0.0.1:59998", timeout=0.2
     )
@@ -73,19 +77,39 @@ def test_reachability_diagnostic_when_offline():
     assert "make serve" in msg
 
 
+def test_reachability_cross_origin_redirect_strips_authorization():
+    import urllib.request
+
+    handler = install_skill._SafeRedirectHandler()
+    req = urllib.request.Request(
+        "http://127.0.0.1:8765/health",
+        headers={"Authorization": "Bearer secret-token"},
+    )
+    new_req = handler.redirect_request(
+        req, None, 302, "Found", {}, "http://external.example.com/health"
+    )
+    assert "authorization" not in [k.lower() for k in new_req.headers]
+    assert "authorization" not in [k.lower() for k in new_req.unredirected_hdrs]
+
+    same_req = handler.redirect_request(
+        req, None, 302, "Found", {}, "http://127.0.0.1:8765/health/"
+    )
+    assert "Authorization" in same_req.headers
+
+
 def test_skill_markdown_contains_refusal_contract():
     skill_file = ROOT / "skills" / "remove-ai-marks" / "SKILL.md"
     assert skill_file.is_file()
     content = skill_file.read_text(encoding="utf-8")
 
     expected_refusal = (
-        "The watermarks-remover service is offline or unreachable at $WATERMARKS_SERVICE_URL. "
+        "The watermarks-remover service is offline or unreachable at $WM. "
         "No files or text have been modified. Start the service with `make serve` or `docker compose up -d` before retrying."
     )
     assert expected_refusal in content
 
     assert "Mandatory Preflight Check" in content
-    assert 'curl -sf "$WM/health"' in content
+    assert '"$WM/health"' in content
     assert "PROHIBITION (FAIL CLOSED)" in content
     assert "#196" in content
 
@@ -158,3 +182,28 @@ def test_hook_written_file_check_exits_error_on_service_unavailable(tmp_path, mo
     monkeypatch.setattr(hook_written_file, "scan_file", mock_scan)
     exit_code = hook_written_file.run_check(test_file)
     assert exit_code == hook_written_file.EXIT_HOOK_ERROR
+
+
+def test_scan_file_propagates_service_unavailable_status(monkeypatch, tmp_path):
+    test_file = tmp_path / "sample.png"
+    test_file.write_bytes(b"dummy image data")
+
+    mock_report = {
+        "format": "png",
+        "has_c2pa": False,
+        "has_ai_metadata": False,
+        "findings": [],
+        "notes": [],
+        "status": "service_unavailable",
+        "error": "service_unavailable",
+        "detail": "connection refused on 127.0.0.1:8765",
+    }
+
+    monkeypatch.setattr(audit_lib, "inspect_image", lambda path: mock_report)
+    monkeypatch.setattr(audit_lib, "classify", lambda path: "image")
+
+    item = audit_lib.scan_file(test_file)
+    assert item.get("status") == "service_unavailable"
+    assert item.get("error") == "service_unavailable"
+    assert item.get("detail") == "connection refused on 127.0.0.1:8765"
+    assert audit_lib.is_actionable(item) is True

--- a/tests/test_service_contract.py
+++ b/tests/test_service_contract.py
@@ -65,7 +65,9 @@ def test_reachability_diagnostic_when_online(mock_service):
 
 
 def test_reachability_diagnostic_when_offline():
-    reachable, msg = install_skill.check_service_reachability(url="http://127.0.0.1:59998", timeout=0.2)
+    reachable, msg = install_skill.check_service_reachability(
+        url="http://127.0.0.1:59998", timeout=0.2
+    )
     assert reachable is False
     assert "service unreachable" in msg
     assert "make serve" in msg
@@ -83,7 +85,7 @@ def test_skill_markdown_contains_refusal_contract():
     assert expected_refusal in content
 
     assert "Mandatory Preflight Check" in content
-    assert "curl -sf \"$WM/health\"" in content
+    assert 'curl -sf "$WM/health"' in content
     assert "PROHIBITION (FAIL CLOSED)" in content
     assert "#196" in content
 

--- a/tests/test_service_contract.py
+++ b/tests/test_service_contract.py
@@ -1,0 +1,158 @@
+"""Tests for the fail-closed service contract (#196, #316).
+
+Verifies:
+- Preflight refusal contract documentation in SKILL.md
+- install_skill.py reachability diagnostics (online, offline, suppression)
+- check_staged.py and hook_written_file.py fail-closed behavior on service_unavailable
+"""
+
+from __future__ import annotations
+
+import http.server
+import json
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "service" / "scripts"
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(SCRIPTS))
+
+import audit_lib
+import check_staged
+import hook_written_file
+import install_skill
+
+
+class _MockHealthHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/health":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"ok": True, "version": "0.7.0-test"}).encode("utf-8"))
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, format, *args):
+        pass
+
+
+@pytest.fixture
+def mock_service():
+    server = http.server.HTTPServer(("127.0.0.1", 0), _MockHealthHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    port = server.server_address[1]
+    url = f"http://127.0.0.1:{port}"
+    yield url
+    server.shutdown()
+    server.server_close()
+    thread.join(timeout=3)
+
+
+def test_reachability_diagnostic_when_online(mock_service):
+    reachable, msg = install_skill.check_service_reachability(url=mock_service)
+    assert reachable is True
+    assert "service reachable" in msg
+    assert "v0.7.0-test" in msg
+
+
+def test_reachability_diagnostic_when_offline():
+    reachable, msg = install_skill.check_service_reachability(url="http://127.0.0.1:59998", timeout=0.2)
+    assert reachable is False
+    assert "service unreachable" in msg
+    assert "make serve" in msg
+
+
+def test_skill_markdown_contains_refusal_contract():
+    skill_file = ROOT / "skills" / "remove-ai-marks" / "SKILL.md"
+    assert skill_file.is_file()
+    content = skill_file.read_text(encoding="utf-8")
+
+    expected_refusal = (
+        "The watermarks-remover service is offline or unreachable at $WATERMARKS_SERVICE_URL. "
+        "No files or text have been modified. Start the service with `make serve` or `docker compose up -d` before retrying."
+    )
+    assert expected_refusal in content
+
+    assert "Mandatory Preflight Check" in content
+    assert "curl -sf \"$WM/health\"" in content
+    assert "PROHIBITION (FAIL CLOSED)" in content
+    assert "#196" in content
+
+
+def test_clean_user_facing_text_contains_fail_closed_notice():
+    skill_file = ROOT / "skills" / "clean-user-facing-text" / "SKILL.md"
+    assert skill_file.is_file()
+    content = skill_file.read_text(encoding="utf-8")
+    assert "Fail-closed execution notice" in content
+    assert "#196" in content
+
+
+def test_audit_lib_treats_service_unavailable_as_actionable():
+    item = {
+        "path": "test.txt",
+        "kind": "text",
+        "status": "service_unavailable",
+        "has_c2pa": False,
+        "confidence": [],
+    }
+    assert audit_lib.is_actionable(item) is True
+
+    item_error = {
+        "path": "test.txt",
+        "kind": "text",
+        "error": "service_unavailable",
+        "has_c2pa": False,
+        "confidence": [],
+    }
+    assert audit_lib.is_actionable(item_error) is True
+
+
+def test_check_staged_exits_nonzero_on_service_unavailable(tmp_path, monkeypatch, capsys):
+    test_file = tmp_path / "staged.txt"
+    test_file.write_text("sample content", encoding="utf-8")
+
+    def mock_scan(path, check_stylometry=False):
+        return {
+            "path": str(path),
+            "kind": "text",
+            "status": "service_unavailable",
+            "detail": "connection refused on 127.0.0.1:8765",
+            "has_c2pa": False,
+            "findings": [],
+            "confidence": [],
+        }
+
+    monkeypatch.setattr(check_staged, "scan_file", mock_scan)
+    with patch("sys.argv", ["check_staged.py", str(test_file)]):
+        exit_code = check_staged.main()
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "service_unavailable" in captured.err
+
+
+def test_hook_written_file_check_exits_error_on_service_unavailable(tmp_path, monkeypatch):
+    test_file = tmp_path / "written.txt"
+    test_file.write_text("sample content", encoding="utf-8")
+
+    def mock_scan(path):
+        return {
+            "path": str(path),
+            "name": path.name,
+            "kind": "text",
+            "status": "service_unavailable",
+            "detail": "service offline",
+        }
+
+    monkeypatch.setattr(hook_written_file, "scan_file", mock_scan)
+    exit_code = hook_written_file.run_check(test_file)
+    assert exit_code == hook_written_file.EXIT_HOOK_ERROR

--- a/tests/test_service_contract.py
+++ b/tests/test_service_contract.py
@@ -97,6 +97,13 @@ def test_reachability_cross_origin_redirect_strips_authorization():
     assert "Authorization" in same_req.headers
 
 
+def test_reachability_refuses_api_key_over_remote_plain_http(monkeypatch):
+    monkeypatch.setenv("WATERMARKS_SERVICE_API_KEY", "test-token")
+    reachable, msg = install_skill.check_service_reachability(url="http://remote.example.com:8765")
+    assert reachable is False
+    assert "refusing to send API key over plain remote HTTP" in msg
+
+
 def test_skill_markdown_contains_refusal_contract():
     skill_file = ROOT / "skills" / "remove-ai-marks" / "SKILL.md"
     assert skill_file.is_file()
@@ -109,6 +116,7 @@ def test_skill_markdown_contains_refusal_contract():
     assert expected_refusal in content
 
     assert "Mandatory Preflight Check" in content
+    assert "AUTH_ARGS" in content
     assert '"$WM/health"' in content
     assert "PROHIBITION (FAIL CLOSED)" in content
     assert "#196" in content

--- a/tests/test_service_contract.py
+++ b/tests/test_service_contract.py
@@ -96,6 +96,40 @@ def test_reachability_cross_origin_redirect_strips_authorization():
     )
     assert "Authorization" in same_req.headers
 
+    # Case-insensitive host and default port normalization should preserve Authorization
+    case_req = urllib.request.Request(
+        "http://EXAMPLE.COM/health",
+        headers={"Authorization": "Bearer secret-token"},
+    )
+    same_case_req = handler.redirect_request(
+        case_req, None, 302, "Found", {}, "http://example.com:80/health/"
+    )
+    assert "Authorization" in same_case_req.headers
+
+
+def test_reachability_non_dict_response(monkeypatch):
+    import io
+
+    class DummyResp(io.BytesIO):
+        def __init__(self, data):
+            super().__init__(data)
+            self.status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    for payload in (b'"ok"', b'["item1", "item2"]', b"123", b"null"):
+        monkeypatch.setattr(
+            "urllib.request.OpenerDirector.open",
+            lambda *args, p=payload, **kwargs: DummyResp(p),
+        )
+        reachable, msg = install_skill.check_service_reachability(url="http://127.0.0.1:8765")
+        assert reachable is False
+        assert "service unreachable" in msg
+
 
 def test_reachability_refuses_api_key_over_remote_plain_http(monkeypatch):
     monkeypatch.setenv("WATERMARKS_SERVICE_API_KEY", "test-token")


### PR DESCRIPTION
## What

- Enforces a mandatory `GET /health` preflight before any `/inspect` or `/clean` call in `skills/remove-ai-marks/SKILL.md`.
- Defines an explicit refusal contract requiring the model to emit exact refusal wording and halt immediately when the service is unreachable.
- Explicitly forbids models from substituting improvised LLM rewrites in place of an offline service call.
- Adds an install-time reachability diagnostic to `install_skill.py` checking `GET /health` on `$WATERMARKS_SERVICE_URL`.
- Ensures `audit_lib.py`, `check_staged.py`, and `hook_written_file.py` fail closed on `service_unavailable` (exit 1).
- Adds unit tests in `tests/test_service_contract.py` (7 tests, all passing).

## Why

In #196, a user's resume was submitted while the watermark service was offline. Instead of stopping, the model announced it would "proceed with a full Layer B rewrite — which is actually the most effective approach for a resume", fabricated prose, and claimed success. No Layer A Unicode was stripped, no metadata was touched, and no detector was consulted.

A silent false negative in a privacy tool is worse than a crash because the user acts on fabricated success. This PR establishes a strict fail-closed contract across both skills and CLI hooks, ensuring offline services result in a hard refusal rather than unverified assistant improvisation.

Closes #316. Ref #196.

## Checklist

- [x] Behaviour matches `SKILL.md` / `references/removal-matrix.md` when relevant
- [x] Unit tests updated or added under `tests/`
- [x] `python3 -m pytest -q` passes (93 passed, 4 skipped)
- [x] Docs updated (README and/or skill references) if user-facing behaviour changes
- [x] No drive-by refactors unrelated to the fix or feature

## Notes for the reviewer

Contracts updated in `remove-ai-marks` and `clean-user-facing-text`. Preflight refusal phrasing is standardized and machine-verifiable. All 7 tests in `test_service_contract.py` and 86 existing suite tests pass locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer now checks service availability after installation and reports the result; checks can be disabled when needed.
  * Inspection and cleanup workflows now report unavailable services with clear diagnostics.

* **Bug Fixes**
  * Workflows stop safely without modifying files when required services, Python, or bundled tools are unavailable.
  * Staged-file and written-file checks now return errors when service availability prevents reliable analysis.
  * Health checks protect authentication across redirects and refuse to send API keys over remote unencrypted connections.

* **Documentation**
  * Added guidance for stopping safely instead of using unverified fallback rewrites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->