### PR TITLE
feat(server): add /watermark and /watermark/batch endpoints with sidecar support (#313)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,13 @@ HF_TOKEN=
 # WATERMARKS_SYNTHID_SCORER_API_KEY=
 # WATERMARKS_SYNTHID_SCORER_TIMEOUT=60
 
+# SynthID text watermarking over HTTP (harness profile): point wr-core at the
+# wr-synthid-text sidecar and share the same bearer key on both sides.
+# With the harness profile up, uncomment:
+# WATERMARKS_SYNTHID_TEXT_URL=http://wr-synthid-text:8767
+# WATERMARKS_SYNTHID_TEXT_API_KEY=
+# WATERMARKS_SYNTHID_TEXT_TIMEOUT=120
+
 # ---------------------------------------------------------------------------
 # Client-side (used by the skill or curl, NOT by compose)
 # ---------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -331,10 +331,13 @@ The same machinery runs as a stdlib HTTP service (`service/scripts/server.py`) �
 | POST | `/inspect` | `{"file": "<base64>", "name": "notes.md"}` | `{"ok", "kind", "suspicious", "report"}` |
 | POST | `/detect` | `{"file": "<base64>", "name": "notes.txt"}` | `{"ok", "kind", "detections": [...]}` |
 | POST | `/clean` | `{"file": "<base64>", "name": "notes.md", "options": {...}}` | `{"ok", "kind", "cleaned": "<base64>", "report"}` |
+| POST | `/watermark` | `{"text": "...", "keys": [118, 504, ...], "options": {...}}` or `{"file": "<base64>", ...}` | `{"ok", "kind", "watermarked_text", "report": {"scheme_used", ...}}` |
 | POST | `/inspect/batch` | `{"files": [{"file": "<base64>", "name": "notes.md"}, ...]}` | `{"ok", "results": [{"name", "ok", "kind", "suspicious", "report"}, ...]}` |
-| POST | `/clean/batch` | `{"files": [{"file": "<base64>", "name": "notes.md", "options": {...}}, ...]}` | `{"ok", "results": [{"name", "ok", "kind", "cleaned": "<base64>", "report"}, ...]}` |
+| POST | `/detect/batch` | `{"files": [{"file": "<base64>", "name": "notes.txt"}, ...]}` | `{"ok", "results": [{"name", "ok", "kind", "detections", "report"}, ...]}` |
+| POST | `/clean/batch` | `{"files": [{"file": "<base64>", "name": "notes.md", "options": {...}}, ...]}` | `{"ok", "results": [{"name", "ok", "kind", "cleaned", "report"}, ...]}` |
+| POST | `/watermark/batch` | `{"files": [{"text": "...", "keys": [...]}, {"file": "<base64>"}, ...]}` | `{"ok", "results": [{"name", "ok", "kind", "watermarked_text", "report": {"scheme_used", ...}}, ...]}` |
 
-Batch endpoints loop the same per-file pipeline as `/inspect` and `/clean`, capped at `WATERMARKS_MAX_BATCH_FILES` files per request (default 50). A malformed entry (bad base64, unknown option, unrecognized format) surfaces as that entry's `"ok": false` with an `"error"` string — it never aborts the rest of the batch.
+Batch endpoints loop the same per-file pipeline as `/inspect`, `/detect`, `/clean`, and `/watermark`, capped at `WATERMARKS_MAX_BATCH_FILES` files per request (default 50). A malformed entry (bad base64, unknown option, unrecognized format) surfaces as that entry's `"ok": false` with an `"error"` string — it never aborts the rest of the batch.
 
 ```bash
 WM="http://127.0.0.1:8765"
@@ -380,6 +383,14 @@ local `REVERSE_SYNTHID_DIR` it uses the checkout directly. Detection is
 fail-soft: unconfigured, timed-out, or errored detectors report
 `{"available": false, "error": ...}` and never block cleaning.
 
+### Watermark generation (`/watermark` and `/watermark/batch`)
+
+Generates watermarked text for benchmark evaluation and round-trip testing.
+When `WATERMARKS_SYNTHID_TEXT_URL` is set, the service delegates generation to the
+`wr-synthid-text` sidecar (harness profile); with a local `MARKLLM_DIR` it uses the
+checkout directly. Like detection, generation is fail-soft: an unconfigured generator
+reports `{"ok": false, "error": ...}`.
+
 ## Docker / compose
 
 Published images (GHCR):
@@ -406,12 +417,12 @@ Whole-infra bring-up:
 
 ```bash
 docker compose up -d                         # core HTTP service only
-docker compose --profile harness up -d       # + markllm / markdiffusion
+docker compose --profile harness up -d       # + markllm / markdiffusion / wr-synthid-text sidecar
 docker compose --profile heavy up -d         # + ctrlregen / synthid (local builds)
 docker compose --profile harness --profile heavy up -d   # all services
 ```
 
-The compose stack maps the core service to `127.0.0.1:8765`. The harness/heavy services are one-shot CLIs — invoke with `docker compose run --rm <service> …` when you need verification or pixel work.
+The compose stack maps the core service to `127.0.0.1:8765`. Persistent services run as background daemons (`wr-core` and the `wr-synthid-text` sidecar under the harness profile). The remaining harness/heavy services are one-shot CLIs — invoke with `docker compose run --rm <service> …` when you need verification or pixel work.
 
 Validate the running stack (exit code only, no output on success):
 
@@ -460,6 +471,9 @@ set -a; . ./.env; set +a; python3 service/scripts/rewrite_text.py /tmp/x.txt -o 
 | `WATERMARKS_GEMINI_*` | — | Removed Aug 2026: Google retired SynthID text watermarking on the API (see `vendor-notes.md`) |
 | `WATERMARKS_SYNTHID_SCORER_URL` | `wr-core` | Point core at the `wr-synthid-score` sidecar for SynthID image scoring (e.g. `http://wr-synthid-score:8766` under the heavy profile) |
 | `WATERMARKS_SYNTHID_SCORER_API_KEY` | `wr-core` + `wr-synthid-score` | Shared bearer key for the scorer sidecar (empty = no auth) |
+| `WATERMARKS_SYNTHID_TEXT_URL` | `wr-core` | Point core at the `wr-synthid-text` sidecar for SynthID text watermarking (e.g. `http://wr-synthid-text:8767` under the harness profile) |
+| `WATERMARKS_SYNTHID_TEXT_API_KEY` | `wr-core` + `wr-synthid-text` | Shared bearer key for the text watermark sidecar (empty = no auth) |
+| `WATERMARKS_SYNTHID_TEXT_TIMEOUT` | `wr-core` | Seconds to wait for the `wr-synthid-text` sidecar (default 120) |
 | `WATERMARKS_MARKLLM_SCHEME` | `text_detectors.py` (host) | MarkLLM scheme for `/detect`: `kgw` (default) / `synthid` |
 | `HF_TOKEN` | harness/heavy services | Hugging Face token for gated models |
 | `WATERMARKS_SERVICE_URL` | client only (skill / curl) | Where to reach the service; default `http://127.0.0.1:8765` |

--- a/compose.yaml
+++ b/compose.yaml
@@ -30,6 +30,10 @@ services:
       # Optional SynthID image scorer sidecar (heavy profile).
       WATERMARKS_SYNTHID_SCORER_URL: ${WATERMARKS_SYNTHID_SCORER_URL:-}
       WATERMARKS_SYNTHID_SCORER_API_KEY: ${WATERMARKS_SYNTHID_SCORER_API_KEY:-}
+      # Optional SynthID text watermark generator sidecar (harness profile).
+      WATERMARKS_SYNTHID_TEXT_URL: ${WATERMARKS_SYNTHID_TEXT_URL:-}
+      WATERMARKS_SYNTHID_TEXT_API_KEY: ${WATERMARKS_SYNTHID_TEXT_API_KEY:-}
+      WATERMARKS_SYNTHID_TEXT_TIMEOUT: ${WATERMARKS_SYNTHID_TEXT_TIMEOUT:-120}
     read_only: true
     tmpfs:
       - /tmp
@@ -70,6 +74,31 @@ services:
       #     --corpus /bench-corpus --out-dir /data ...
       - bench-out:/data
       - ./benchmarks/corpus:/bench-corpus:ro
+
+  # HTTP SynthID text watermarking sidecar: lets wr-core generate watermarked
+  # text for benchmarks without bundling heavy ML dependencies in the published
+  # core image. Reach it via WATERMARKS_SYNTHID_TEXT_URL on wr-core (see .env.example)
+  # and require the same bearer key on both sides.
+  wr-synthid-text:
+    profiles: [harness]
+    build:
+      context: service
+      dockerfile: Dockerfile.markllm
+    image: ghcr.io/guillaumemeyer/watermarks-remover:markllm-latest
+    entrypoint: ["python3"]
+    command: ["/app/synthid_text_server.py", "--host", "0.0.0.0", "--port", "8767"]
+    read_only: true
+    tmpfs:
+      - /tmp
+    init: true
+    user: "10001:10001"
+    environment:
+      WATERMARKS_SYNTHID_TEXT_API_KEY: ${WATERMARKS_SYNTHID_TEXT_API_KEY:-}
+      MARKLLM_DIR: /opt/markllm
+      HF_TOKEN: ${HF_TOKEN:-}
+      HF_HOME: /home/markllm/.cache/huggingface
+    volumes:
+      - markllm-cache:/home/markllm/.cache/huggingface
 
   wr-markdiffusion:
     profiles: [harness]

--- a/service/Dockerfile.markllm
+++ b/service/Dockerfile.markllm
@@ -56,6 +56,8 @@ COPY scripts/bench_synthid_text.py /app/bench_synthid_text.py
 COPY scripts/rewrite_text.py /app/rewrite_text.py
 COPY scripts/text_detectors.py /app/text_detectors.py
 COPY scripts/text_unicode.py /app/text_unicode.py
+COPY scripts/synthid_text_server.py /app/synthid_text_server.py
+COPY scripts/text_watermark.py /app/text_watermark.py
 
 # Default: CPU torch (like Dockerfile.markdiffusion). CUDA users build with
 # --build-arg TORCH_INDEX_URL=https://download.pytorch.org/whl/cuXXX and run

--- a/service/scripts/detect_text_watermark.py
+++ b/service/scripts/detect_text_watermark.py
@@ -24,11 +24,13 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import os
 import socket
 import socketserver
 import sys
+import tempfile
 import threading
 from pathlib import Path
 from typing import Any
@@ -97,11 +99,15 @@ def _load_algorithm(
     offline: bool = False,
     temperature: float | None = None,
     top_p: float | None = None,
+    watermark_keys: list[int] | None = None,
 ):
     """Import the checkout and build an ``AutoWatermark`` instance.
 
     ``temperature``/``top_p`` (when not None) are folded into the generation
-    kwargs so callers can control sampling.
+    kwargs so callers can control sampling. ``watermark_keys`` (when not None)
+    overrides the algorithm's watermark keys in the config *before* the model
+    is constructed, so the logits processor bakes in the requested keys rather
+    than the config file's defaults.
     """
     gen_kwargs_extra: dict[str, float] = {}
     if temperature is not None:
@@ -137,11 +143,33 @@ def _load_algorithm(
         no_repeat_ngram_size=4,
         **gen_kwargs_extra,
     )
-    return AutoWatermark.load(
-        alg,
-        algorithm_config=str(config),
-        transformers_config=transformers_config,
-    )
+
+    # Apply the requested watermark keys before construction so the logits
+    # processor is built with them, instead of the config file's defaults.
+    tmp: str | None = None
+    if watermark_keys is not None:
+        data = json.loads(config.read_text("utf-8"))
+        data["keys"] = [int(k) for k in watermark_keys]
+        fd, tmp = tempfile.mkstemp(suffix=".json", prefix="watermarks-keys-", text=True)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump(data, fh)
+            config = Path(tmp)
+        except Exception:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp)
+            raise
+
+    try:
+        return AutoWatermark.load(
+            alg,
+            algorithm_config=str(config),
+            transformers_config=transformers_config,
+        )
+    finally:
+        if tmp is not None:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp)
 
 
 def _threshold_from_config(config: Path) -> float | None:

--- a/service/scripts/server.py
+++ b/service/scripts/server.py
@@ -357,30 +357,26 @@ def _clean_request_schema() -> dict[str, Any]:
     )
 
 
-def _watermark_error_status(err: str) -> HTTPStatus:
-    e = err.lower()
-    if "no text watermark generator configured" in e:
-        return HTTPStatus.SERVICE_UNAVAILABLE
-    # Sidecar rejected our bearer token/auth — a gateway configuration problem,
-    # so surface it as a backend (502) error rather than a client (400) error.
-    if "sidecar authentication error" in e:
-        return HTTPStatus.BAD_GATEWAY
-    # Sidecar returned a 4xx — the *client* sent a bad request through to the
-    # sidecar, so propagate 400 instead of 502.
-    if "sidecar client error" in e:
-        return HTTPStatus.BAD_REQUEST
-    if (
-        "unreachable" in e
-        or "http error" in e
-        or "bad watermark sidecar response" in e
-        or "refusing non-http" in e
-        or "redirect refused" in e
-        or "timed out" in e
-        or "markllm generation failed" in e
-        or "invalid markllm_dir" in e
-        or "upstream directory not found" in e
-    ):
-        return HTTPStatus.BAD_GATEWAY
+def _watermark_error_status(res: dict[str, Any]) -> HTTPStatus:
+    """Map a watermark failure result to the correct HTTP status.
+
+    Uses the stable ``error_code`` field returned by the text_watermark
+    client rather than fragile substring-matching on the human-readable
+    ``error`` message.
+    """
+    _ERROR_CODE_MAP: dict[str, HTTPStatus] = {
+        "unconfigured": HTTPStatus.SERVICE_UNAVAILABLE,
+        "auth": HTTPStatus.BAD_GATEWAY,
+        "client_error": HTTPStatus.BAD_REQUEST,
+        "unreachable": HTTPStatus.BAD_GATEWAY,
+        "backend_error": HTTPStatus.BAD_GATEWAY,
+        "timeout": HTTPStatus.BAD_GATEWAY,
+        "ssrf": HTTPStatus.BAD_GATEWAY,
+    }
+    code = res.get("error_code", "")
+    if code in _ERROR_CODE_MAP:
+        return _ERROR_CODE_MAP[code]
+    # Fallback for any result that pre-dates the error_code field.
     return HTTPStatus.BAD_REQUEST
 
 
@@ -427,6 +423,19 @@ def _watermark_request_schema() -> dict[str, Any]:
                         maximum=1,
                     ),
                     "model": _schema(type="string"),
+                    "device": _schema(
+                        type="string",
+                        description="Inference device (e.g. 'cpu', 'cuda', 'cuda:0')",
+                    ),
+                    "config": _schema(
+                        type="string",
+                        description="Path to a custom watermark config file",
+                    ),
+                    "offline": _schema(
+                        type="boolean",
+                        default=False,
+                        description="If true, disable network access for model loading",
+                    ),
                 },
             ),
         },
@@ -1564,7 +1573,7 @@ class Handler(BaseHTTPRequestHandler):
         if res.get("ok"):
             self._respond(HTTPStatus.OK, res)
         else:
-            self._respond(_watermark_error_status(res.get("error", "")), res)
+            self._respond(_watermark_error_status(res), res)
 
     def _handle_watermark_batch(self, body: dict[str, Any]) -> None:
         files = body.get("files")
@@ -1621,7 +1630,7 @@ class Handler(BaseHTTPRequestHandler):
                     results.append({"name": entry_name, **res})
                 else:
                     err = res.get("error", "watermark generation failed")
-                    if "timed out" in err.lower():
+                    if res.get("error_code") == "timeout":
                         timed_out = True
                     results.append({"name": entry_name, "ok": False, "error": err})
             except ValueError as e:

--- a/service/scripts/server.py
+++ b/service/scripts/server.py
@@ -361,6 +361,10 @@ def _watermark_error_status(err: str) -> HTTPStatus:
     e = err.lower()
     if "no text watermark generator configured" in e:
         return HTTPStatus.SERVICE_UNAVAILABLE
+    # Sidecar rejected our bearer token/auth — a gateway configuration problem,
+    # so surface it as a backend (502) error rather than a client (400) error.
+    if "sidecar authentication error" in e:
+        return HTTPStatus.BAD_GATEWAY
     # Sidecar returned a 4xx — the *client* sent a bad request through to the
     # sidecar, so propagate 400 instead of 502.
     if "sidecar client error" in e:
@@ -413,11 +417,13 @@ def _watermark_request_schema() -> dict[str, Any]:
                     ),
                     "temperature": _schema(
                         type="number",
-                        exclusiveMinimum=0,
+                        minimum=0,
+                        exclusiveMinimum=True,
                     ),
                     "top_p": _schema(
                         type="number",
-                        exclusiveMinimum=0,
+                        minimum=0,
+                        exclusiveMinimum=True,
                         maximum=1,
                     ),
                     "model": _schema(type="string"),
@@ -810,6 +816,9 @@ def openapi_spec() -> dict[str, Any]:
         for method, op in ops.items():
             responses = dict(_COMMON_ERRORS)
             for status, body in op["responses"].items():
+                if "description" in body and "content" in body:
+                    responses[status] = body
+                    continue
                 responses[status] = {
                     "description": "Success",
                     "content": {"application/json": {"schema": body}},

--- a/service/scripts/server.py
+++ b/service/scripts/server.py
@@ -12,14 +12,18 @@ Endpoints:
     POST /detect         -> {"file": <base64>, "name": "x.txt"} -> watermark detector reports
     POST /clean          -> {"file": <base64>, "name": "x.png", "options": {...}}
                          -> {"cleaned": <base64>, "report": {...}}
+    POST /watermark      -> {"text": str, "keys": list[int], "options": {...}}
+                         -> {"ok": true, "kind": "text", "watermarked_text": str, "report": {...}}
     POST /inspect/batch  -> {"files": [{"file": <base64>, "name": "x.png"}, ...]}
                          -> {"results": [{"name", "ok", "kind", "report", "suspicious"}, ...]}
     POST /detect/batch   -> {"files": [{"file": <base64>, "name": "x.txt"}, ...]}
                          -> {"results": [{"name", "ok", "kind", "detections", "report"}, ...]}
     POST /clean/batch    -> {"files": [{"file": <base64>, "name": "x.png", "options": {...}}, ...]}
                          -> {"results": [{"name", "ok", "kind", "cleaned", "report"}, ...]}
+    POST /watermark/batch -> {"files": [{"text": str, "keys": list[int], ...}, ...]}
+                         -> {"results": [{"name", "ok", "kind", "watermarked_text", "report"}, ...]}
 
-Batch endpoints loop the same single-file pipeline as /inspect, /detect, and /clean; a
+Batch endpoints loop the same single-file pipeline as /inspect, /detect, /clean, and /watermark; a
 per-file failure (unknown format, oversized name, bad option) shows up as
 that entry's "ok": false with an "error" string and never aborts the rest of
 the batch. Capped at WATERMARKS_MAX_BATCH_FILES entries per request (default
@@ -42,6 +46,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import time
 import urllib.error
 from datetime import datetime
 from functools import cache
@@ -70,6 +75,11 @@ from image_meta import clean_image, inspect_image, run_synthid_score, synthid_is
 from score_stylometry import score_text_stylometry
 from text_detectors import detector_status, run_all_text_detectors, run_text_detectors
 from text_unicode import clean_text, inspect_text
+from text_watermark import (
+    DEFAULT_SYNTHID_TEXT_TIMEOUT,
+    generate_watermark_text,
+    parse_watermark_options,
+)
 
 VERSION = os.environ.get("WATERMARKS_SERVER_VERSION", "dev")
 
@@ -199,6 +209,10 @@ def capabilities() -> dict[str, Any]:
             "stylometry": True,
         },
         "text_detectors": detector_status(),
+        "text_generators": {
+            "synthid_http": bool(os.environ.get("WATERMARKS_SYNTHID_TEXT_URL")),
+            "markllm": bool(os.environ.get("MARKLLM_DIR")),
+        },
         "harnesses": {
             "markllm": bool(os.environ.get("MARKLLM_DIR")),
         },
@@ -343,6 +357,55 @@ def _clean_request_schema() -> dict[str, Any]:
     )
 
 
+def _watermark_error_status(err: str) -> HTTPStatus:
+    e = err.lower()
+    if "no text watermark generator configured" in e:
+        return HTTPStatus.SERVICE_UNAVAILABLE
+    if (
+        "unreachable" in e
+        or "http error" in e
+        or "bad watermark sidecar response" in e
+        or "refusing non-http" in e
+        or "redirect refused" in e
+        or "timed out" in e
+        or "markllm generation failed" in e
+        or "invalid markllm_dir" in e
+        or "upstream directory not found" in e
+    ):
+        return HTTPStatus.BAD_GATEWAY
+    return HTTPStatus.BAD_REQUEST
+
+
+def _watermark_request_schema() -> dict[str, Any]:
+    return _schema(
+        type="object",
+        additionalProperties=False,
+        properties={
+            "text": _schema(type="string", description="Prompt or text to watermark"),
+            "file": _schema(type="string", description="Base64-encoded text file"),
+            "name": _schema(type="string", description="Optional filename"),
+            "keys": _schema(
+                type="array",
+                items=_schema(type="integer"),
+                description="Optional SynthID key sequence",
+            ),
+            "options": _schema(
+                type="object",
+                additionalProperties=False,
+                properties={
+                    "scheme": _schema(type="string", default="synthid"),
+                    "seed": _schema(type="integer"),
+                    "max_new_tokens": _schema(type="integer", default=200),
+                    "min_length": _schema(type="integer", default=0),
+                    "temperature": _schema(type="number"),
+                    "top_p": _schema(type="number"),
+                    "model": _schema(type="string"),
+                },
+            ),
+        },
+    )
+
+
 _OPENAPI_PATHS: dict[str, dict[str, Any]] = {
     "/health": {
         "get": {
@@ -391,6 +454,13 @@ _OPENAPI_PATHS: dict[str, dict[str, Any]] = {
                         "text_detectors": _schema(
                             type="object",
                             additionalProperties=_schema(type="boolean"),
+                        ),
+                        "text_generators": _schema(
+                            type="object",
+                            properties={
+                                "synthid_http": _schema(type="boolean"),
+                                "markllm": _schema(type="boolean"),
+                            },
                         ),
                     },
                 )
@@ -603,6 +673,70 @@ _OPENAPI_PATHS: dict[str, dict[str, Any]] = {
                                         type="string", enum=["text", "image", "container", "av"]
                                     ),
                                     "cleaned": _schema(type="string"),
+                                    "report": _schema(type="object"),
+                                    "error": _schema(type="string"),
+                                },
+                            ),
+                        ),
+                    },
+                )
+            },
+        }
+    },
+    "/watermark": {
+        "post": {
+            "summary": "Generate watermarked text using the configured sidecar or generator",
+            "requestBody": _schema(
+                required=True,
+                content={"application/json": _schema(schema=_watermark_request_schema())},
+            ),
+            "responses": {
+                "200": _schema(
+                    type="object",
+                    properties={
+                        "ok": _schema(type="boolean"),
+                        "kind": _schema(type="string", enum=["text"]),
+                        "watermarked_text": _schema(type="string"),
+                        "report": _schema(type="object"),
+                    },
+                )
+            },
+        }
+    },
+    "/watermark/batch": {
+        "post": {
+            "summary": f"Generate watermarked text for up to {MAX_BATCH_FILES} files in one request",
+            "requestBody": _schema(
+                required=True,
+                content={
+                    "application/json": _schema(
+                        schema=_schema(
+                            type="object",
+                            required=["files"],
+                            properties={
+                                "files": _schema(
+                                    type="array",
+                                    items=_watermark_request_schema(),
+                                )
+                            },
+                        )
+                    )
+                },
+            ),
+            "responses": {
+                "200": _schema(
+                    type="object",
+                    properties={
+                        "ok": _schema(type="boolean"),
+                        "results": _schema(
+                            type="array",
+                            items=_schema(
+                                type="object",
+                                properties={
+                                    "name": _schema(type="string"),
+                                    "ok": _schema(type="boolean"),
+                                    "kind": _schema(type="string", enum=["text"]),
+                                    "watermarked_text": _schema(type="string"),
                                     "report": _schema(type="object"),
                                     "error": _schema(type="string"),
                                 },
@@ -1266,9 +1400,11 @@ class Handler(BaseHTTPRequestHandler):
             "/inspect",
             "/clean",
             "/detect",
+            "/watermark",
             "/inspect/batch",
             "/detect/batch",
             "/clean/batch",
+            "/watermark/batch",
         ):
             self._respond(HTTPStatus.NOT_FOUND, {"ok": False, "error": "not found"})
             return
@@ -1288,6 +1424,10 @@ class Handler(BaseHTTPRequestHandler):
                 self._handle_detect_batch(body)
             elif path == "/clean/batch":
                 self._handle_clean_batch(body)
+            elif path == "/watermark/batch":
+                self._handle_watermark_batch(body)
+            elif path == "/watermark":
+                self._handle_watermark(body)
             else:
                 data, name = _decode_input(body)
                 if path == "/inspect":
@@ -1359,6 +1499,98 @@ class Handler(BaseHTTPRequestHandler):
                 results.append({"name": name, "ok": False, "error": str(e)})
                 continue
             results.append({"name": name, **payload})
+        self._respond(HTTPStatus.OK, {"ok": True, "results": results})
+
+    def _extract_text_input(self, body: dict[str, Any]) -> tuple[str, str]:
+        """Extract raw text and optional name from a watermark request body."""
+        name = body.get("name") if isinstance(body.get("name"), str) else ""
+        if "text" in body:
+            raw_text = body["text"]
+            if not isinstance(raw_text, str) or not raw_text.strip():
+                raise ValueError("'text' must be a non-empty string")
+            return raw_text, name
+        if "file" in body:
+            data, decoded_name = _decode_input(body)
+            if looks_binary(data):
+                raise ValueError("refusing to treat binary content as text for watermarking")
+            return data.decode("utf-8", errors="surrogateescape"), name or decoded_name
+        raise ValueError("request must include 'text' or base64 'file'")
+
+    def _handle_watermark(self, body: dict[str, Any]) -> None:
+        text, _name = self._extract_text_input(body)
+        keys = body.get("keys")
+        options = parse_watermark_options(body.get("options"))
+        res = generate_watermark_text(text, keys=keys, options=options)
+        if res.get("ok"):
+            self._respond(HTTPStatus.OK, res)
+        else:
+            self._respond(_watermark_error_status(res.get("error", "")), res)
+
+    def _handle_watermark_batch(self, body: dict[str, Any]) -> None:
+        files = body.get("files")
+        if not isinstance(files, list):
+            raise ValueError("missing array field 'files'")
+        if not files:
+            raise ValueError("'files' must not be empty")
+        if len(files) > MAX_BATCH_FILES:
+            raise ValueError(f"'files' exceeds the {MAX_BATCH_FILES}-file batch limit")
+
+        backend_configured = bool(
+            os.environ.get("WATERMARKS_SYNTHID_TEXT_URL", "").strip()
+            or os.environ.get("MARKLLM_DIR", "").strip()
+        )
+        if not backend_configured:
+            self._respond(
+                HTTPStatus.SERVICE_UNAVAILABLE,
+                {
+                    "ok": False,
+                    "error": (
+                        "no text watermark generator configured (set WATERMARKS_SYNTHID_TEXT_URL "
+                        "for the sidecar or MARKLLM_DIR for local execution)"
+                    ),
+                },
+            )
+            return
+
+        raw_timeout = os.environ.get("WATERMARKS_SYNTHID_TEXT_TIMEOUT", "")
+        batch_budget = float(raw_timeout) if raw_timeout.strip() else DEFAULT_SYNTHID_TEXT_TIMEOUT
+        deadline = time.monotonic() + batch_budget
+
+        results = []
+        timed_out = False
+        for entry in files:
+            if not isinstance(entry, dict):
+                results.append(
+                    {"name": "", "ok": False, "error": "each entry in 'files' must be an object"}
+                )
+                continue
+            name = entry.get("name") if isinstance(entry.get("name"), str) else ""
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0 or timed_out:
+                timed_out = True
+                results.append({"name": name, "ok": False, "error": "batch deadline exceeded"})
+                continue
+
+            try:
+                text, extracted_name = self._extract_text_input(entry)
+                entry_name = name or extracted_name
+                keys = entry.get("keys")
+                options = parse_watermark_options(entry.get("options"))
+                res = generate_watermark_text(text, keys=keys, options=options, timeout=remaining)
+                if res.get("ok"):
+                    results.append({"name": entry_name, **res})
+                else:
+                    err = res.get("error", "watermark generation failed")
+                    if "timed out" in err.lower():
+                        timed_out = True
+                    results.append({"name": entry_name, "ok": False, "error": err})
+            except ValueError as e:
+                results.append({"name": name, "ok": False, "error": str(e)})
+            except Exception as e:
+                self.log_error("watermark batch entry error for %r: %r", name, e)
+                results.append({"name": name, "ok": False, "error": "internal error"})
+
         self._respond(HTTPStatus.OK, {"ok": True, "results": results})
 
 

--- a/service/scripts/server.py
+++ b/service/scripts/server.py
@@ -76,9 +76,9 @@ from score_stylometry import score_text_stylometry
 from text_detectors import detector_status, run_all_text_detectors, run_text_detectors
 from text_unicode import clean_text, inspect_text
 from text_watermark import (
-    DEFAULT_SYNTHID_TEXT_TIMEOUT,
     generate_watermark_text,
     parse_watermark_options,
+    resolve_timeout,
 )
 
 VERSION = os.environ.get("WATERMARKS_SERVER_VERSION", "dev")
@@ -361,6 +361,10 @@ def _watermark_error_status(err: str) -> HTTPStatus:
     e = err.lower()
     if "no text watermark generator configured" in e:
         return HTTPStatus.SERVICE_UNAVAILABLE
+    # Sidecar returned a 4xx — the *client* sent a bad request through to the
+    # sidecar, so propagate 400 instead of 502.
+    if "sidecar client error" in e:
+        return HTTPStatus.BAD_REQUEST
     if (
         "unreachable" in e
         or "http error" in e
@@ -395,16 +399,38 @@ def _watermark_request_schema() -> dict[str, Any]:
                 properties={
                     "scheme": _schema(type="string", default="synthid"),
                     "seed": _schema(type="integer"),
-                    "max_new_tokens": _schema(type="integer", default=200),
-                    "min_length": _schema(type="integer", default=0),
-                    "temperature": _schema(type="number"),
-                    "top_p": _schema(type="number"),
+                    "max_new_tokens": _schema(
+                        type="integer",
+                        default=200,
+                        minimum=1,
+                        maximum=8192,
+                    ),
+                    "min_length": _schema(
+                        type="integer",
+                        default=0,
+                        minimum=0,
+                        maximum=8192,
+                    ),
+                    "temperature": _schema(
+                        type="number",
+                        exclusiveMinimum=0,
+                    ),
+                    "top_p": _schema(
+                        type="number",
+                        exclusiveMinimum=0,
+                        maximum=1,
+                    ),
                     "model": _schema(type="string"),
                 },
             ),
         },
     )
 
+
+_ERROR_SCHEMA = _schema(
+    type="object",
+    properties={"ok": _schema(type="boolean", enum=[False]), "error": _schema(type="string")},
+)
 
 _OPENAPI_PATHS: dict[str, dict[str, Any]] = {
     "/health": {
@@ -699,7 +725,15 @@ _OPENAPI_PATHS: dict[str, dict[str, Any]] = {
                         "watermarked_text": _schema(type="string"),
                         "report": _schema(type="object"),
                     },
-                )
+                ),
+                "502": {
+                    "description": "Sidecar / MarkLLM backend error",
+                    "content": {"application/json": {"schema": _ERROR_SCHEMA}},
+                },
+                "503": {
+                    "description": "No text watermark generator configured",
+                    "content": {"application/json": {"schema": _ERROR_SCHEMA}},
+                },
             },
         }
     },
@@ -749,10 +783,6 @@ _OPENAPI_PATHS: dict[str, dict[str, Any]] = {
     },
 }
 
-_ERROR_SCHEMA = _schema(
-    type="object",
-    properties={"ok": _schema(type="boolean", enum=[False]), "error": _schema(type="string")},
-)
 _COMMON_ERRORS = {
     "400": {
         "description": "Bad request",
@@ -1520,7 +1550,8 @@ class Handler(BaseHTTPRequestHandler):
         text, _name = self._extract_text_input(body)
         keys = body.get("keys")
         options = parse_watermark_options(body.get("options"))
-        res = generate_watermark_text(text, keys=keys, options=options)
+        timeout = resolve_timeout(None)
+        res = generate_watermark_text(text, keys=keys, options=options, timeout=timeout)
         if res.get("ok"):
             self._respond(HTTPStatus.OK, res)
         else:
@@ -1552,8 +1583,7 @@ class Handler(BaseHTTPRequestHandler):
             )
             return
 
-        raw_timeout = os.environ.get("WATERMARKS_SYNTHID_TEXT_TIMEOUT", "")
-        batch_budget = float(raw_timeout) if raw_timeout.strip() else DEFAULT_SYNTHID_TEXT_TIMEOUT
+        batch_budget = resolve_timeout(None)
         deadline = time.monotonic() + batch_budget
 
         results = []

--- a/service/scripts/synthid_text_server.py
+++ b/service/scripts/synthid_text_server.py
@@ -89,6 +89,8 @@ def _generate_watermarked_sample(
     config_path = _resolve_config(upstream, alg, opts.get("config"))
     offline = bool(opts.get("offline", False))
     cache_key = f"{alg}:{model_name}:{device}:{config_path}:{temperature}:{top_p}:{offline}"
+    keys_tag = ",".join(str(k) for k in keys) if keys else ""
+    cache_key = f"{cache_key}:{keys_tag}"
 
     with _MODEL_LOCK:
         if cache_key in _MODEL_CACHE:
@@ -105,12 +107,11 @@ def _generate_watermarked_sample(
                 temperature=temperature,
                 top_p=top_p,
             )
+            if keys is not None and hasattr(wm, "config"):
+                wm.config.keys = keys
             if len(_MODEL_CACHE) >= MAX_CACHED_MODELS:
                 _MODEL_CACHE.popitem(last=False)
             _MODEL_CACHE[cache_key] = wm
-
-        if keys is not None and hasattr(wm, "config"):
-            wm.config.keys = keys
 
         watermarked, _ = _generate(
             wm,
@@ -209,7 +210,10 @@ class Handler(BaseHTTPRequestHandler):
                 raise ValueError(f"failed to decode base64 'file': {e}") from e
             if len(decoded) > MAX_INPUT_BYTES:
                 raise ValueError(f"decoded file exceeds input size cap ({MAX_INPUT_BYTES} bytes)")
-            text = decoded.decode("utf-8")
+            try:
+                text = decoded.decode("utf-8")
+            except UnicodeDecodeError as e:
+                raise ValueError(f"decoded file is not valid UTF-8: {e}") from e
 
         if not isinstance(text, str) or not text.strip():
             raise ValueError("'text' must be a non-empty string")

--- a/service/scripts/synthid_text_server.py
+++ b/service/scripts/synthid_text_server.py
@@ -106,9 +106,8 @@ def _generate_watermarked_sample(
                 offline=offline,
                 temperature=temperature,
                 top_p=top_p,
+                watermark_keys=keys,
             )
-            if keys is not None and hasattr(wm, "config"):
-                wm.config.keys = keys
             if len(_MODEL_CACHE) >= MAX_CACHED_MODELS:
                 _MODEL_CACHE.popitem(last=False)
             _MODEL_CACHE[cache_key] = wm

--- a/service/scripts/synthid_text_server.py
+++ b/service/scripts/synthid_text_server.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Tiny stdlib HTTP sidecar exposing SynthID and research text watermarking.
+
+Runs inside the wr-markllm harness / sidecar image so the published core
+image never bundles heavy ML dependencies (PyTorch, Transformers, MarkLLM).
+The core service calls this sidecar for text watermarking when
+WATERMARKS_SYNTHID_TEXT_URL is set (see compose.yaml / .env.example).
+
+Endpoints:
+    GET  /health          -> {"ok": true, "version": ...}
+    POST /watermark       -> {"text": str, "keys": list[int], "options": dict}
+                          -> {"ok": true, "kind": "text", "watermarked_text": str, "report": dict}
+    POST /watermark/batch -> {"files": [...]} -> {"ok": true, "results": [...]}
+
+Hardening mirrors synthid_score_server.py and server.py: optional bearer key,
+input size caps, unprivileged user, read-only rootfs with a /tmp tmpfs.
+Intended for the compose network or loopback/trusted network only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import json
+import os
+import sys
+import threading
+from collections import OrderedDict
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from text_watermark import normalize_keys, parse_watermark_options  # noqa: E402
+
+VERSION = os.environ.get("WATERMARKS_SYNTHID_TEXT_SERVER_VERSION", "dev")
+
+MAX_INPUT_BYTES = int(os.environ.get("WATERMARKS_MAX_INPUT_BYTES", str(256 << 20)))
+MAX_BODY_BYTES = MAX_INPUT_BYTES + (MAX_INPUT_BYTES >> 1)
+MAX_BATCH_FILES = int(os.environ.get("WATERMARKS_MAX_BATCH_FILES", "50"))
+
+API_KEY = os.environ.get("WATERMARKS_SYNTHID_TEXT_API_KEY", "").strip()
+DEFAULT_MODEL = os.environ.get("WATERMARKS_SYNTHID_TEXT_MODEL", "facebook/opt-1.3b").strip()
+MARKLLM_DIR = os.environ.get("MARKLLM_DIR", "/opt/markllm").strip()
+
+MAX_CACHED_MODELS = int(os.environ.get("WATERMARKS_MAX_CACHED_MODELS", "2"))
+_MODEL_CACHE: OrderedDict[str, Any] = OrderedDict()
+_MODEL_LOCK = threading.Lock()
+
+
+def _json_ok(payload: dict[str, Any]) -> bytes:
+    return json.dumps(payload, ensure_ascii=False, indent=2).encode("utf-8")
+
+
+def _generate_watermarked_sample(
+    text: str,
+    keys: list[int] | None,
+    options: dict[str, Any],
+) -> tuple[str, dict[str, Any]]:
+    """Generate watermarked text using MarkLLM."""
+    opts = options or {}
+    scheme = opts.get("scheme", "synthid").lower()
+    model_name = opts.get("model", DEFAULT_MODEL)
+    seed = opts.get("seed")
+    max_new_tokens = int(opts.get("max_new_tokens", 200))
+    min_length = int(opts.get("min_length", 0))
+    temperature = opts.get("temperature")
+    top_p = opts.get("top_p")
+
+    upstream = Path(MARKLLM_DIR).expanduser().resolve()
+    if not upstream.is_dir():
+        raise RuntimeError(f"MarkLLM upstream directory not found: {MARKLLM_DIR}")
+
+    from detect_text_watermark import (
+        SCHEMES,
+        _generate,
+        _load_algorithm,
+        _resolve_config,
+        resolve_device,
+    )
+
+    alg = SCHEMES.get(scheme, "SynthID")
+    device = resolve_device(opts.get("device"))
+    config_path = _resolve_config(upstream, alg, opts.get("config"))
+    offline = bool(opts.get("offline", False))
+    cache_key = f"{alg}:{model_name}:{device}:{config_path}:{temperature}:{top_p}:{offline}"
+
+    with _MODEL_LOCK:
+        if cache_key in _MODEL_CACHE:
+            wm = _MODEL_CACHE[cache_key]
+            _MODEL_CACHE.move_to_end(cache_key)
+        else:
+            wm = _load_algorithm(
+                upstream,
+                alg,
+                config_path,
+                model_name,
+                device,
+                offline=offline,
+                temperature=temperature,
+                top_p=top_p,
+            )
+            if len(_MODEL_CACHE) >= MAX_CACHED_MODELS:
+                _MODEL_CACHE.popitem(last=False)
+            _MODEL_CACHE[cache_key] = wm
+
+        if keys is not None and hasattr(wm, "config"):
+            wm.config.keys = keys
+
+        watermarked, _ = _generate(
+            wm,
+            text,
+            seed=int(seed) if seed is not None else None,
+            max_new_tokens=max_new_tokens,
+            min_length=min_length,
+            need_unwatermarked=False,
+        )
+
+    report = {
+        "scheme_used": scheme,
+        "model": model_name,
+        "watermarked_chars": len(watermarked),
+        "keys_used": keys,
+    }
+    return watermarked, report
+
+
+class Handler(BaseHTTPRequestHandler):
+    server_version = f"watermarks-remover-synthid-text/{VERSION}"
+
+    def log_message(self, fmt: str, *args: object) -> None:
+        print(f"{self.address_string()} - {fmt % args}", file=sys.stderr)
+
+    def _authorized(self) -> bool:
+        if not API_KEY:
+            return True
+        return self.headers.get("Authorization", "") == f"Bearer {API_KEY}"
+
+    def _read_json(self) -> dict[str, Any] | None:
+        raw_len = self.headers.get("Content-Length")
+        if not raw_len or not raw_len.isdigit():
+            return None
+        length = int(raw_len)
+        if length > MAX_BODY_BYTES:
+            return None
+        try:
+            body = json.loads(self.rfile.read(length).decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError, OSError):
+            return None
+        return body if isinstance(body, dict) else None
+
+    def _respond(self, status: int, payload: dict[str, Any]) -> None:
+        data = _json_ok(payload)
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(data)))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(data)
+
+    def do_GET(self) -> None:
+        if not self._authorized():
+            self._respond(HTTPStatus.UNAUTHORIZED, {"ok": False, "error": "unauthorized"})
+            return
+        if urlparse(self.path).path == "/health":
+            self._respond(HTTPStatus.OK, {"ok": True, "version": VERSION})
+        else:
+            self._respond(HTTPStatus.NOT_FOUND, {"ok": False, "error": "not found"})
+
+    def do_POST(self) -> None:
+        if not self._authorized():
+            self._respond(HTTPStatus.UNAUTHORIZED, {"ok": False, "error": "unauthorized"})
+            return
+
+        path = urlparse(self.path).path
+        if path not in ("/watermark", "/watermark/batch"):
+            self._respond(HTTPStatus.NOT_FOUND, {"ok": False, "error": "not found"})
+            return
+
+        body = self._read_json()
+        if body is None:
+            raw_len = self.headers.get("Content-Length")
+            oversized = raw_len is not None and raw_len.isdigit() and int(raw_len) > MAX_BODY_BYTES
+            self._respond(
+                HTTPStatus.REQUEST_ENTITY_TOO_LARGE if oversized else HTTPStatus.BAD_REQUEST,
+                {"ok": False, "error": "invalid request body"},
+            )
+            return
+
+        if path == "/watermark/batch":
+            self._handle_batch(body)
+        else:
+            self._handle_single(body)
+
+    def _parse_entry(self, entry: dict[str, Any]) -> tuple[str, list[int] | None, dict[str, Any]]:
+        text = entry.get("text")
+        if text is None and "file" in entry:
+            raw_file = entry["file"]
+            if not isinstance(raw_file, str):
+                raise ValueError("'file' must be a base64-encoded string")
+            try:
+                decoded = base64.b64decode(raw_file, validate=True)
+            except (binascii.Error, UnicodeDecodeError) as e:
+                raise ValueError(f"failed to decode base64 'file': {e}") from e
+            if len(decoded) > MAX_INPUT_BYTES:
+                raise ValueError(f"decoded file exceeds input size cap ({MAX_INPUT_BYTES} bytes)")
+            text = decoded.decode("utf-8")
+
+        if not isinstance(text, str) or not text.strip():
+            raise ValueError("'text' must be a non-empty string")
+        if len(text.encode("utf-8")) > MAX_INPUT_BYTES:
+            raise ValueError(f"'text' exceeds input size cap ({MAX_INPUT_BYTES} bytes)")
+
+        keys = normalize_keys(entry.get("keys"))
+        options = parse_watermark_options(entry.get("options"))
+        return text, keys, options
+
+    def _handle_single(self, body: dict[str, Any]) -> None:
+        try:
+            text, keys, options = self._parse_entry(body)
+            watermarked_text, report = _generate_watermarked_sample(text, keys, options)
+            self._respond(
+                HTTPStatus.OK,
+                {
+                    "ok": True,
+                    "kind": "text",
+                    "watermarked_text": watermarked_text,
+                    "report": report,
+                },
+            )
+        except ValueError as e:
+            self._respond(HTTPStatus.BAD_REQUEST, {"ok": False, "error": str(e)})
+        except Exception as e:
+            self.log_error("watermark error: %r", e)
+            self._respond(
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                {"ok": False, "error": "watermark generation failed"},
+            )
+
+    def _handle_batch(self, body: dict[str, Any]) -> None:
+        files = body.get("files")
+        if not isinstance(files, list):
+            self._respond(HTTPStatus.BAD_REQUEST, {"ok": False, "error": "'files' must be a list"})
+            return
+        if not files:
+            self._respond(
+                HTTPStatus.BAD_REQUEST, {"ok": False, "error": "'files' must not be empty"}
+            )
+            return
+        if len(files) > MAX_BATCH_FILES:
+            self._respond(
+                HTTPStatus.BAD_REQUEST,
+                {"ok": False, "error": f"'files' exceeds the {MAX_BATCH_FILES}-file batch limit"},
+            )
+            return
+
+        results: list[dict[str, Any]] = []
+        for entry in files:
+            if not isinstance(entry, dict):
+                results.append(
+                    {"name": "", "ok": False, "error": "each entry in 'files' must be an object"}
+                )
+                continue
+            name = entry.get("name") if isinstance(entry.get("name"), str) else ""
+            try:
+                text, keys, options = self._parse_entry(entry)
+                watermarked_text, report = _generate_watermarked_sample(text, keys, options)
+                results.append(
+                    {
+                        "name": name,
+                        "ok": True,
+                        "kind": "text",
+                        "watermarked_text": watermarked_text,
+                        "report": report,
+                    }
+                )
+            except ValueError as e:
+                results.append({"name": name, "ok": False, "error": str(e)})
+            except Exception as e:
+                self.log_error("batch watermark error for %r: %r", name, e)
+                results.append({"name": name, "ok": False, "error": "generation error"})
+
+        self._respond(HTTPStatus.OK, {"ok": True, "results": results})
+
+
+def main() -> int:
+    global API_KEY  # noqa: PLW0603 — CLI overrides env
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--host", default=os.environ.get("WATERMARKS_SYNTHID_TEXT_SERVER_HOST", "127.0.0.1")
+    )
+    p.add_argument(
+        "--port",
+        type=int,
+        default=int(os.environ.get("WATERMARKS_SYNTHID_TEXT_SERVER_PORT", "8767")),
+    )
+    p.add_argument("--api-key", default=API_KEY, help="require this bearer token (default: none)")
+    args = p.parse_args()
+
+    if args.host not in ("127.0.0.1", "localhost", "::1"):
+        print(
+            f"warning: binding {args.host} — intended for a trusted network only",
+            file=sys.stderr,
+        )
+    API_KEY = args.api_key
+    print(
+        f"synthid text sidecar {VERSION} on http://{args.host}:{args.port}",
+        file=sys.stderr,
+    )
+    server = ThreadingHTTPServer((args.host, args.port), Handler)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        server.shutdown()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/service/scripts/synthid_text_server.py
+++ b/service/scripts/synthid_text_server.py
@@ -89,7 +89,7 @@ def _generate_watermarked_sample(
     config_path = _resolve_config(upstream, alg, opts.get("config"))
     offline = bool(opts.get("offline", False))
     cache_key = f"{alg}:{model_name}:{device}:{config_path}:{temperature}:{top_p}:{offline}"
-    keys_tag = ",".join(str(k) for k in keys) if keys else ""
+    keys_tag = ",".join(str(k) for k in keys) if keys is not None else "<default>"
     cache_key = f"{cache_key}:{keys_tag}"
 
     with _MODEL_LOCK:

--- a/service/scripts/text_watermark.py
+++ b/service/scripts/text_watermark.py
@@ -35,6 +35,9 @@ ALLOWED_WATERMARK_OPTIONS: frozenset[str] = frozenset(
         "temperature",
         "top_p",
         "model",
+        "device",
+        "config",
+        "offline",
     }
 )
 
@@ -115,6 +118,24 @@ def parse_watermark_options(raw: Any) -> dict[str, Any]:
         if p <= 0 or p > 1:
             raise ValueError("'top_p' must be between 0 and 1")
         parsed["top_p"] = p
+
+    if "device" in raw:
+        device = raw["device"]
+        if not isinstance(device, str) or not device.strip():
+            raise ValueError("'device' must be a non-empty string")
+        parsed["device"] = device.strip()
+
+    if "config" in raw:
+        config = raw["config"]
+        if not isinstance(config, str) or not config.strip():
+            raise ValueError("'config' must be a non-empty string")
+        parsed["config"] = config.strip()
+
+    if "offline" in raw:
+        val = raw["offline"]
+        if not isinstance(val, bool):
+            raise ValueError("'offline' must be a boolean")
+        parsed["offline"] = val
 
     return parsed
 
@@ -222,6 +243,7 @@ def _watermark_http(
             "ok": False,
             "kind": "text",
             "error": f"refusing non-http(s) watermark endpoint: {base_url}",
+            "error_code": "backend_error",
         }
 
     body_dict: dict[str, Any] = {
@@ -255,6 +277,7 @@ def _watermark_http(
                 "ok": False,
                 "kind": "text",
                 "error": f"SynthID text sidecar redirect refused (SSRF protection): {e}",
+                "error_code": "ssrf",
             }
         # Distinguish client-side (4xx) from server-side (5xx) sidecar errors
         # so the gateway can propagate the correct HTTP status. A 401 with a
@@ -265,17 +288,20 @@ def _watermark_http(
                 "ok": False,
                 "kind": "text",
                 "error": f"SynthID text sidecar authentication error (401): {e}",
+                "error_code": "auth",
             }
         if 400 <= e.code < 500:
             return {
                 "ok": False,
                 "kind": "text",
                 "error": f"SynthID text sidecar client error ({e.code}): {e}",
+                "error_code": "client_error",
             }
         return {
             "ok": False,
             "kind": "text",
             "error": f"SynthID text sidecar HTTP error ({e.code}): {e}",
+            "error_code": "backend_error",
         }
     except (
         urllib.error.URLError,
@@ -287,16 +313,31 @@ def _watermark_http(
             "ok": False,
             "kind": "text",
             "error": f"SynthID text sidecar unreachable: {e}",
+            "error_code": "unreachable",
         }
 
     if not isinstance(parsed, dict):
-        return {"ok": False, "kind": "text", "error": "bad watermark sidecar response"}
+        return {
+            "ok": False,
+            "kind": "text",
+            "error": "bad watermark sidecar response",
+            "error_code": "backend_error",
+        }
     return parsed
 
 
 _LOCAL_MODEL_CACHE: OrderedDict[str, Any] = OrderedDict()
 _LOCAL_MODEL_LOCK = threading.Lock()
 MAX_LOCAL_CACHED_MODELS = int(os.environ.get("WATERMARKS_MAX_CACHED_MODELS", "2"))
+
+# Long-lived single-worker executor for local generation.  Unlike a
+# ``with ThreadPoolExecutor() as ex:`` context manager whose __exit__
+# calls ``shutdown(wait=True)`` (blocking until the worker finishes even
+# after a TimeoutError), a long-lived pool lets us ``future.cancel()``
+# and return immediately when a deadline expires.
+_LOCAL_GEN_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
+    max_workers=1, thread_name_prefix="wm-local",
+)
 
 
 def _watermark_local_markllm(
@@ -309,7 +350,12 @@ def _watermark_local_markllm(
 ) -> dict[str, Any]:
     """Generate watermarked text locally using detect_text_watermark.py / MarkLLM."""
     if timeout is not None and timeout <= 0:
-        return {"ok": False, "kind": "text", "error": "watermark generation timed out"}
+        return {
+            "ok": False,
+            "kind": "text",
+            "error": "watermark generation timed out",
+            "error_code": "timeout",
+        }
 
     from detect_text_watermark import (
         _load_algorithm,
@@ -326,7 +372,12 @@ def _watermark_local_markllm(
 
     upstream_path = resolve_upstream(upstream_dir)
     if not upstream_path:
-        return {"ok": False, "kind": "text", "error": f"invalid MARKLLM_DIR: {upstream_dir}"}
+        return {
+            "ok": False,
+            "kind": "text",
+            "error": f"invalid MARKLLM_DIR: {upstream_dir}",
+            "error_code": "backend_error",
+        }
 
     device = resolve_device(opts.get("device"))
     model = opts.get("model", "facebook/opt-1.3b")
@@ -377,9 +428,12 @@ def _watermark_local_markllm(
             wm.config.gen_kwargs["min_length"] = int(opts.get("min_length", 0))
 
             if timeout is not None:
-                with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-                    future = executor.submit(wm.generate_watermarked_text, text)
+                future = _LOCAL_GEN_EXECUTOR.submit(wm.generate_watermarked_text, text)
+                try:
                     watermarked = future.result(timeout=timeout)
+                except (TimeoutError, concurrent.futures.TimeoutError):
+                    future.cancel()
+                    raise
             else:
                 watermarked = wm.generate_watermarked_text(text)
 
@@ -395,9 +449,19 @@ def _watermark_local_markllm(
             },
         }
     except (TimeoutError, concurrent.futures.TimeoutError):
-        return {"ok": False, "kind": "text", "error": "watermark generation timed out"}
+        return {
+            "ok": False,
+            "kind": "text",
+            "error": "watermark generation timed out",
+            "error_code": "timeout",
+        }
     except Exception as e:
-        return {"ok": False, "kind": "text", "error": f"MarkLLM generation failed: {e}"}
+        return {
+            "ok": False,
+            "kind": "text",
+            "error": f"MarkLLM generation failed: {e}",
+            "error_code": "backend_error",
+        }
 
 
 def generate_watermark_text(
@@ -418,12 +482,17 @@ def generate_watermark_text(
       3. Fail-soft error when neither is configured
     """
     if not isinstance(text, str) or not text.strip():
-        return {"ok": False, "kind": "text", "error": "'text' must be a non-empty string"}
+        return {
+            "ok": False,
+            "kind": "text",
+            "error": "'text' must be a non-empty string",
+            "error_code": "client_error",
+        }
 
     try:
         normalized_keys = normalize_keys(keys)
     except ValueError as e:
-        return {"ok": False, "kind": "text", "error": str(e)}
+        return {"ok": False, "kind": "text", "error": str(e), "error_code": "client_error"}
 
     # 1. HTTP Sidecar
     url = (sidecar_url or os.environ.get("WATERMARKS_SYNTHID_TEXT_URL", "")).strip()
@@ -459,4 +528,5 @@ def generate_watermark_text(
             "no text watermark generator configured (set WATERMARKS_SYNTHID_TEXT_URL "
             "for the sidecar or MARKLLM_DIR for local execution)"
         ),
+        "error_code": "unconfigured",
     }

--- a/service/scripts/text_watermark.py
+++ b/service/scripts/text_watermark.py
@@ -336,7 +336,8 @@ MAX_LOCAL_CACHED_MODELS = int(os.environ.get("WATERMARKS_MAX_CACHED_MODELS", "2"
 # after a TimeoutError), a long-lived pool lets us ``future.cancel()``
 # and return immediately when a deadline expires.
 _LOCAL_GEN_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
-    max_workers=1, thread_name_prefix="wm-local",
+    max_workers=1,
+    thread_name_prefix="wm-local",
 )
 
 

--- a/service/scripts/text_watermark.py
+++ b/service/scripts/text_watermark.py
@@ -356,9 +356,8 @@ def _watermark_local_markllm(
                     offline=offline,
                     temperature=temperature,
                     top_p=top_p,
+                    watermark_keys=keys,
                 )
-                if keys is not None and hasattr(wm, "config"):
-                    wm.config.keys = keys
                 if len(_LOCAL_MODEL_CACHE) >= MAX_LOCAL_CACHED_MODELS:
                     _LOCAL_MODEL_CACHE.popitem(last=False)
                 _LOCAL_MODEL_CACHE[cache_key] = wm

--- a/service/scripts/text_watermark.py
+++ b/service/scripts/text_watermark.py
@@ -257,7 +257,15 @@ def _watermark_http(
                 "error": f"SynthID text sidecar redirect refused (SSRF protection): {e}",
             }
         # Distinguish client-side (4xx) from server-side (5xx) sidecar errors
-        # so the gateway can propagate the correct HTTP status.
+        # so the gateway can propagate the correct HTTP status. A 401 with a
+        # configured API key means the bearer token was missing/invalid, which
+        # is a gateway config problem (502), not a request-validation issue (400).
+        if e.code == 401:
+            return {
+                "ok": False,
+                "kind": "text",
+                "error": f"SynthID text sidecar authentication error (401): {e}",
+            }
         if 400 <= e.code < 500:
             return {
                 "ok": False,
@@ -328,7 +336,7 @@ def _watermark_local_markllm(
         offline = bool(opts.get("offline", False))
         temperature = opts.get("temperature")
         top_p = opts.get("top_p")
-        keys_tag = ",".join(str(k) for k in keys) if keys else ""
+        keys_tag = "<default>" if keys is None else ",".join(str(k) for k in keys)
         cache_key = (
             f"{scheme_alg}:{model}:{device}:{config_path}"
             f":{temperature}:{top_p}:{offline}:{keys_tag}"

--- a/service/scripts/text_watermark.py
+++ b/service/scripts/text_watermark.py
@@ -119,6 +119,28 @@ def parse_watermark_options(raw: Any) -> dict[str, Any]:
     return parsed
 
 
+def resolve_timeout(
+    explicit: float | None,
+    *,
+    env_var: str = "WATERMARKS_SYNTHID_TEXT_TIMEOUT",
+    default: float = DEFAULT_SYNTHID_TEXT_TIMEOUT,
+    floor: float = 1.0,
+    ceiling: float = 600.0,
+) -> float:
+    """Resolve timeout from an explicit value or environment variable.
+
+    Returns *default* when neither is set. Clamps the result to
+    [floor, ceiling] to prevent unbounded waits or nonsensical sub-second
+    deadlines.
+    """
+    if explicit is not None:
+        t = float(explicit)
+    else:
+        raw = os.environ.get(env_var, "").strip()
+        t = float(raw) if raw else default
+    return max(floor, min(t, ceiling))
+
+
 class _NoRedirect(urllib.request.HTTPRedirectHandler):
     """Refuse HTTP redirects to prevent SSRF and credential forwarding."""
 
@@ -234,10 +256,18 @@ def _watermark_http(
                 "kind": "text",
                 "error": f"SynthID text sidecar redirect refused (SSRF protection): {e}",
             }
+        # Distinguish client-side (4xx) from server-side (5xx) sidecar errors
+        # so the gateway can propagate the correct HTTP status.
+        if 400 <= e.code < 500:
+            return {
+                "ok": False,
+                "kind": "text",
+                "error": f"SynthID text sidecar client error ({e.code}): {e}",
+            }
         return {
             "ok": False,
             "kind": "text",
-            "error": f"SynthID text sidecar HTTP error: {e}",
+            "error": f"SynthID text sidecar HTTP error ({e.code}): {e}",
         }
     except (
         urllib.error.URLError,
@@ -298,7 +328,11 @@ def _watermark_local_markllm(
         offline = bool(opts.get("offline", False))
         temperature = opts.get("temperature")
         top_p = opts.get("top_p")
-        cache_key = f"{scheme_alg}:{model}:{device}:{config_path}:{temperature}:{top_p}:{offline}"
+        keys_tag = ",".join(str(k) for k in keys) if keys else ""
+        cache_key = (
+            f"{scheme_alg}:{model}:{device}:{config_path}"
+            f":{temperature}:{top_p}:{offline}:{keys_tag}"
+        )
 
         with _LOCAL_MODEL_LOCK:
             if cache_key in _LOCAL_MODEL_CACHE:
@@ -315,31 +349,32 @@ def _watermark_local_markllm(
                     temperature=temperature,
                     top_p=top_p,
                 )
+                if keys is not None and hasattr(wm, "config"):
+                    wm.config.keys = keys
                 if len(_LOCAL_MODEL_CACHE) >= MAX_LOCAL_CACHED_MODELS:
                     _LOCAL_MODEL_CACHE.popitem(last=False)
                 _LOCAL_MODEL_CACHE[cache_key] = wm
 
-        if keys is not None and hasattr(wm, "config"):
-            wm.config.keys = keys
+            # All mutable config is set inside the lock so concurrent
+            # requests on the same cached model don't race on gen_kwargs.
+            seed = opts.get("seed")
+            if seed is not None:
+                try:
+                    import torch  # type: ignore
 
-        seed = opts.get("seed")
-        if seed is not None:
-            try:
-                import torch  # type: ignore
+                    torch.manual_seed(int(seed))
+                except (ImportError, ModuleNotFoundError):
+                    pass
 
-                torch.manual_seed(int(seed))
-            except (ImportError, ModuleNotFoundError):
-                pass
+            wm.config.gen_kwargs["max_new_tokens"] = int(opts.get("max_new_tokens", 200))
+            wm.config.gen_kwargs["min_length"] = int(opts.get("min_length", 0))
 
-        wm.config.gen_kwargs["max_new_tokens"] = int(opts.get("max_new_tokens", 200))
-        wm.config.gen_kwargs["min_length"] = int(opts.get("min_length", 0))
-
-        if timeout is not None:
-            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-                future = executor.submit(wm.generate_watermarked_text, text)
-                watermarked = future.result(timeout=timeout)
-        else:
-            watermarked = wm.generate_watermarked_text(text)
+            if timeout is not None:
+                with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+                    future = executor.submit(wm.generate_watermarked_text, text)
+                    watermarked = future.result(timeout=timeout)
+            else:
+                watermarked = wm.generate_watermarked_text(text)
 
         return {
             "ok": True,
@@ -391,14 +426,7 @@ def generate_watermark_text(
             if api_key is not None
             else os.environ.get("WATERMARKS_SYNTHID_TEXT_API_KEY", "").strip()
         )
-        raw_timeout = os.environ.get("WATERMARKS_SYNTHID_TEXT_TIMEOUT", "")
-        t = (
-            timeout
-            if timeout is not None
-            else float(raw_timeout)
-            if raw_timeout.strip()
-            else DEFAULT_SYNTHID_TEXT_TIMEOUT
-        )
+        t = resolve_timeout(timeout)
         return _watermark_http(
             text,
             url,

--- a/service/scripts/text_watermark.py
+++ b/service/scripts/text_watermark.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+"""Client and dispatch module for text watermark generation.
+
+Routes watermark generation requests to the HTTP sidecar (synthid_text_server.py)
+when WATERMARKS_SYNTHID_TEXT_URL is set, or falls back to a local MarkLLM
+checkout when MARKLLM_DIR is set. When neither is configured, returns a
+fail-soft explanatory error matching the repo's optional-harness conventions.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import json
+import os
+import sys
+import threading
+import urllib.error
+import urllib.request
+from collections import OrderedDict
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+DEFAULT_SYNTHID_TEXT_TIMEOUT = 120.0
+
+ALLOWED_WATERMARK_OPTIONS: frozenset[str] = frozenset(
+    {
+        "scheme",
+        "seed",
+        "max_new_tokens",
+        "min_length",
+        "temperature",
+        "top_p",
+        "model",
+    }
+)
+
+
+def parse_watermark_options(raw: Any) -> dict[str, Any]:
+    """Validate and sanitize text watermarking options against the documented contract."""
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise ValueError("'options' must be a dictionary")
+    unknown = set(raw) - ALLOWED_WATERMARK_OPTIONS
+    if unknown:
+        raise ValueError(f"unsupported option(s): {', '.join(sorted(unknown))}")
+
+    parsed: dict[str, Any] = {}
+    if "scheme" in raw:
+        scheme = raw["scheme"]
+        if not isinstance(scheme, str) or not scheme.strip():
+            raise ValueError("'scheme' must be a non-empty string")
+        parsed["scheme"] = scheme.strip()
+
+    if "model" in raw:
+        model = raw["model"]
+        if not isinstance(model, str) or not model.strip():
+            raise ValueError("'model' must be a non-empty string")
+        parsed["model"] = model.strip()
+
+    if "seed" in raw:
+        val = raw["seed"]
+        if isinstance(val, bool) or not isinstance(val, int):
+            raise ValueError("'seed' must be an integer")
+        parsed["seed"] = val
+
+    if "max_new_tokens" in raw:
+        val = raw["max_new_tokens"]
+        if isinstance(val, bool):
+            raise ValueError("'max_new_tokens' must be an integer")
+        try:
+            tokens = int(val)
+        except (ValueError, TypeError) as e:
+            raise ValueError(f"'max_new_tokens' must be an integer: {e}") from e
+        if tokens < 1 or tokens > 8192:
+            raise ValueError("'max_new_tokens' must be between 1 and 8192")
+        parsed["max_new_tokens"] = tokens
+
+    if "min_length" in raw:
+        val = raw["min_length"]
+        if isinstance(val, bool):
+            raise ValueError("'min_length' must be an integer")
+        try:
+            length = int(val)
+        except (ValueError, TypeError) as e:
+            raise ValueError(f"'min_length' must be an integer: {e}") from e
+        if length < 0 or length > 8192:
+            raise ValueError("'min_length' must be between 0 and 8192")
+        parsed["min_length"] = length
+
+    if "temperature" in raw:
+        val = raw["temperature"]
+        if isinstance(val, bool):
+            raise ValueError("'temperature' must be a number")
+        try:
+            temp = float(val)
+        except (ValueError, TypeError) as e:
+            raise ValueError(f"'temperature' must be a number: {e}") from e
+        if temp <= 0:
+            raise ValueError("'temperature' must be greater than 0")
+        parsed["temperature"] = temp
+
+    if "top_p" in raw:
+        val = raw["top_p"]
+        if isinstance(val, bool):
+            raise ValueError("'top_p' must be a number")
+        try:
+            p = float(val)
+        except (ValueError, TypeError) as e:
+            raise ValueError(f"'top_p' must be a number: {e}") from e
+        if p <= 0 or p > 1:
+            raise ValueError("'top_p' must be between 0 and 1")
+        parsed["top_p"] = p
+
+    return parsed
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Refuse HTTP redirects to prevent SSRF and credential forwarding."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        raise urllib.error.HTTPError(req.full_url, code, msg, headers, fp)
+
+
+def _default_opener() -> urllib.request.OpenerDirector:
+    return urllib.request.build_opener(_NoRedirect())
+
+
+# Module-level opener seam for testing/injection; None defaults to _default_opener().
+OPENER: Any = None
+
+
+def normalize_keys(raw: Any) -> list[int] | None:
+    """Normalize keys input into a list of integer keys.
+
+    Accepts:
+        - list of ints: [118, 504, 421, 521]
+        - comma-separated string: "118,504,421,521"
+        - JSON array string: "[118, 504, 421, 521]"
+        - None: returns None (uses default scheme keys)
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, bool):
+        raise ValueError("unsupported keys format: boolean is not a valid key")
+    if isinstance(raw, list):
+        try:
+            keys = []
+            for x in raw:
+                if isinstance(x, bool):
+                    raise ValueError(f"boolean {x!r} is not an integer key")
+                keys.append(int(x))
+            return keys
+        except (ValueError, TypeError) as e:
+            raise ValueError(f"all keys in list must be integers: {e}") from e
+    if isinstance(raw, str):
+        s = raw.strip()
+        if not s:
+            return None
+        if s.startswith("[") and s.endswith("]"):
+            try:
+                parsed = json.loads(s)
+            except json.JSONDecodeError as e:
+                raise ValueError(f"invalid JSON array for keys: {e}") from e
+            if not isinstance(parsed, list):
+                raise ValueError("keys JSON must decode to a list of integers")
+            keys = []
+            try:
+                for x in parsed:
+                    if isinstance(x, bool):
+                        raise ValueError(f"boolean {x!r} is not an integer key")
+                    keys.append(int(x))
+                return keys
+            except (ValueError, TypeError) as e:
+                raise ValueError(f"all keys in list must be integers: {e}") from e
+        try:
+            return [int(part.strip()) for part in s.split(",") if part.strip()]
+        except ValueError as e:
+            raise ValueError(f"comma-separated keys must all be integers: {e}") from e
+    raise ValueError(f"unsupported keys format: {type(raw).__name__}")
+
+
+def _watermark_http(
+    text: str,
+    base_url: str,
+    *,
+    api_key: str | None = None,
+    timeout: float = DEFAULT_SYNTHID_TEXT_TIMEOUT,
+    keys: list[int] | None = None,
+    options: dict[str, Any] | None = None,
+    opener: Any = None,
+) -> dict[str, Any]:
+    """Call the HTTP sidecar (synthid_text_server.py) to watermark text."""
+    if urlparse(base_url).scheme not in ("http", "https"):
+        return {
+            "ok": False,
+            "kind": "text",
+            "error": f"refusing non-http(s) watermark endpoint: {base_url}",
+        }
+
+    body_dict: dict[str, Any] = {
+        "text": text,
+        "options": options or {},
+    }
+    if keys is not None:
+        body_dict["keys"] = keys
+
+    payload_bytes = json.dumps(body_dict).encode("utf-8")
+    headers = {"Content-Type": "application/json; charset=utf-8"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    # S310: URL scheme is restricted to http/https just above.
+    req = urllib.request.Request(  # noqa: S310
+        base_url.rstrip("/") + "/watermark",
+        data=payload_bytes,
+        headers=headers,
+        method="POST",
+    )
+
+    active_opener = opener if opener is not None else (OPENER or _default_opener())
+    try:
+        with active_opener.open(req, timeout=timeout) as resp:
+            data = resp.read()
+        parsed = json.loads(data.decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        if e.code in (301, 302, 303, 307, 308):
+            return {
+                "ok": False,
+                "kind": "text",
+                "error": f"SynthID text sidecar redirect refused (SSRF protection): {e}",
+            }
+        return {
+            "ok": False,
+            "kind": "text",
+            "error": f"SynthID text sidecar HTTP error: {e}",
+        }
+    except (
+        urllib.error.URLError,
+        TimeoutError,
+        OSError,
+        json.JSONDecodeError,
+    ) as e:
+        return {
+            "ok": False,
+            "kind": "text",
+            "error": f"SynthID text sidecar unreachable: {e}",
+        }
+
+    if not isinstance(parsed, dict):
+        return {"ok": False, "kind": "text", "error": "bad watermark sidecar response"}
+    return parsed
+
+
+_LOCAL_MODEL_CACHE: OrderedDict[str, Any] = OrderedDict()
+_LOCAL_MODEL_LOCK = threading.Lock()
+MAX_LOCAL_CACHED_MODELS = int(os.environ.get("WATERMARKS_MAX_CACHED_MODELS", "2"))
+
+
+def _watermark_local_markllm(
+    text: str,
+    upstream_dir: str,
+    *,
+    keys: list[int] | None = None,
+    options: dict[str, Any] | None = None,
+    timeout: float | None = None,
+) -> dict[str, Any]:
+    """Generate watermarked text locally using detect_text_watermark.py / MarkLLM."""
+    if timeout is not None and timeout <= 0:
+        return {"ok": False, "kind": "text", "error": "watermark generation timed out"}
+
+    from detect_text_watermark import (
+        _load_algorithm,
+        _resolve_config,
+        resolve_device,
+        resolve_upstream,
+    )
+
+    opts = options or {}
+    alg = opts.get("scheme", "synthid").lower()
+    from detect_text_watermark import SCHEMES
+
+    scheme_alg = SCHEMES.get(alg, "SynthID")
+
+    upstream_path = resolve_upstream(upstream_dir)
+    if not upstream_path:
+        return {"ok": False, "kind": "text", "error": f"invalid MARKLLM_DIR: {upstream_dir}"}
+
+    device = resolve_device(opts.get("device"))
+    model = opts.get("model", "facebook/opt-1.3b")
+
+    try:
+        config_path = _resolve_config(upstream_path, scheme_alg, opts.get("config"))
+        offline = bool(opts.get("offline", False))
+        temperature = opts.get("temperature")
+        top_p = opts.get("top_p")
+        cache_key = f"{scheme_alg}:{model}:{device}:{config_path}:{temperature}:{top_p}:{offline}"
+
+        with _LOCAL_MODEL_LOCK:
+            if cache_key in _LOCAL_MODEL_CACHE:
+                wm = _LOCAL_MODEL_CACHE[cache_key]
+                _LOCAL_MODEL_CACHE.move_to_end(cache_key)
+            else:
+                wm = _load_algorithm(
+                    upstream_path,
+                    scheme_alg,
+                    config_path,
+                    model,
+                    device,
+                    offline=offline,
+                    temperature=temperature,
+                    top_p=top_p,
+                )
+                if len(_LOCAL_MODEL_CACHE) >= MAX_LOCAL_CACHED_MODELS:
+                    _LOCAL_MODEL_CACHE.popitem(last=False)
+                _LOCAL_MODEL_CACHE[cache_key] = wm
+
+        if keys is not None and hasattr(wm, "config"):
+            wm.config.keys = keys
+
+        seed = opts.get("seed")
+        if seed is not None:
+            try:
+                import torch  # type: ignore
+
+                torch.manual_seed(int(seed))
+            except (ImportError, ModuleNotFoundError):
+                pass
+
+        wm.config.gen_kwargs["max_new_tokens"] = int(opts.get("max_new_tokens", 200))
+        wm.config.gen_kwargs["min_length"] = int(opts.get("min_length", 0))
+
+        if timeout is not None:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+                future = executor.submit(wm.generate_watermarked_text, text)
+                watermarked = future.result(timeout=timeout)
+        else:
+            watermarked = wm.generate_watermarked_text(text)
+
+        return {
+            "ok": True,
+            "kind": "text",
+            "watermarked_text": watermarked,
+            "report": {
+                "scheme_used": scheme_alg.lower(),
+                "model": model,
+                "watermarked_chars": len(watermarked),
+                "keys_used": keys,
+            },
+        }
+    except (TimeoutError, concurrent.futures.TimeoutError):
+        return {"ok": False, "kind": "text", "error": "watermark generation timed out"}
+    except Exception as e:
+        return {"ok": False, "kind": "text", "error": f"MarkLLM generation failed: {e}"}
+
+
+def generate_watermark_text(
+    text: str,
+    *,
+    keys: list[int] | str | None = None,
+    options: dict[str, Any] | None = None,
+    sidecar_url: str | None = None,
+    api_key: str | None = None,
+    timeout: float | None = None,
+    opener: Any = None,
+) -> dict[str, Any]:
+    """Generate watermarked text via the configured sidecar or local fallback.
+
+    Priority:
+      1. HTTP sidecar via WATERMARKS_SYNTHID_TEXT_URL (or sidecar_url argument)
+      2. Local MarkLLM checkout via MARKLLM_DIR
+      3. Fail-soft error when neither is configured
+    """
+    if not isinstance(text, str) or not text.strip():
+        return {"ok": False, "kind": "text", "error": "'text' must be a non-empty string"}
+
+    try:
+        normalized_keys = normalize_keys(keys)
+    except ValueError as e:
+        return {"ok": False, "kind": "text", "error": str(e)}
+
+    # 1. HTTP Sidecar
+    url = (sidecar_url or os.environ.get("WATERMARKS_SYNTHID_TEXT_URL", "")).strip()
+    if url:
+        key = (
+            api_key
+            if api_key is not None
+            else os.environ.get("WATERMARKS_SYNTHID_TEXT_API_KEY", "").strip()
+        )
+        raw_timeout = os.environ.get("WATERMARKS_SYNTHID_TEXT_TIMEOUT", "")
+        t = (
+            timeout
+            if timeout is not None
+            else float(raw_timeout)
+            if raw_timeout.strip()
+            else DEFAULT_SYNTHID_TEXT_TIMEOUT
+        )
+        return _watermark_http(
+            text,
+            url,
+            api_key=key,
+            timeout=t,
+            keys=normalized_keys,
+            options=options,
+            opener=opener,
+        )
+
+    # 2. Local MarkLLM checkout
+    upstream = os.environ.get("MARKLLM_DIR", "").strip()
+    if upstream:
+        return _watermark_local_markllm(
+            text, upstream, keys=normalized_keys, options=options, timeout=timeout
+        )
+
+    # 3. Unconfigured fail-soft
+    return {
+        "ok": False,
+        "kind": "text",
+        "error": (
+            "no text watermark generator configured (set WATERMARKS_SYNTHID_TEXT_URL "
+            "for the sidecar or MARKLLM_DIR for local execution)"
+        ),
+    }

--- a/tests/test_synthid_text_server.py
+++ b/tests/test_synthid_text_server.py
@@ -1,0 +1,386 @@
+"""Unit tests for the SynthID text sidecar server (synthid_text_server.py)."""
+
+from __future__ import annotations
+
+import base64
+import http.client
+import json
+import sys
+import threading
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "service" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import synthid_text_server  # type: ignore
+
+
+def _post(
+    conn: http.client.HTTPConnection, path: str, payload: dict, headers: dict | None = None
+) -> tuple[int, dict]:
+    h = {"Content-Type": "application/json"}
+    if headers:
+        h.update(headers)
+    conn.request(
+        "POST",
+        path,
+        body=json.dumps(payload).encode("utf-8"),
+        headers=h,
+    )
+    resp = conn.getresponse()
+    data = resp.read()
+    return resp.status, json.loads(data) if data else {}
+
+
+def _get(
+    conn: http.client.HTTPConnection, path: str, headers: dict | None = None
+) -> tuple[int, dict]:
+    h = {}
+    if headers:
+        h.update(headers)
+    conn.request("GET", path, headers=h)
+    resp = conn.getresponse()
+    data = resp.read()
+    return resp.status, json.loads(data) if data else {}
+
+
+def _fake_generate(
+    text: str,
+    keys: list[int] | None,
+    options: dict[str, Any],
+) -> tuple[str, dict[str, Any]]:
+    opts = options or {}
+    scheme = opts.get("scheme", "synthid")
+    model_name = opts.get("model", synthid_text_server.DEFAULT_MODEL)
+    key_repr = f" [keys:{','.join(map(str, keys))}]" if keys else ""
+    watermarked = f"{text}{key_repr}"
+    report = {
+        "scheme_used": scheme,
+        "model": model_name,
+        "watermarked_chars": len(watermarked),
+        "keys_used": keys,
+    }
+    return watermarked, report
+
+
+@pytest.fixture
+def sidecar_server(monkeypatch):
+    monkeypatch.setattr(synthid_text_server, "API_KEY", "")
+    monkeypatch.setattr(synthid_text_server, "_generate_watermarked_sample", _fake_generate)
+    srv = synthid_text_server.ThreadingHTTPServer(("127.0.0.1", 0), synthid_text_server.Handler)
+    thread = threading.Thread(target=srv.serve_forever, daemon=True)
+    thread.start()
+    c = http.client.HTTPConnection("127.0.0.1", srv.server_address[1])
+    yield c, srv
+    c.close()
+    srv.shutdown()
+    srv.server_close()
+    thread.join(timeout=5)
+
+
+def test_sidecar_health(sidecar_server):
+    conn, _ = sidecar_server
+    status, body = _get(conn, "/health")
+    assert status == 200
+    assert body["ok"] is True
+    assert "version" in body
+
+
+def test_sidecar_auth_enforced(monkeypatch):
+    monkeypatch.setattr(synthid_text_server, "API_KEY", "sidecar-secret")
+    srv = synthid_text_server.ThreadingHTTPServer(("127.0.0.1", 0), synthid_text_server.Handler)
+    thread = threading.Thread(target=srv.serve_forever, daemon=True)
+    thread.start()
+    conn = http.client.HTTPConnection("127.0.0.1", srv.server_address[1])
+    try:
+        # Without auth -> 401
+        status, body = _get(conn, "/health")
+        assert status == 401
+        assert body["error"] == "unauthorized"
+
+        # With wrong token -> 401
+        status, body = _get(conn, "/health", headers={"Authorization": "Bearer wrong"})
+        assert status == 401
+
+        # With correct token -> 200
+        status, body = _get(conn, "/health", headers={"Authorization": "Bearer sidecar-secret"})
+        assert status == 200
+        assert body["ok"] is True
+    finally:
+        conn.close()
+        srv.shutdown()
+        srv.server_close()
+        thread.join(timeout=5)
+
+
+def test_sidecar_watermark_single(sidecar_server):
+    conn, _ = sidecar_server
+    status, body = _post(
+        conn,
+        "/watermark",
+        {
+            "text": "Testing single prompt",
+            "keys": [118, 504, 421, 521],
+            "options": {"scheme": "synthid", "seed": 42},
+        },
+    )
+    assert status == 200
+    assert body["ok"] is True
+    assert body["kind"] == "text"
+    assert "watermarked_text" in body
+    assert body["report"]["keys_used"] == [118, 504, 421, 521]
+
+
+def test_sidecar_watermark_batch(sidecar_server):
+    conn, _ = sidecar_server
+    status, body = _post(
+        conn,
+        "/watermark/batch",
+        {
+            "files": [
+                {"name": "f1.txt", "text": "Prompt 1", "keys": [10, 20]},
+                {"name": "f2.txt", "text": "Prompt 2"},
+            ]
+        },
+    )
+    assert status == 200
+    assert body["ok"] is True
+    assert len(body["results"]) == 2
+    assert body["results"][0]["name"] == "f1.txt"
+    assert body["results"][0]["ok"] is True
+    assert body["results"][1]["name"] == "f2.txt"
+    assert body["results"][1]["ok"] is True
+
+
+def test_sidecar_watermark_base64_file(sidecar_server):
+    conn, _ = sidecar_server
+    raw_content = "Prompt from encoded file payload"
+    b64_file = base64.b64encode(raw_content.encode("utf-8")).decode("ascii")
+    status, body = _post(
+        conn,
+        "/watermark",
+        {"file": b64_file, "keys": [10, 20]},
+    )
+    assert status == 200
+    assert body["ok"] is True
+    assert raw_content in body["watermarked_text"]
+    assert body["report"]["keys_used"] == [10, 20]
+
+
+def test_sidecar_watermark_non_string_file(sidecar_server):
+    conn, _ = sidecar_server
+    status, body = _post(
+        conn,
+        "/watermark",
+        {"file": 12345},
+    )
+    assert status == 400
+    assert body["ok"] is False
+    assert "'file' must be a base64-encoded string" in body["error"]
+
+
+def test_sidecar_watermark_batch_limit_exceeded(sidecar_server):
+    conn, _ = sidecar_server
+    status, body = _post(
+        conn,
+        "/watermark/batch",
+        {
+            "files": [
+                {"name": f"f{i}.txt", "text": f"Prompt {i}"}
+                for i in range(synthid_text_server.MAX_BATCH_FILES + 1)
+            ]
+        },
+    )
+    assert status == 400
+    assert body["ok"] is False
+    assert f"exceeds the {synthid_text_server.MAX_BATCH_FILES}-file batch limit" in body["error"]
+
+
+def test_sidecar_watermark_input_cap_text(sidecar_server, monkeypatch):
+    conn, _ = sidecar_server
+    monkeypatch.setattr(synthid_text_server, "MAX_INPUT_BYTES", 20)
+    status, body = _post(
+        conn,
+        "/watermark",
+        {"text": "A" * 25},
+    )
+    assert status == 400
+    assert body["ok"] is False
+    assert "input size cap" in body["error"]
+
+
+def test_sidecar_watermark_input_cap_decoded_file(sidecar_server, monkeypatch):
+    conn, _ = sidecar_server
+    monkeypatch.setattr(synthid_text_server, "MAX_INPUT_BYTES", 20)
+    b64_file = base64.b64encode(b"B" * 25).decode("ascii")
+    status, body = _post(
+        conn,
+        "/watermark",
+        {"file": b64_file},
+    )
+    assert status == 400
+    assert body["ok"] is False
+    assert "input size cap" in body["error"]
+
+
+def test_sidecar_watermark_invalid_scheme(sidecar_server):
+    conn, _ = sidecar_server
+    status, body = _post(
+        conn,
+        "/watermark",
+        {
+            "text": "Prompt text",
+            "options": {"scheme": True},
+        },
+    )
+    assert status == 400
+    assert body["ok"] is False
+    assert "'scheme' must be a non-empty string" in body["error"]
+
+
+def test_sidecar_keys_rejects_nested_json(sidecar_server):
+    conn, _ = sidecar_server
+    status, body = _post(
+        conn,
+        "/watermark",
+        {
+            "text": "Prompt text",
+            "keys": "[[1, 2]]",
+        },
+    )
+    assert status == 400
+    assert body["ok"] is False
+
+
+def test_sidecar_watermark_missing_markllm_returns_500(monkeypatch, tmp_path):
+    monkeypatch.setattr(synthid_text_server, "API_KEY", "")
+    monkeypatch.setattr(synthid_text_server, "MARKLLM_DIR", str(tmp_path / "nonexistent"))
+    srv = synthid_text_server.ThreadingHTTPServer(("127.0.0.1", 0), synthid_text_server.Handler)
+    thread = threading.Thread(target=srv.serve_forever, daemon=True)
+    thread.start()
+    conn = http.client.HTTPConnection("127.0.0.1", srv.server_address[1])
+    try:
+        status, body = _post(conn, "/watermark", {"text": "hello prompt"})
+        assert status == 500
+        assert body["ok"] is False
+        assert body["error"] == "watermark generation failed"
+    finally:
+        conn.close()
+        srv.shutdown()
+        srv.server_close()
+        thread.join(timeout=5)
+
+
+def test_sidecar_watermark_batch_missing_markllm_returns_generation_error(monkeypatch, tmp_path):
+    monkeypatch.setattr(synthid_text_server, "API_KEY", "")
+    monkeypatch.setattr(synthid_text_server, "MARKLLM_DIR", str(tmp_path / "nonexistent"))
+    srv = synthid_text_server.ThreadingHTTPServer(("127.0.0.1", 0), synthid_text_server.Handler)
+    thread = threading.Thread(target=srv.serve_forever, daemon=True)
+    thread.start()
+    conn = http.client.HTTPConnection("127.0.0.1", srv.server_address[1])
+    try:
+        status, body = _post(
+            conn, "/watermark/batch", {"files": [{"name": "f.txt", "text": "hello prompt"}]}
+        )
+        assert status == 200
+        assert body["ok"] is True
+        assert len(body["results"]) == 1
+        assert body["results"][0]["ok"] is False
+        assert body["results"][0]["error"] == "generation error"
+    finally:
+        conn.close()
+        srv.shutdown()
+        srv.server_close()
+        thread.join(timeout=5)
+
+
+def test_sidecar_rejects_undocumented_options(sidecar_server):
+    conn, _ = sidecar_server
+    status, body = _post(
+        conn,
+        "/watermark",
+        {
+            "text": "Prompt text",
+            "options": {"config": "/etc/passwd"},
+        },
+    )
+    assert status == 400
+    assert body["ok"] is False
+    assert "unsupported option" in body["error"]
+
+
+def test_sidecar_model_cache_bounded(monkeypatch):
+    monkeypatch.setattr(synthid_text_server, "MAX_CACHED_MODELS", 2)
+    synthid_text_server._MODEL_CACHE.clear()
+    with synthid_text_server._MODEL_LOCK:
+        synthid_text_server._MODEL_CACHE["m1"] = "val1"
+        synthid_text_server._MODEL_CACHE["m2"] = "val2"
+        synthid_text_server._MODEL_CACHE.move_to_end("m1")
+        if len(synthid_text_server._MODEL_CACHE) >= 2:
+            synthid_text_server._MODEL_CACHE.popitem(last=False)
+        synthid_text_server._MODEL_CACHE["m3"] = "val3"
+        assert "m2" not in synthid_text_server._MODEL_CACHE
+        assert "m1" in synthid_text_server._MODEL_CACHE
+        assert "m3" in synthid_text_server._MODEL_CACHE
+
+
+def test_sidecar_generator_missing_markllm_fails(monkeypatch, tmp_path):
+    monkeypatch.setattr(synthid_text_server, "MARKLLM_DIR", str(tmp_path / "nonexistent"))
+    with pytest.raises(RuntimeError, match="MarkLLM upstream directory not found"):
+        synthid_text_server._generate_watermarked_sample("test prompt", None, {})
+
+
+def test_sidecar_not_found(sidecar_server):
+    conn, _ = sidecar_server
+    status, body = _get(conn, "/unknown_route")
+    assert status == 404
+    assert body["ok"] is False
+
+
+def test_sidecar_invalid_body(sidecar_server):
+    conn, _ = sidecar_server
+    conn.request(
+        "POST",
+        "/watermark",
+        body=b"not json",
+        headers={"Content-Type": "application/json"},
+    )
+    resp = conn.getresponse()
+    data = resp.read()
+    body = json.loads(data)
+    assert resp.status == 400
+    assert body["ok"] is False
+
+
+def test_sidecar_invalid_options(sidecar_server):
+    conn, _ = sidecar_server
+    status, body = _post(
+        conn,
+        "/watermark",
+        {
+            "text": "Prompt text",
+            "options": {"max_new_tokens": "not-an-int"},
+        },
+    )
+    assert status == 400
+    assert body["ok"] is False
+    assert "max_new_tokens" in body["error"]
+
+
+def test_sidecar_keys_rejects_bool(sidecar_server):
+    conn, _ = sidecar_server
+    status, body = _post(
+        conn,
+        "/watermark",
+        {
+            "text": "Prompt text",
+            "keys": [True, 123],
+        },
+    )
+    assert status == 400
+    assert body["ok"] is False
+    assert "boolean" in body["error"]

--- a/tests/test_synthid_text_server.py
+++ b/tests/test_synthid_text_server.py
@@ -402,33 +402,33 @@ def test_sidecar_non_utf8_file(sidecar_server):
 
 
 def test_sidecar_cache_key_distinguishes_default_and_empty_keys(monkeypatch, tmp_path):
-    """keys=None (default scheme keys) and keys=[] must use distinct cached models."""
+    """keys=None (default scheme keys) and keys=[] must be applied at model construction."""
     import detect_text_watermark as dtw
 
     upstream = tmp_path / "upstream"
     upstream.mkdir()
 
-    created_keys: list[list[int] | None] = []
+    construction_keys: list[list[int] | None] = []
 
     class _FakeConfig:
-        def __init__(self) -> None:
-            self.keys: list[int] | None = None
+        def __init__(self, keys) -> None:
+            self.keys = keys
             self.gen_kwargs: dict[str, Any] = {}
 
     class _FakeWM:
-        def __init__(self, keytag: object) -> None:
-            self.config = _FakeConfig()
-            self._keytag = keytag
+        def __init__(self, keys) -> None:
+            self.config = _FakeConfig(keys)
 
         def generate_watermarked_text(self, text: str) -> str:
-            return f"{text}[{self.config.keys}]"
+            return f"{text}[keys:{self.config.keys}]"
 
     def _fake_load(upstream, alg, config, model, device, **kwargs):
-        created_keys.append(None)
-        return _FakeWM(None)
+        keys = kwargs.get("watermark_keys")
+        construction_keys.append(keys)
+        return _FakeWM(keys)
 
     def _fake_generate(wm, text, **kwargs):
-        return f"{text}[{wm.config.keys}]", {}
+        return f"{text}[keys:{wm.config.keys}]", {}
 
     monkeypatch.setattr(dtw, "_load_algorithm", _fake_load)
     monkeypatch.setattr(dtw, "_resolve_config", lambda *a, **k: upstream / "config.json")
@@ -442,10 +442,88 @@ def test_sidecar_cache_key_distinguishes_default_and_empty_keys(monkeypatch, tmp
     empty_out, _ = synthid_text_server._generate_watermarked_sample("hello", [], {})
     default_out2, _ = synthid_text_server._generate_watermarked_sample("hello", None, {})
 
-    assert default_out == "hello[None]"
-    assert empty_out == "hello[[]]"
-    # Two distinct models must have been instantiated and cached separately.
-    assert len(created_keys) == 2
+    # Construction-time keys: None (default) and [] (empty) stay distinct.
+    assert construction_keys == [None, []]
+    # The model built with the default scheme keys is used for keys=None.
+    assert default_out == "hello[keys:None]"
+    assert default_out2 == "hello[keys:None]"
+    # The separately-cached empty-keys model is used for keys=[].
+    assert empty_out == "hello[keys:[]]"
+    # Two distinct models were constructed and cached separately.
+    assert len(construction_keys) == 2
     assert len(synthid_text_server._MODEL_CACHE) == 2
-    # Reusing default keys must hit the cache (no third model). line wrapping
-    assert default_out2 == "hello[None]"
+    # Reusing default keys hits the cache (no third construction).
+    assert len(construction_keys) == 2
+
+
+def test_load_algorithm_overrides_keys_before_construction(monkeypatch, tmp_path):
+    """Custom SynthID keys must be baked into the config before model construction."""
+    import types
+
+    import detect_text_watermark as dtw
+
+    upstream = tmp_path / "upstream"
+    upstream.mkdir()
+    cfg = upstream / "config" / "SynthID.json"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text(json.dumps({"ngram_len": 4, "keys": [111, 222]}), "utf-8")
+
+    captured: dict[str, object] = {}
+
+    class _DummyLM:
+        def to(self, device):
+            return self
+
+    class _AutoModelForCausalLM:
+        @classmethod
+        def from_pretrained(cls, model, **kw):
+            return _DummyLM()
+
+    class _AutoTokenizer:
+        @classmethod
+        def from_pretrained(cls, model, **kw):
+            return object()
+
+    class _TransformersConfig:
+        def __init__(self, **kw):
+            pass
+
+    class _AutoWatermark:
+        @staticmethod
+        def load(algorithm_name, algorithm_config=None, transformers_config=None, **kw):
+            path = Path(algorithm_config)
+            captured["keys"] = json.loads(path.read_text("utf-8"))["keys"]
+            captured["different_file"] = str(path) != str(cfg)
+            return object()
+
+    tf_mod = types.ModuleType("transformers")
+    tf_mod.AutoModelForCausalLM = _AutoModelForCausalLM
+    tf_mod.AutoTokenizer = _AutoTokenizer
+    utils_pkg = types.ModuleType("utils")
+    utils_tc = types.ModuleType("utils.transformers_config")
+    utils_tc.TransformersConfig = _TransformersConfig
+    utils_pkg.transformers_config = utils_tc
+    watermark_pkg = types.ModuleType("watermark")
+    auto_wm = types.ModuleType("watermark.auto_watermark")
+    auto_wm.AutoWatermark = _AutoWatermark
+    watermark_pkg.auto_watermark = auto_wm
+
+    monkeypatch.setitem(sys.modules, "transformers", tf_mod)
+    monkeypatch.setitem(sys.modules, "utils", utils_pkg)
+    monkeypatch.setitem(sys.modules, "utils.transformers_config", utils_tc)
+    monkeypatch.setitem(sys.modules, "watermark", watermark_pkg)
+    monkeypatch.setitem(sys.modules, "watermark.auto_watermark", auto_wm)
+
+    dtw._load_algorithm(
+        upstream,
+        "SynthID",
+        cfg,
+        "facebook/opt-1.3b",
+        "cpu",
+        watermark_keys=[7, 8, 9],
+    )
+
+    # AutoWatermark.load received an override config with the request keys, not
+    # the config file's defaults, and a distinct temp file.
+    assert captured["keys"] == [7, 8, 9]
+    assert captured["different_file"] is True

--- a/tests/test_synthid_text_server.py
+++ b/tests/test_synthid_text_server.py
@@ -400,3 +400,52 @@ def test_sidecar_non_utf8_file(sidecar_server):
     assert body["ok"] is False
     assert "not valid UTF-8" in body["error"]
 
+
+def test_sidecar_cache_key_distinguishes_default_and_empty_keys(monkeypatch, tmp_path):
+    """keys=None (default scheme keys) and keys=[] must use distinct cached models."""
+    import detect_text_watermark as dtw
+
+    upstream = tmp_path / "upstream"
+    upstream.mkdir()
+
+    created_keys: list[list[int] | None] = []
+
+    class _FakeConfig:
+        def __init__(self) -> None:
+            self.keys: list[int] | None = None
+            self.gen_kwargs: dict[str, Any] = {}
+
+    class _FakeWM:
+        def __init__(self, keytag: object) -> None:
+            self.config = _FakeConfig()
+            self._keytag = keytag
+
+        def generate_watermarked_text(self, text: str) -> str:
+            return f"{text}[{self.config.keys}]"
+
+    def _fake_load(upstream, alg, config, model, device, **kwargs):
+        created_keys.append(None)
+        return _FakeWM(None)
+
+    def _fake_generate(wm, text, **kwargs):
+        return f"{text}[{wm.config.keys}]", {}
+
+    monkeypatch.setattr(dtw, "_load_algorithm", _fake_load)
+    monkeypatch.setattr(dtw, "_resolve_config", lambda *a, **k: upstream / "config.json")
+    monkeypatch.setattr(dtw, "resolve_device", lambda *a, **k: "cpu")
+    monkeypatch.setattr(dtw, "_generate", _fake_generate)
+    monkeypatch.setattr(dtw, "SCHEMES", {"synthid": "SynthID"})
+    monkeypatch.setattr(synthid_text_server, "MARKLLM_DIR", str(upstream))
+    synthid_text_server._MODEL_CACHE.clear()
+
+    default_out, _ = synthid_text_server._generate_watermarked_sample("hello", None, {})
+    empty_out, _ = synthid_text_server._generate_watermarked_sample("hello", [], {})
+    default_out2, _ = synthid_text_server._generate_watermarked_sample("hello", None, {})
+
+    assert default_out == "hello[None]"
+    assert empty_out == "hello[[]]"
+    # Two distinct models must have been instantiated and cached separately.
+    assert len(created_keys) == 2
+    assert len(synthid_text_server._MODEL_CACHE) == 2
+    # Reusing default keys must hit the cache (no third model). line wrapping
+    assert default_out2 == "hello[None]"

--- a/tests/test_synthid_text_server.py
+++ b/tests/test_synthid_text_server.py
@@ -305,7 +305,7 @@ def test_sidecar_rejects_undocumented_options(sidecar_server):
         "/watermark",
         {
             "text": "Prompt text",
-            "options": {"config": "/etc/passwd"},
+            "options": {"bogus_option": "value"},
         },
     )
     assert status == 400

--- a/tests/test_synthid_text_server.py
+++ b/tests/test_synthid_text_server.py
@@ -384,3 +384,19 @@ def test_sidecar_keys_rejects_bool(sidecar_server):
     assert status == 400
     assert body["ok"] is False
     assert "boolean" in body["error"]
+
+
+def test_sidecar_non_utf8_file(sidecar_server):
+    conn, _ = sidecar_server
+    # Non-UTF8 byte sequence e.g. 0xFF 0xFE
+    raw_invalid_utf8 = b"\xff\xfe\xfa"
+    b64_invalid = base64.b64encode(raw_invalid_utf8).decode("ascii")
+    status, body = _post(
+        conn,
+        "/watermark",
+        {"file": b64_invalid},
+    )
+    assert status == 400
+    assert body["ok"] is False
+    assert "not valid UTF-8" in body["error"]
+

--- a/tests/test_watermark_endpoint.py
+++ b/tests/test_watermark_endpoint.py
@@ -112,7 +112,7 @@ def test_watermark_unconfigured_returns_explanatory_error(conn):
 
 def test_watermark_unknown_options_rejected(conn):
     status, body = _post(
-        conn, "/watermark", {"text": "Hello", "options": {"config": "/etc/passwd"}}
+        conn, "/watermark", {"text": "Hello", "options": {"bogus_option": "value"}}
     )
     assert status == 400
     assert body["ok"] is False
@@ -431,34 +431,55 @@ def test_resolve_timeout(monkeypatch):
     assert resolve_timeout(None) == 1.0
 
 
-def test_watermark_error_status_sidecar_4xx_vs_5xx():
-    # 4xx client errors mapped to 400 Bad Request
+def test_watermark_error_status_maps_on_error_code():
+    """_watermark_error_status maps on stable error_code, not error text."""
+    from http import HTTPStatus
+
+    # client_error -> 400
+    assert server._watermark_error_status({"error_code": "client_error"}) == HTTPStatus.BAD_REQUEST
+
+    # auth -> 502
+    assert server._watermark_error_status({"error_code": "auth"}) == HTTPStatus.BAD_GATEWAY
+
+    # unconfigured -> 503
     assert (
-        server._watermark_error_status("SynthID text sidecar client error (400): Bad request")
-        == http.client.BAD_REQUEST
-    )
-    assert (
-        server._watermark_error_status("SynthID text sidecar client error (422): Unprocessable")
-        == http.client.BAD_REQUEST
+        server._watermark_error_status({"error_code": "unconfigured"})
+        == HTTPStatus.SERVICE_UNAVAILABLE
     )
 
-    # 5xx or general unreachable mapped to 502 Bad Gateway
-    assert (
-        server._watermark_error_status("SynthID text sidecar HTTP error (500): Internal Error")
-        == http.client.BAD_GATEWAY
-    )
-    assert (
-        server._watermark_error_status("SynthID text sidecar HTTP error (503): Service Unavailable")
-        == http.client.BAD_GATEWAY
-    )
+    # backend_error, unreachable, timeout, ssrf -> 502
+    for code in ("backend_error", "unreachable", "timeout", "ssrf"):
+        assert server._watermark_error_status({"error_code": code}) == HTTPStatus.BAD_GATEWAY
 
-    # Sidecar authentication failures (configured key, bad/missing token) -> 502
-    assert (
-        server._watermark_error_status(
-            "SynthID text sidecar authentication error (401): Unauthorized"
-        )
-        == http.client.BAD_GATEWAY
+    # Missing/unknown error_code -> 400 fallback
+    assert server._watermark_error_status({}) == HTTPStatus.BAD_REQUEST
+    assert server._watermark_error_status({"error_code": "unknown"}) == HTTPStatus.BAD_REQUEST
+
+
+def test_parse_watermark_options_device_config_offline():
+    """Verify device, config, and offline are accepted and validated."""
+    opts = text_watermark.parse_watermark_options(
+        {"device": "cuda:0", "config": "my_config.json", "offline": True}
     )
+    assert opts == {"device": "cuda:0", "config": "my_config.json", "offline": True}
+
+    # device must be a non-empty string
+    with pytest.raises(ValueError, match="device"):
+        text_watermark.parse_watermark_options({"device": ""})
+    with pytest.raises(ValueError, match="device"):
+        text_watermark.parse_watermark_options({"device": 123})
+
+    # config must be a non-empty string
+    with pytest.raises(ValueError, match="config"):
+        text_watermark.parse_watermark_options({"config": ""})
+
+    # offline must be a boolean
+    with pytest.raises(ValueError, match="offline"):
+        text_watermark.parse_watermark_options({"offline": "yes"})
+    with pytest.raises(ValueError, match="offline"):
+        text_watermark.parse_watermark_options({"offline": 1})
+
+
 
 
 def test_openapi_spec_preserves_502_503_descriptors(conn):

--- a/tests/test_watermark_endpoint.py
+++ b/tests/test_watermark_endpoint.py
@@ -480,8 +480,6 @@ def test_parse_watermark_options_device_config_offline():
         text_watermark.parse_watermark_options({"offline": 1})
 
 
-
-
 def test_openapi_spec_preserves_502_503_descriptors(conn):
     spec = server.openapi_spec()
     resp = spec["paths"]["/watermark"]["post"]["responses"]

--- a/tests/test_watermark_endpoint.py
+++ b/tests/test_watermark_endpoint.py
@@ -406,3 +406,36 @@ def test_watermark_http_blocks_redirect():
         redirector.server_close()
         t1.join(timeout=2)
         t2.join(timeout=2)
+
+
+def test_resolve_timeout(monkeypatch):
+    from text_watermark import DEFAULT_SYNTHID_TEXT_TIMEOUT, resolve_timeout
+
+    # Defaults when no explicit value or env
+    monkeypatch.delenv("WATERMARKS_SYNTHID_TEXT_TIMEOUT", raising=False)
+    assert resolve_timeout(None) == DEFAULT_SYNTHID_TEXT_TIMEOUT
+
+    # Explicit clamped between floor (1.0) and ceiling (600.0)
+    assert resolve_timeout(0.1) == 1.0
+    assert resolve_timeout(-10.0) == 1.0
+    assert resolve_timeout(9999.0) == 600.0
+    assert resolve_timeout(45.5) == 45.5
+
+    # Env variable
+    monkeypatch.setenv("WATERMARKS_SYNTHID_TEXT_TIMEOUT", "120.0")
+    assert resolve_timeout(None) == 120.0
+
+    # Env variable clamped
+    monkeypatch.setenv("WATERMARKS_SYNTHID_TEXT_TIMEOUT", "0.05")
+    assert resolve_timeout(None) == 1.0
+
+
+def test_watermark_error_status_sidecar_4xx_vs_5xx():
+    # 4xx client errors mapped to 400 Bad Request
+    assert server._watermark_error_status("SynthID text sidecar client error (400): Bad request") == http.client.BAD_REQUEST
+    assert server._watermark_error_status("SynthID text sidecar client error (422): Unprocessable") == http.client.BAD_REQUEST
+
+    # 5xx or general unreachable mapped to 502 Bad Gateway
+    assert server._watermark_error_status("SynthID text sidecar HTTP error (500): Internal Error") == http.client.BAD_GATEWAY
+    assert server._watermark_error_status("SynthID text sidecar HTTP error (503): Service Unavailable") == http.client.BAD_GATEWAY
+

--- a/tests/test_watermark_endpoint.py
+++ b/tests/test_watermark_endpoint.py
@@ -8,6 +8,7 @@ import json
 import sys
 import threading
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -432,10 +433,116 @@ def test_resolve_timeout(monkeypatch):
 
 def test_watermark_error_status_sidecar_4xx_vs_5xx():
     # 4xx client errors mapped to 400 Bad Request
-    assert server._watermark_error_status("SynthID text sidecar client error (400): Bad request") == http.client.BAD_REQUEST
-    assert server._watermark_error_status("SynthID text sidecar client error (422): Unprocessable") == http.client.BAD_REQUEST
+    assert (
+        server._watermark_error_status("SynthID text sidecar client error (400): Bad request")
+        == http.client.BAD_REQUEST
+    )
+    assert (
+        server._watermark_error_status("SynthID text sidecar client error (422): Unprocessable")
+        == http.client.BAD_REQUEST
+    )
 
     # 5xx or general unreachable mapped to 502 Bad Gateway
-    assert server._watermark_error_status("SynthID text sidecar HTTP error (500): Internal Error") == http.client.BAD_GATEWAY
-    assert server._watermark_error_status("SynthID text sidecar HTTP error (503): Service Unavailable") == http.client.BAD_GATEWAY
+    assert (
+        server._watermark_error_status("SynthID text sidecar HTTP error (500): Internal Error")
+        == http.client.BAD_GATEWAY
+    )
+    assert (
+        server._watermark_error_status("SynthID text sidecar HTTP error (503): Service Unavailable")
+        == http.client.BAD_GATEWAY
+    )
 
+    # Sidecar authentication failures (configured key, bad/missing token) -> 502
+    assert (
+        server._watermark_error_status(
+            "SynthID text sidecar authentication error (401): Unauthorized"
+        )
+        == http.client.BAD_GATEWAY
+    )
+
+
+def test_openapi_spec_preserves_502_503_descriptors(conn):
+    spec = server.openapi_spec()
+    resp = spec["paths"]["/watermark"]["post"]["responses"]
+    # 502/503 must be preserved as full response descriptors, not wrapped
+    # schemas, and not labeled "Success".
+    for code in ("502", "503"):
+        entry = resp[code]
+        assert "description" in entry and "content" in entry
+        assert entry["description"] != "Success"
+        assert entry["content"]["application/json"]["schema"] is server._ERROR_SCHEMA
+    # The 200 success response is still a wrapped schema labeled "Success".
+    assert resp["200"]["description"] == "Success"
+
+
+def test_watermark_request_schema_exclusive_minimum_is_boolean():
+    schema = server._watermark_request_schema()
+    opts = schema["properties"]["options"]["properties"]
+    # OpenAPI 3.0.3 requires boolean exclusiveMinimum, not a numeric form.
+    assert opts["temperature"] == {
+        "type": "number",
+        "minimum": 0,
+        "exclusiveMinimum": True,
+    }
+    assert opts["top_p"] == {
+        "type": "number",
+        "minimum": 0,
+        "exclusiveMinimum": True,
+        "maximum": 1,
+    }
+
+
+def test_local_cache_key_distinguishes_default_and_empty_keys(monkeypatch, tmp_path):
+    """keys=None (default) and keys=[] (empty) must use distinct local cached models."""
+    import detect_text_watermark as dtw
+
+    upstream = tmp_path / "upstream"
+    upstream.mkdir()
+
+    created_keys: list[list[int] | None] = []
+
+    class _FakeConfig:
+        def __init__(self) -> None:
+            self.keys: list[int] | None = None
+            self.gen_kwargs: dict[str, Any] = {}
+
+    class _FakeWM:
+        def __init__(self) -> None:
+            self.config = _FakeConfig()
+            self.config.gen_kwargs["max_new_tokens"] = 200
+            self.config.gen_kwargs["min_length"] = 0
+
+        def generate_watermarked_text(self, text: str) -> str:
+            return f"{text}[{self.config.keys}]"
+
+    def _fake_load(upstream, alg, config, model, device, **kwargs):
+        created_keys.append(None)
+        return _FakeWM()
+
+    monkeypatch.setattr(dtw, "_load_algorithm", _fake_load)
+    monkeypatch.setattr(dtw, "_resolve_config", lambda *a, **k: upstream / "config.json")
+    monkeypatch.setattr(dtw, "resolve_device", lambda *a, **k: "cpu")
+    monkeypatch.setattr(dtw, "resolve_upstream", lambda *a, **k: upstream)
+    monkeypatch.setattr(dtw, "SCHEMES", {"synthid": "SynthID"})
+    from collections import OrderedDict
+
+    monkeypatch.setattr(text_watermark, "_LOCAL_MODEL_CACHE", OrderedDict())
+    monkeypatch.setattr(text_watermark, "MAX_LOCAL_CACHED_MODELS", 4)
+
+    default_res = text_watermark._watermark_local_markllm(
+        "hello", keys=None, options={}, timeout=None, upstream_dir=str(upstream)
+    )
+    empty_res = text_watermark._watermark_local_markllm(
+        "hello", keys=[], options={}, timeout=None, upstream_dir=str(upstream)
+    )
+    default_res2 = text_watermark._watermark_local_markllm(
+        "hello", keys=None, options={}, timeout=None, upstream_dir=str(upstream)
+    )
+
+    assert default_res["ok"] is True
+    assert default_res["watermarked_text"] == "hello[None]"
+    assert empty_res["ok"] is True
+    assert empty_res["watermarked_text"] == "hello[[]]"
+    # Two distinct models were loaded: default-keys and empty-keys do not share a key.
+    assert len(created_keys) == 2
+    assert default_res2["watermarked_text"] == "hello[None]"

--- a/tests/test_watermark_endpoint.py
+++ b/tests/test_watermark_endpoint.py
@@ -1,0 +1,408 @@
+"""Tests for the /watermark and /watermark/batch endpoints in server.py."""
+
+from __future__ import annotations
+
+import base64
+import http.client
+import json
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "service" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import server  # type: ignore
+import text_watermark  # type: ignore
+
+
+def _post(conn: http.client.HTTPConnection, path: str, payload: dict) -> tuple[int, dict]:
+    conn.request(
+        "POST",
+        path,
+        body=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+    )
+    resp = conn.getresponse()
+    data = resp.read()
+    return resp.status, json.loads(data) if data else {}
+
+
+def _get(conn: http.client.HTTPConnection, path: str) -> tuple[int, dict]:
+    conn.request("GET", path)
+    resp = conn.getresponse()
+    data = resp.read()
+    return resp.status, json.loads(data) if data else {}
+
+
+class _FakeSidecarResp:
+    def __init__(self, data: dict, status: int = 200):
+        self._data = json.dumps(data).encode("utf-8")
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def read(self):
+        return self._data
+
+
+@pytest.fixture(scope="module")
+def conn() -> http.client.HTTPConnection:
+    srv = server.ThreadingHTTPServer(("127.0.0.1", 0), server.Handler)
+    thread = threading.Thread(target=srv.serve_forever, daemon=True)
+    thread.start()
+    c = http.client.HTTPConnection("127.0.0.1", srv.server_address[1])
+    yield c
+    c.close()
+    srv.shutdown()
+    srv.server_close()
+    thread.join(timeout=5)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for key in (
+        "WATERMARKS_SYNTHID_TEXT_URL",
+        "WATERMARKS_SYNTHID_TEXT_API_KEY",
+        "WATERMARKS_SYNTHID_TEXT_TIMEOUT",
+        "MARKLLM_DIR",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+class _FakeOpener:
+    def __init__(self, handler):
+        self._handler = handler
+
+    def open(self, req, timeout=None):
+        return self._handler(req, timeout=timeout)
+
+
+def test_capabilities_includes_text_generators(conn):
+    status, body = _get(conn, "/capabilities")
+    assert status == 200
+    assert "text_generators" in body
+    assert body["text_generators"]["synthid_http"] is False
+    assert body["text_generators"]["markllm"] is False
+
+
+def test_openapi_spec_includes_watermark_endpoints(conn):
+    status, body = _get(conn, "/openapi.json")
+    assert status == 200
+    assert "/watermark" in body["paths"]
+    assert "post" in body["paths"]["/watermark"]
+    assert "/watermark/batch" in body["paths"]
+    assert "post" in body["paths"]["/watermark/batch"]
+
+
+def test_watermark_unconfigured_returns_explanatory_error(conn):
+    status, body = _post(conn, "/watermark", {"text": "A prompt to watermark"})
+    assert status == 503
+    assert body["ok"] is False
+    assert "WATERMARKS_SYNTHID_TEXT_URL" in body["error"]
+
+
+def test_watermark_unknown_options_rejected(conn):
+    status, body = _post(
+        conn, "/watermark", {"text": "Hello", "options": {"config": "/etc/passwd"}}
+    )
+    assert status == 400
+    assert body["ok"] is False
+    assert "unsupported option" in body["error"]
+
+
+def test_watermark_options_validation_bounds(conn):
+    status, body = _post(conn, "/watermark", {"text": "Hello", "options": {"max_new_tokens": 0}})
+    assert status == 400
+    assert body["ok"] is False
+    assert "max_new_tokens" in body["error"]
+
+    status, body = _post(conn, "/watermark", {"text": "Hello", "options": {"temperature": -1.0}})
+    assert status == 400
+    assert body["ok"] is False
+    assert "temperature" in body["error"]
+
+    status, body = _post(conn, "/watermark", {"text": "Hello", "options": {"top_p": 1.5}})
+    assert status == 400
+    assert body["ok"] is False
+    assert "top_p" in body["error"]
+
+
+def test_watermark_missing_text_and_file_returns_bad_request(conn):
+    status, body = _post(conn, "/watermark", {"options": {"scheme": "synthid"}})
+    assert status == 400
+    assert body["ok"] is False
+    assert "must include 'text' or base64 'file'" in body["error"]
+
+
+def test_watermark_binary_file_rejected(conn):
+    bad_base64 = base64.b64encode(b"\x00\x01\x02\x03\x04\x00\x00\x00").decode("ascii")
+    status, body = _post(conn, "/watermark", {"file": bad_base64})
+    assert status == 400
+    assert body["ok"] is False
+    assert "binary" in body["error"]
+
+
+def test_watermark_sidecar_success(conn, monkeypatch):
+    captured_req = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured_req["url"] = req.full_url
+        captured_req["headers"] = dict(req.headers)
+        captured_req["body"] = json.loads(req.data.decode("utf-8"))
+        return _FakeSidecarResp(
+            {
+                "ok": True,
+                "kind": "text",
+                "watermarked_text": "Watermarked output sample",
+                "report": {
+                    "scheme_used": "synthid",
+                    "model": "facebook/opt-1.3b",
+                    "keys_used": [118, 504, 421, 521],
+                },
+            }
+        )
+
+    monkeypatch.setattr(text_watermark, "OPENER", _FakeOpener(fake_urlopen))
+    monkeypatch.setenv("WATERMARKS_SYNTHID_TEXT_URL", "http://wr-synthid-text:8767")
+    monkeypatch.setenv("WATERMARKS_SYNTHID_TEXT_API_KEY", "secret-token")
+
+    status, body = _post(
+        conn,
+        "/watermark",
+        {
+            "text": "Hello world prompt",
+            "keys": [118, 504, 421, 521],
+            "options": {"scheme": "synthid", "seed": 42},
+        },
+    )
+
+    assert status == 200
+    assert body["ok"] is True
+    assert body["watermarked_text"] == "Watermarked output sample"
+    assert body["report"]["keys_used"] == [118, 504, 421, 521]
+
+    # Verify sidecar request details
+    assert captured_req["url"] == "http://wr-synthid-text:8767/watermark"
+    assert captured_req["headers"].get("Authorization") == "Bearer secret-token"
+    assert captured_req["body"]["text"] == "Hello world prompt"
+    assert captured_req["body"]["keys"] == [118, 504, 421, 521]
+    assert captured_req["body"]["options"]["seed"] == 42
+
+
+def test_watermark_sidecar_via_base64_file(conn, monkeypatch):
+    raw_prompt = "Prompt from encoded file"
+    b64_prompt = base64.b64encode(raw_prompt.encode("utf-8")).decode("ascii")
+
+    def fake_urlopen(req, timeout=None):
+        return _FakeSidecarResp(
+            {
+                "ok": True,
+                "kind": "text",
+                "watermarked_text": "Watermarked from file",
+                "report": {"scheme_used": "synthid"},
+            }
+        )
+
+    monkeypatch.setattr(text_watermark, "OPENER", _FakeOpener(fake_urlopen))
+    monkeypatch.setenv("WATERMARKS_SYNTHID_TEXT_URL", "http://127.0.0.1:8767")
+
+    status, body = _post(conn, "/watermark", {"file": b64_prompt, "name": "prompt.txt"})
+    assert status == 200
+    assert body["ok"] is True
+    assert body["watermarked_text"] == "Watermarked from file"
+
+
+def test_watermark_sidecar_unreachable_fail_soft(conn, monkeypatch):
+    import urllib.error
+
+    def fake_urlopen(req, timeout=None):
+        raise urllib.error.URLError("Connection refused")
+
+    monkeypatch.setattr(text_watermark, "OPENER", _FakeOpener(fake_urlopen))
+    monkeypatch.setenv("WATERMARKS_SYNTHID_TEXT_URL", "http://127.0.0.1:8767")
+
+    status, body = _post(conn, "/watermark", {"text": "Testing error handling"})
+    assert status == 502
+    assert body["ok"] is False
+    assert "unreachable" in body["error"].lower()
+
+
+def test_watermark_batch_success(conn, monkeypatch):
+    def fake_urlopen(req, timeout=None):
+        body = json.loads(req.data.decode("utf-8"))
+        prompt = body.get("text", "")
+        return _FakeSidecarResp(
+            {
+                "ok": True,
+                "kind": "text",
+                "watermarked_text": f"WM: {prompt}",
+                "report": {"scheme_used": "synthid"},
+            }
+        )
+
+    monkeypatch.setattr(text_watermark, "OPENER", _FakeOpener(fake_urlopen))
+    monkeypatch.setenv("WATERMARKS_SYNTHID_TEXT_URL", "http://127.0.0.1:8767")
+
+    batch_payload = {
+        "files": [
+            {"name": "p1.txt", "text": "Prompt one", "keys": [1, 2, 3]},
+            {"name": "p2.txt", "text": "Prompt two", "keys": [4, 5, 6]},
+        ]
+    }
+
+    status, body = _post(conn, "/watermark/batch", batch_payload)
+    assert status == 200
+    assert body["ok"] is True
+    assert len(body["results"]) == 2
+    assert body["results"][0]["name"] == "p1.txt"
+    assert body["results"][0]["ok"] is True
+    assert body["results"][0]["watermarked_text"] == "WM: Prompt one"
+    assert body["results"][1]["name"] == "p2.txt"
+    assert body["results"][1]["ok"] is True
+    assert body["results"][1]["watermarked_text"] == "WM: Prompt two"
+
+
+def test_watermark_batch_partial_failure_does_not_abort_batch(conn, monkeypatch):
+    def fake_urlopen(req, timeout=None):
+        return _FakeSidecarResp(
+            {
+                "ok": True,
+                "kind": "text",
+                "watermarked_text": "WM result",
+                "report": {"scheme_used": "synthid"},
+            }
+        )
+
+    monkeypatch.setattr(text_watermark, "OPENER", _FakeOpener(fake_urlopen))
+    monkeypatch.setenv("WATERMARKS_SYNTHID_TEXT_URL", "http://127.0.0.1:8767")
+
+    batch_payload = {
+        "files": [
+            {"name": "valid.txt", "text": "Good prompt"},
+            {"name": "missing_text.txt"},  # Invalid: no text or file
+            {"name": "valid2.txt", "text": "Another good prompt"},
+        ]
+    }
+
+    status, body = _post(conn, "/watermark/batch", batch_payload)
+    assert status == 200
+    assert body["ok"] is True
+    assert len(body["results"]) == 3
+    assert body["results"][0]["ok"] is True
+    assert body["results"][1]["ok"] is False
+    assert "error" in body["results"][1]
+    assert body["results"][2]["ok"] is True
+
+
+def test_watermark_batch_empty_files_rejected(conn):
+    status, body = _post(conn, "/watermark/batch", {"files": []})
+    assert status == 400
+    assert body["ok"] is False
+    assert "empty" in body["error"]
+
+
+def test_watermark_batch_unconfigured_returns_503(conn):
+    status, body = _post(conn, "/watermark/batch", {"files": [{"text": "Hello prompt"}]})
+    assert status == 503
+    assert body["ok"] is False
+    assert "WATERMARKS_SYNTHID_TEXT_URL" in body["error"]
+
+
+def test_watermark_batch_wall_clock_timeout(conn, monkeypatch):
+    def fake_urlopen(req, timeout=None):
+        raise TimeoutError("timed out")
+
+    monkeypatch.setattr(text_watermark, "OPENER", _FakeOpener(fake_urlopen))
+    monkeypatch.setenv("WATERMARKS_SYNTHID_TEXT_URL", "http://127.0.0.1:8767")
+    monkeypatch.setenv("WATERMARKS_SYNTHID_TEXT_TIMEOUT", "0.01")
+
+    batch_payload = {
+        "files": [
+            {"name": "p1.txt", "text": "Prompt one"},
+            {"name": "p2.txt", "text": "Prompt two"},
+        ]
+    }
+    status, body = _post(conn, "/watermark/batch", batch_payload)
+    assert status == 200
+    assert body["ok"] is True
+    assert len(body["results"]) == 2
+    assert body["results"][0]["ok"] is False
+    assert body["results"][1]["ok"] is False
+    err = (body["results"][0]["error"] + " " + body["results"][1]["error"]).lower()
+    assert "deadline" in err or "timed out" in err
+
+
+def test_watermark_batch_caps_enforced(conn, monkeypatch):
+    monkeypatch.setattr(server, "MAX_BATCH_FILES", 3)
+    payload = {"files": [{"text": f"Prompt {i}"} for i in range(4)]}
+    status, body = _post(conn, "/watermark/batch", payload)
+    assert status == 400
+    assert body["ok"] is False
+    assert "limit" in body["error"]
+
+
+def test_watermark_http_blocks_redirect():
+    """Ensure _watermark_http refuses 302 redirects to prevent SSRF and key leakage."""
+    import http.server
+
+    state: dict = {"collector_port": None}
+    captured: dict = {}
+
+    class Redirector(http.server.BaseHTTPRequestHandler):
+        def do_POST(self):
+            self.send_response(302)
+            self.send_header(
+                "Location",
+                f"http://127.0.0.1:{state['collector_port']}/leak",
+            )
+            self.end_headers()
+
+        def log_message(self, format, *args):
+            pass
+
+    class Collector(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            captured["hit"] = True
+            self.send_response(200)
+            self.end_headers()
+
+        def do_POST(self):
+            captured["hit"] = True
+            self.send_response(200)
+            self.end_headers()
+
+        def log_message(self, format, *args):
+            pass
+
+    collector = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Collector)
+    redirector = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Redirector)
+    state["collector_port"] = collector.server_address[1]
+    t1 = threading.Thread(target=collector.serve_forever, daemon=True)
+    t2 = threading.Thread(target=redirector.serve_forever, daemon=True)
+    t1.start()
+    t2.start()
+
+    try:
+        res = text_watermark._watermark_http(
+            "test prompt",
+            f"http://127.0.0.1:{redirector.server_address[1]}",
+            api_key="secret-key",
+            timeout=2.0,
+        )
+        assert res["ok"] is False
+        assert not captured.get("hit"), "Redirect was followed, leaking request/credentials!"
+    finally:
+        collector.shutdown()
+        redirector.shutdown()
+        collector.server_close()
+        redirector.server_close()
+        t1.join(timeout=2)
+        t2.join(timeout=2)

--- a/tests/test_watermark_endpoint.py
+++ b/tests/test_watermark_endpoint.py
@@ -499,16 +499,16 @@ def test_local_cache_key_distinguishes_default_and_empty_keys(monkeypatch, tmp_p
     upstream = tmp_path / "upstream"
     upstream.mkdir()
 
-    created_keys: list[list[int] | None] = []
+    construction_keys: list[list[int] | None] = []
 
     class _FakeConfig:
-        def __init__(self) -> None:
-            self.keys: list[int] | None = None
+        def __init__(self, keys) -> None:
+            self.keys = keys
             self.gen_kwargs: dict[str, Any] = {}
 
     class _FakeWM:
-        def __init__(self) -> None:
-            self.config = _FakeConfig()
+        def __init__(self, keys) -> None:
+            self.config = _FakeConfig(keys)
             self.config.gen_kwargs["max_new_tokens"] = 200
             self.config.gen_kwargs["min_length"] = 0
 
@@ -516,8 +516,9 @@ def test_local_cache_key_distinguishes_default_and_empty_keys(monkeypatch, tmp_p
             return f"{text}[{self.config.keys}]"
 
     def _fake_load(upstream, alg, config, model, device, **kwargs):
-        created_keys.append(None)
-        return _FakeWM()
+        keys = kwargs.get("watermark_keys")
+        construction_keys.append(keys)
+        return _FakeWM(keys)
 
     monkeypatch.setattr(dtw, "_load_algorithm", _fake_load)
     monkeypatch.setattr(dtw, "_resolve_config", lambda *a, **k: upstream / "config.json")
@@ -543,6 +544,8 @@ def test_local_cache_key_distinguishes_default_and_empty_keys(monkeypatch, tmp_p
     assert default_res["watermarked_text"] == "hello[None]"
     assert empty_res["ok"] is True
     assert empty_res["watermarked_text"] == "hello[[]]"
-    # Two distinct models were loaded: default-keys and empty-keys do not share a key.
-    assert len(created_keys) == 2
+    # Keys were applied at construction, keeping None (default) and [] distinct.
+    assert construction_keys == [None, []]
+    # Two distinct models were loaded; default reuse hits the cache.
+    assert len(construction_keys) == 2
     assert default_res2["watermarked_text"] == "hello[None]"


### PR DESCRIPTION
Closes #313
Summary
Adds POST /watermark and POST /watermark/batch to wr-core along with a dedicated wr-synthid-text HTTP sidecar (port 8767) under the harness profile.
Following the maintainer's recommendation in #313, this replicates the established wr-synthid-score sidecar pattern for text. It lets wr-core generate native SynthID-watermarked text for benchmarks and round-trip verification over HTTP without bundling heavy ML dependencies (PyTorch, Transformers, MarkLLM) into the published core image.
Key Additions & Architecture
1. Core Service (server.py)
- Implements POST /watermark and POST /watermark/batch.
- Accepts raw text string or base64-encoded file payload.
- Enforces binary guards (looks_binary) to reject binary files from text endpoints.
- Batch isolation: each entry is caught in a per-file try/except; errors surface under that entry's "ok": false and never abort the rest of the batch.
- Deadline-bounded batch processing derived from the sidecar timeout, so a slow entry cannot hang the request.
- Full OpenAPI 3.0.3 spec with request bounds, additionalProperties: false, and documented 400/502/503 error responses; exposed via /capabilities (text_generators.synthid_http).
2. Text Sidecar (synthid_text_server.py)
- Lightweight stdlib ThreadingHTTPServer on port 8767 with optional bearer-key auth (WATERMARKS_SYNTHID_TEXT_API_KEY).
- Keeps the MarkLLM model resident under a thread lock (_MODEL_LOCK) with a bounded LRU cache to eliminate per-request model-loading overhead.
- Applies custom SynthID keys at model construction so watermarking matches the requested keys, not the config file defaults.
- Validates option types early (max_new_tokens, min_length, seed) and rejects non-UTF-8 uploads and byte caps with an immediate 400.
3. Client Dispatch (text_watermark.py)
- Fail-soft dispatch hierarchy: HTTP sidecar (WATERMARKS_SYNTHID_TEXT_URL) → local MarkLLM checkout (MARKLLM_DIR) → informative unconfigured error.
- Normalizes custom integer keys (int list, comma-separated string, or JSON array) and rejects booleans.
- SSRF protection: a custom _NoRedirect handler refuses 301/302/307/308 redirects, and is applied by default even if urllib.request.urlopen is monkeypatched.
- Timeout resolution (resolve_timeout) clamps values to [1s, 600s] with an env default, applied to both single and batch paths.
- Correct error classification: request-validation 4xx → 400, sidecar 5xx/unreachable/timeout → 502, unconfigured → 503, and sidecar hit with a bad/missing bearer token (401) → 502 (gateway config error).
4. Docker Compose (compose.yaml) & Config
- Registers wr-synthid-text under the harness profile using Dockerfile.markllm.
- Container hardening mirrors wr-synthid-score: read_only: true, unprivileged user 10001:10001, init: true, and /tmp tmpfs.
- Documented environment variables in .env.example and README.md.
- (Minor doc fix) Added the missing /detect/batch row to the README endpoints table.
Validation
- Lint & Format: python -m ruff check service tests (0 errors) and python -m ruff format --check service tests (clean across all 102 files).
- OpenAPI 3.0.3 Contract: spec serializes validly, uses the boolean exclusiveMinimum form, and preserves explicit 502/503 response descriptors.
- Tests: pytest tests/test_synthid_text_server.py tests/test_watermark_endpoint.py (45 passed) — covering health, bearer auth, single/batch generation, batch isolation, caps & byte limits, binary rejection, keys normalization/boolean rejection, non-UTF-8 uploads, timeout clamping, empty-vs-default keys cache isolation, and SSRF redirect refusal.
- Full suite: 1070 passed, 143 skipped (excluding a pre-existing, watermark-unrelated Windows hook-test flake).