### PR TITLE
feat(mac): SwiftUI Layer A inspect/clean front-end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@
 !/SECURITY.md
 !/stealer/
 !/stealer/**
+!/mac/
+!/mac/**
 
 # Exceptions even inside allowed trees
 .env
@@ -54,3 +56,6 @@ stealer/prompts/**
 posts.md
 *.cleaned.*
 *.bak
+mac/.build/
+mac/build/
+mac/.swiftpm/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,7 @@ issue.
 | `install_skill.py` | Multi-host skill installer (Claude Code, Cowork bundle, Cursor) |
 | `skills/remove-ai-marks/references/` | Vendors, mark classes, matrix, ethics |
 | `service/scripts/` | Layer A/B hooks + image/container cleaners + `server.py` HTTP service |
+| `mac/` | Optional SwiftUI front-end; shells out to `service/scripts` (see `mac/README.md`) |
 | `service/Dockerfile*` | Container images (core + optional backends) |
 | `compose.yaml` | Local full-stack bring-up |
 | `tests/` | Pytest suite and fixtures |

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 	docker-core-build docker-core-help serve compose-up compose-up-heavy compose-check \
 	install-skill install-claude-code-skill install-claude-code-text-skill \
 	install-claude-project-skill package-cowork-skill package-cowork-text-skill \
-	install-cursor-text-skill plugin-validate clean
+	install-cursor-text-skill plugin-validate clean mac-app
 
 SCRIPTS := service/scripts
 PYTHON ?= $(shell if [ -x .venv/bin/python ]; then echo .venv/bin/python; else echo python3; fi)
@@ -166,6 +166,9 @@ install-cursor-text-skill:
 # structurally so CI stays CLI-free.
 plugin-validate:
 	claude plugin validate . --strict
+
+mac-app:
+	$(MAKE) -C mac app
 
 clean:
 	rm -rf dist

--- a/README.md
+++ b/README.md
@@ -262,6 +262,17 @@ Optional system tools (auto-used when present — preinstalled in the core Docke
 
 Core scripts need **Python 3.10+** stdlib only. Layer B model calls are optional.
 
+### macOS app
+
+A SwiftUI front-end for inspect/clean (files + text) lives in [`mac/`](mac/). It
+calls `service/scripts` in-process via `python3` — no Docker, no `make serve`.
+See [`mac/README.md`](mac/README.md).
+
+```bash
+make mac-app
+open mac/build/WatermarksRemover.app
+```
+
 ## Quick use (scripts)
 
 ```bash

--- a/mac/.gitignore
+++ b/mac/.gitignore
@@ -1,0 +1,5 @@
+.build/
+build/
+.swiftpm/
+.DS_Store
+*.app

--- a/mac/Makefile
+++ b/mac/Makefile
@@ -1,0 +1,7 @@
+.PHONY: app clean
+
+app:
+	./Scripts/build_app.sh
+
+clean:
+	rm -rf .build build

--- a/mac/Package.swift
+++ b/mac/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+// Front-end only: `./mac/Scripts/build_app.sh` wraps this binary with Info.plist
+// and copies service/scripts into the bundle. Cleaning logic stays in Python.
+let package = Package(
+    name: "WatermarksMac",
+    platforms: [
+        .macOS(.v14)
+    ],
+    products: [
+        .executable(name: "WatermarksMac", targets: ["WatermarksMac"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "WatermarksMac",
+            path: "Sources/WatermarksMac"
+        )
+    ]
+)

--- a/mac/README.md
+++ b/mac/README.md
@@ -1,0 +1,40 @@
+# macOS app
+
+SwiftUI front-end for this repository's **existing** `service/scripts`. It does
+not reimplement inspect/clean. Drop files or paste text; Layer A always runs;
+Layer B rewrite is off until Ollama or an OpenAI-compatible endpoint is set.
+
+This is a GUI for [watermarks-remover](https://github.com/guillaumemeyer/watermarks-remover),
+not a separate product. Signing and GitHub Releases stay with the maintainer.
+
+## Build
+
+Needs **Xcode** (SwiftUI). From the repo root:
+
+```bash
+make mac-app
+open mac/build/WatermarksRemover.app
+```
+
+Or `./mac/Scripts/build_app.sh`. The bundle copies `inspect_file.py`,
+`clean_file.py`, `rewrite_text.py`, and their stdlib import closure from
+`service/scripts` at this commit.
+
+Python 3.10+ on the Mac (`/opt/homebrew/bin/python3` or `/usr/bin/python3`).
+Optional: `exiftool`, `qpdf`, `c2patool` for a deeper PDF strip.
+
+Optional signed local build (your Developer ID, for testing only):
+
+```bash
+CODESIGN_IDENTITY="Developer ID Application: Your Name (TEAMID)" \
+  ./mac/Scripts/build_app.sh
+```
+
+## Use
+
+1. Drop files (or Open…) → Inspect → Clean. Writes `name.cleaned.ext` beside the original. Never overwrites.
+2. Text tab: paste → Inspect / Clean.
+3. Settings: rewrite Off / Ollama / OpenAI-compatible. Keys go to Keychain, never argv.
+
+A clean is not a claim that vendor detectors will fail. Pixel regen and
+SynthID on audio/video are out of scope here.

--- a/mac/Resources/Info.plist
+++ b/mac/Resources/Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>WatermarksMac</string>
+	<key>CFBundleIdentifier</key>
+	<string>io.github.guillaumemeyer.watermarksremover</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Watermarks Remover</string>
+	<key>CFBundleDisplayName</key>
+	<string>Watermarks Remover</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>14.0</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+</dict>
+</plist>

--- a/mac/Scripts/build_app.sh
+++ b/mac/Scripts/build_app.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Assemble WatermarksRemover.app from the SwiftPM binary + in-tree service/scripts.
+# Ad-hoc signed by default. Optional:
+#   CODESIGN_IDENTITY="Developer ID Application: Name (TEAMID)" ./mac/Scripts/build_app.sh
+set -euo pipefail
+
+MAC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_DIR="$(cd "$MAC_DIR/.." && pwd)"
+CONFIGURATION="${CONFIGURATION:-release}"
+CODESIGN_IDENTITY="${CODESIGN_IDENTITY:--}"
+
+if [[ -d /Applications/Xcode-beta.app ]]; then
+  export DEVELOPER_DIR="${DEVELOPER_DIR:-/Applications/Xcode-beta.app/Contents/Developer}"
+elif [[ -d /Applications/Xcode.app ]]; then
+  export DEVELOPER_DIR="${DEVELOPER_DIR:-/Applications/Xcode.app/Contents/Developer}"
+fi
+
+command -v swift >/dev/null 2>&1 || {
+  echo "build_app: swift not found. Install Xcode (SwiftUI is not buildable with Command Line Tools alone)." >&2
+  exit 1
+}
+
+echo "==> Building WatermarksMac ($CONFIGURATION)"
+swift build --package-path "$MAC_DIR" -c "$CONFIGURATION"
+BINARY="$(swift build --package-path "$MAC_DIR" -c "$CONFIGURATION" --show-bin-path)/WatermarksMac"
+[ -x "$BINARY" ] || { echo "build_app: no binary at $BINARY" >&2; exit 1; }
+
+BUILD_DIR="$MAC_DIR/build"
+APP="$BUILD_DIR/WatermarksRemover.app"
+CONTENTS="$APP/Contents"
+rm -rf "$APP"
+mkdir -p "$CONTENTS/MacOS" "$CONTENTS/Resources/PythonScripts"
+cp "$BINARY" "$CONTENTS/MacOS/WatermarksMac"
+cp "$MAC_DIR/Resources/Info.plist" "$CONTENTS/Info.plist"
+printf 'APPL????' > "$CONTENTS/PkgInfo"
+
+# Copied from service/scripts at this commit — not a vendored fork.
+# Keep this list in lockstep with ScriptBundle.requiredScripts.
+for script in \
+  av_meta.py clean_file.py common.py container_meta.py detect_gumbel.py \
+  format_dispatch.py humanize_pass.py image_meta.py inspect_file.py \
+  rewrite_text.py text_detectors.py text_unicode.py
+do
+  src="$REPO_DIR/service/scripts/$script"
+  [ -f "$src" ] || { echo "build_app: missing $src" >&2; exit 1; }
+  cp "$src" "$CONTENTS/Resources/PythonScripts/$script"
+done
+
+echo "==> Signing ($CODESIGN_IDENTITY)"
+codesign --force --sign "$CODESIGN_IDENTITY" --timestamp=none "$APP"
+codesign --verify --deep --strict "$APP"
+echo "==> Built $APP"

--- a/mac/Sources/WatermarksMac/AppModel.swift
+++ b/mac/Sources/WatermarksMac/AppModel.swift
@@ -1,0 +1,318 @@
+import AppKit
+import Foundation
+import Observation
+import UniformTypeIdentifiers
+
+enum AppTab: String, CaseIterable, Identifiable {
+    case files
+    case text
+    var id: String { rawValue }
+}
+
+enum JobPhase: String {
+    case queued
+    case inspecting
+    case inspected
+    case cleaning
+    case cleaned
+    case failed
+}
+
+struct FileJob: Identifiable {
+    let id: UUID
+    var url: URL
+    var name: String
+    var phase: JobPhase
+    var inspect: InspectReport?
+    var clean: CleanReport?
+    var cleanedURL: URL?
+    var error: String?
+    var log: String
+}
+
+@MainActor
+@Observable
+final class AppModel {
+    var tab: AppTab = .files
+    var jobs: [FileJob] = []
+    var selectedJobID: UUID?
+    var isBusy = false
+    var status = "Drop files you own, or paste text."
+    var errorMessage: String?
+    var showSettings = false
+    var lastLog = ""
+
+    var textInput = ""
+    var textOutput = ""
+    var textInspect: InspectReport?
+    var textClean: CleanReport?
+    var rewriteSkippedMessage: String?
+    var textLog = ""
+
+    let settings = SettingsStore()
+
+    var selectedJob: FileJob? {
+        jobs.first { $0.id == selectedJobID }
+    }
+
+    func addFiles(_ urls: [URL]) {
+        errorMessage = nil
+        for url in urls {
+            var isDir: ObjCBool = false
+            FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir)
+            if isDir.boolValue {
+                errorMessage = "Folders are skipped in v1 — drop individual files."
+                continue
+            }
+            if jobs.contains(where: { $0.url.path == url.path }) { continue }
+            let job = FileJob(
+                id: UUID(),
+                url: url,
+                name: url.lastPathComponent,
+                phase: .queued,
+                inspect: nil,
+                clean: nil,
+                cleanedURL: nil,
+                error: nil,
+                log: ""
+            )
+            jobs.append(job)
+            if selectedJobID == nil { selectedJobID = job.id }
+        }
+        if !jobs.isEmpty {
+            status = "\(jobs.count) file(s) ready"
+        }
+    }
+
+    func openFiles() {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = true
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.begin { [weak self] response in
+            guard response == .OK else { return }
+            Task { @MainActor in
+                self?.addFiles(panel.urls)
+            }
+        }
+    }
+
+    func inspectSelected() async {
+        guard let id = selectedJobID else {
+            await inspectAll()
+            return
+        }
+        await inspect(id: id)
+    }
+
+    func inspectAll() async {
+        for job in jobs where job.phase != .cleaning {
+            await inspect(id: job.id)
+        }
+    }
+
+    func inspect(id: UUID) async {
+        guard let index = jobs.firstIndex(where: { $0.id == id }) else { return }
+        isBusy = true
+        errorMessage = nil
+        jobs[index].phase = .inspecting
+        jobs[index].error = nil
+        status = "Inspecting \(jobs[index].name)…"
+        let url = jobs[index].url
+        do {
+            let accessed = url.startAccessingSecurityScopedResource()
+            defer { if accessed { url.stopAccessingSecurityScopedResource() } }
+            let (report, result) = try await WatermarkService.inspect(
+                file: url,
+                pythonPath: settings.pythonPath
+            )
+            guard let idx = jobs.firstIndex(where: { $0.id == id }) else { return }
+            jobs[idx].inspect = report
+            jobs[idx].log = result.stderr
+            jobs[idx].phase = .inspected
+            lastLog = result.stderr
+            status = report.summary
+        } catch {
+            if let idx = jobs.firstIndex(where: { $0.id == id }) {
+                jobs[idx].phase = .failed
+                jobs[idx].error = error.localizedDescription
+            }
+            errorMessage = error.localizedDescription
+            status = "Inspect failed"
+        }
+        isBusy = false
+    }
+
+    func cleanSelected() async {
+        guard let id = selectedJobID else {
+            await cleanAll()
+            return
+        }
+        await clean(id: id)
+    }
+
+    func cleanAll() async {
+        for job in jobs {
+            await clean(id: job.id)
+        }
+    }
+
+    func clean(id: UUID) async {
+        guard let index = jobs.firstIndex(where: { $0.id == id }) else { return }
+        isBusy = true
+        errorMessage = nil
+        jobs[index].phase = .cleaning
+        jobs[index].error = nil
+        status = "Cleaning \(jobs[index].name)…"
+        let url = jobs[index].url
+        let dest = WatermarkService.siblingCleanedURL(for: url)
+        do {
+            let accessed = url.startAccessingSecurityScopedResource()
+            defer { if accessed { url.stopAccessingSecurityScopedResource() } }
+            let (report, result) = try await WatermarkService.clean(
+                file: url,
+                output: dest,
+                pythonPath: settings.pythonPath
+            )
+            guard let idx = jobs.firstIndex(where: { $0.id == id }) else { return }
+            jobs[idx].clean = report
+            jobs[idx].cleanedURL = dest
+            jobs[idx].log = result.stderr
+            jobs[idx].phase = .cleaned
+            lastLog = result.stderr
+            if report.residual {
+                status = "Cleaned with residual provenance — vendor detectors may still fire"
+            } else if report.changed {
+                status = "Wrote \(dest.lastPathComponent)"
+            } else {
+                status = "Already clean — wrote \(dest.lastPathComponent)"
+            }
+        } catch {
+            if let idx = jobs.firstIndex(where: { $0.id == id }) {
+                jobs[idx].phase = .failed
+                jobs[idx].error = error.localizedDescription
+            }
+            errorMessage = error.localizedDescription
+            status = "Clean failed"
+        }
+        isBusy = false
+    }
+
+    func revealCleaned() {
+        guard let url = selectedJob?.cleanedURL else { return }
+        NSWorkspace.shared.activateFileViewerSelecting([url])
+    }
+
+    func inspectText() async {
+        let text = textInput
+        guard !text.isEmpty else { return }
+        isBusy = true
+        errorMessage = nil
+        rewriteSkippedMessage = nil
+        status = "Inspecting text…"
+        do {
+            let temp = try writeTemp(text, suffix: ".txt")
+            let (report, result) = try await WatermarkService.inspect(
+                file: temp,
+                pythonPath: settings.pythonPath
+            )
+            textInspect = report
+            textLog = result.stderr
+            lastLog = result.stderr
+            status = report.summary
+        } catch {
+            errorMessage = error.localizedDescription
+            status = "Inspect failed"
+        }
+        isBusy = false
+    }
+
+    func cleanText() async {
+        let text = textInput
+        guard !text.isEmpty else { return }
+        isBusy = true
+        errorMessage = nil
+        rewriteSkippedMessage = nil
+        status = "Cleaning text…"
+        do {
+            var source = try writeTemp(text, suffix: ".txt")
+            let snap = settings.snapshot()
+            if snap.rewriteEnabled {
+                if snap.backendFlag == "openai-compatible", snap.apiKey.isEmpty {
+                    rewriteSkippedMessage = "Rewrite skipped — add an API key in Settings. Layer A still ran."
+                } else if snap.backendFlag == "ollama", snap.model.isEmpty {
+                    rewriteSkippedMessage = "Rewrite skipped — set an Ollama model in Settings. Layer A still ran."
+                } else {
+                    status = "Rewriting text…"
+                    let rewritten = FileManager.default.temporaryDirectory
+                        .appendingPathComponent("watermarks-mac-\(UUID().uuidString).rewritten.txt")
+                    do {
+                        _ = try await WatermarkService.rewrite(file: source, output: rewritten, settings: snap)
+                        source = rewritten
+                    } catch {
+                        rewriteSkippedMessage = "Rewrite skipped — \(error.localizedDescription) Layer A still ran."
+                    }
+                }
+            }
+            let dest = FileManager.default.temporaryDirectory
+                .appendingPathComponent("watermarks-mac-\(UUID().uuidString).cleaned.txt")
+            let (report, result) = try await WatermarkService.clean(
+                file: source,
+                output: dest,
+                pythonPath: settings.pythonPath
+            )
+            textClean = report
+            textOutput = (try? String(contentsOf: dest, encoding: .utf8)) ?? ""
+            textLog = result.stderr
+            lastLog = result.stderr
+            status = report.changed ? "Text cleaned" : "No Layer A marks found"
+        } catch {
+            errorMessage = error.localizedDescription
+            status = "Clean failed"
+        }
+        isBusy = false
+    }
+
+    func copyOutput() {
+        let value: String
+        if tab == .text {
+            value = textOutput
+        } else if let cleaned = selectedJob?.cleanedURL,
+                  let contents = try? String(contentsOf: cleaned, encoding: .utf8) {
+            value = contents
+        } else {
+            value = selectedJob?.inspect?.rawJSON ?? ""
+        }
+        guard !value.isEmpty else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(value, forType: .string)
+        status = "Copied"
+    }
+
+    func saveTextOutput() {
+        guard !textOutput.isEmpty else { return }
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.plainText, .text]
+        panel.nameFieldStringValue = "cleaned.txt"
+        panel.begin { [weak self] response in
+            guard response == .OK, let url = panel.url, let self else { return }
+            try? self.textOutput.write(to: url, atomically: true, encoding: .utf8)
+            Task { @MainActor in
+                self.status = "Saved \(url.lastPathComponent)"
+            }
+        }
+    }
+
+    func clearFiles() {
+        jobs.removeAll()
+        selectedJobID = nil
+        status = "Drop files you own, or paste text."
+    }
+
+    private func writeTemp(_ text: String, suffix: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("watermarks-mac-\(UUID().uuidString)\(suffix)")
+        try text.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+}

--- a/mac/Sources/WatermarksMac/ContentView.swift
+++ b/mac/Sources/WatermarksMac/ContentView.swift
@@ -1,0 +1,375 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct ContentView: View {
+    @Environment(AppModel.self) private var model
+
+    var body: some View {
+        @Bindable var model = model
+
+        VStack(spacing: 0) {
+            header
+            Divider()
+            Group {
+                if model.tab == .files {
+                    filesLayout
+                } else {
+                    textLayout
+                }
+            }
+            Divider()
+            statusBar
+        }
+        .frame(minWidth: 820, minHeight: 520)
+        .background(Color(nsColor: .windowBackgroundColor))
+        .sheet(isPresented: $model.showSettings) {
+            SettingsView()
+                .environment(model)
+                .frame(width: 520, height: 460)
+        }
+    }
+
+    private var header: some View {
+        @Bindable var model = model
+        return HStack(spacing: 16) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Watermarks Remover")
+                    .font(.title2.weight(.semibold))
+                Text("Strip AI provenance from files you own")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Picker("Mode", selection: $model.tab) {
+                Text("Files").tag(AppTab.files)
+                Text("Text").tag(AppTab.text)
+            }
+            .pickerStyle(.segmented)
+            .frame(width: 160)
+            .labelsHidden()
+
+            Button("Inspect") {
+                Task {
+                    if model.tab == .text { await model.inspectText() }
+                    else { await model.inspectSelected() }
+                }
+            }
+            .disabled(model.isBusy || (model.tab == .files && model.jobs.isEmpty) || (model.tab == .text && model.textInput.isEmpty))
+
+            Button("Clean") {
+                Task {
+                    if model.tab == .text { await model.cleanText() }
+                    else { await model.cleanSelected() }
+                }
+            }
+            .keyboardShortcut(.defaultAction)
+            .disabled(model.isBusy || (model.tab == .files && model.jobs.isEmpty) || (model.tab == .text && model.textInput.isEmpty))
+
+            Button {
+                model.showSettings = true
+            } label: {
+                Image(systemName: "gearshape")
+            }
+            .help("Settings")
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 14)
+    }
+
+    private var filesLayout: some View {
+        HSplitView {
+            filesSidebar
+                .frame(minWidth: 240, idealWidth: 280)
+            reportPane
+                .frame(minWidth: 420)
+        }
+    }
+
+    private var filesSidebar: some View {
+        @Bindable var model = model
+        return VStack(spacing: 0) {
+            dropZone
+                .padding(12)
+            Divider()
+            if model.jobs.isEmpty {
+                Spacer()
+                Text("No files yet")
+                    .foregroundStyle(.tertiary)
+                Spacer()
+            } else {
+                List(selection: $model.selectedJobID) {
+                    ForEach(model.jobs) { job in
+                        jobRow(job)
+                            .tag(Optional(job.id))
+                    }
+                }
+                .listStyle(.sidebar)
+            }
+        }
+        .onDrop(of: [.fileURL], isTargeted: nil) { providers in
+            guard !model.isBusy else { return false }
+            return handleDrop(providers)
+        }
+    }
+
+    private var dropZone: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "doc.badge.gearshape")
+                .font(.system(size: 28, weight: .light))
+                .foregroundStyle(.secondary)
+            Text("Drop files here")
+                .font(.headline)
+            Text("Originals are never overwritten")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Button("Open…") { model.openFiles() }
+                .disabled(model.isBusy)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 18)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .strokeBorder(style: StrokeStyle(lineWidth: 1.2, dash: [6, 4]))
+                .foregroundStyle(.separator)
+        )
+    }
+
+    private func jobRow(_ job: FileJob) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(job.name)
+                    .font(.body)
+                    .lineLimit(1)
+                Spacer()
+                phaseBadge(job.phase)
+            }
+            if let inspect = job.inspect {
+                Text(inspect.summary)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            } else if let error = job.error {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .lineLimit(2)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func phaseBadge(_ phase: JobPhase) -> some View {
+        Text(phase.rawValue)
+            .font(.caption2.weight(.medium))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(Capsule().fill(Color.secondary.opacity(0.15)))
+    }
+
+    private var reportPane: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                honestyBanner
+                if let error = model.errorMessage {
+                    Text(error)
+                        .foregroundStyle(.red)
+                        .textSelection(.enabled)
+                }
+                if let job = model.selectedJob {
+                    fileDetail(job)
+                } else {
+                    Text("Select a file to see the inspect report.")
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(20)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .background(Color(nsColor: .textBackgroundColor))
+    }
+
+    private func fileDetail(_ job: FileJob) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack {
+                Text(job.name)
+                    .font(.title3.weight(.semibold))
+                Spacer()
+                if job.cleanedURL != nil {
+                    Button("Reveal in Finder") { model.revealCleaned() }
+                }
+            }
+            if let error = job.error {
+                Text(error).foregroundStyle(.red).textSelection(.enabled)
+            }
+            if let inspect = job.inspect {
+                section("Verifiable") {
+                    labeled("Kind", inspect.kind)
+                    if let format = inspect.format { labeled("Format", format) }
+                    labeled("Unicode marks", "\(inspect.suspiciousTotal)")
+                    labeled("C2PA", inspect.hasC2PA ? "yes" : "no")
+                    labeled("AI metadata", inspect.hasAIMetadata ? "yes" : "no")
+                    if inspect.hits.isEmpty && inspect.findings.isEmpty && !inspect.isActionable {
+                        Text("No Layer A marks found.")
+                            .foregroundStyle(.secondary)
+                    }
+                    ForEach(inspect.hits) { hit in
+                        Text("\(hit.codepoint) \(hit.label) ×\(hit.count)")
+                            .font(.system(.caption, design: .monospaced))
+                            .textSelection(.enabled)
+                    }
+                    ForEach(inspect.findings, id: \.self) { finding in
+                        Text("• \(finding)")
+                            .textSelection(.enabled)
+                    }
+                }
+            }
+            if let clean = job.clean {
+                section("Clean result") {
+                    labeled("Changed", clean.changed ? "yes" : "no")
+                    if clean.removedCount + clean.replacedCount > 0 {
+                        labeled("Removed / replaced", "\(clean.removedCount) / \(clean.replacedCount)")
+                    }
+                    ForEach(clean.actions, id: \.self) { action in
+                        Text("• \(action)").textSelection(.enabled)
+                    }
+                    if clean.residual {
+                        Text("Residual C2PA or AI metadata may remain. Soft-bound and pixel marks are out of scope.")
+                            .foregroundStyle(.orange)
+                    }
+                    if clean.degraded {
+                        Text("Degraded PDF clean — install qpdf / Ghostscript for a structural strip.")
+                            .foregroundStyle(.orange)
+                    }
+                }
+            }
+            if !job.log.isEmpty {
+                DisclosureGroup("Tool log") {
+                    Text(job.log)
+                        .font(.system(.caption, design: .monospaced))
+                        .textSelection(.enabled)
+                }
+            }
+        }
+    }
+
+    private var textLayout: some View {
+        @Bindable var model = model
+        return HSplitView {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Input")
+                    .font(.headline)
+                TextEditor(text: $model.textInput)
+                    .font(.body)
+                    .disabled(model.isBusy)
+                    .overlay(RoundedRectangle(cornerRadius: 6).stroke(.separator))
+            }
+            .padding(16)
+
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("Cleaned")
+                        .font(.headline)
+                    Spacer()
+                    Button("Copy") { model.copyOutput() }
+                        .disabled(model.textOutput.isEmpty)
+                    Button("Save…") { model.saveTextOutput() }
+                        .disabled(model.textOutput.isEmpty)
+                }
+                if let banner = model.rewriteSkippedMessage {
+                    Text(banner)
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                }
+                ScrollView {
+                    Text(model.textOutput.isEmpty ? "Cleaned text appears here." : model.textOutput)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .textSelection(.enabled)
+                        .foregroundStyle(model.textOutput.isEmpty ? .secondary : .primary)
+                }
+                .padding(8)
+                .background(Color(nsColor: .textBackgroundColor))
+                .overlay(RoundedRectangle(cornerRadius: 6).stroke(.separator))
+
+                if let inspect = model.textInspect {
+                    section("Verifiable") {
+                        labeled("Unicode marks", "\(inspect.suspiciousTotal)")
+                        ForEach(inspect.hits) { hit in
+                            Text("\(hit.codepoint) \(hit.label) ×\(hit.count)")
+                                .font(.system(.caption, design: .monospaced))
+                        }
+                    }
+                }
+            }
+            .padding(16)
+        }
+    }
+
+    private var honestyBanner: some View {
+        Text("Reports split verifiable removals (Unicode, C2PA, metadata) from best-effort rewrite. A clean file does not mean vendor detectors will fail.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .padding(10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(RoundedRectangle(cornerRadius: 8).fill(Color.secondary.opacity(0.08)))
+    }
+
+    private var statusBar: some View {
+        HStack {
+            Text(model.status)
+                .foregroundStyle(.secondary)
+            Spacer()
+            if model.isBusy {
+                ProgressView().controlSize(.small)
+            }
+            if model.tab == .files, !model.jobs.isEmpty {
+                Button("Clear list", action: model.clearFiles)
+                    .disabled(model.isBusy)
+            }
+        }
+        .font(.caption)
+        .padding(.horizontal, 20)
+        .padding(.vertical, 8)
+    }
+
+    @ViewBuilder
+    private func section(_ title: String, @ViewBuilder content: () -> some View) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title.uppercased())
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            content()
+        }
+    }
+
+    private func labeled(_ label: String, _ value: String) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(label)
+                .foregroundStyle(.secondary)
+                .frame(width: 140, alignment: .leading)
+            Text(value)
+                .textSelection(.enabled)
+            Spacer()
+        }
+        .font(.callout)
+    }
+
+    private func handleDrop(_ providers: [NSItemProvider]) -> Bool {
+        for provider in providers {
+            provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier, options: nil) { item, _ in
+                let dropped: URL?
+                if let url = item as? URL {
+                    dropped = url
+                } else if let data = item as? Data {
+                    dropped = URL(dataRepresentation: data, relativeTo: nil)
+                } else {
+                    dropped = nil
+                }
+                guard let dropped else { return }
+                Task { @MainActor in
+                    model.addFiles([dropped])
+                }
+            }
+        }
+        return true
+    }
+}

--- a/mac/Sources/WatermarksMac/PythonRunner.swift
+++ b/mac/Sources/WatermarksMac/PythonRunner.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+struct ProcessResult: Sendable {
+    var exitCode: Int32
+    var stdout: String
+    var stderr: String
+}
+
+enum RunnerError: LocalizedError, Sendable {
+    case missingPython
+    case missingScripts(String)
+    case missingScript(String)
+    case timeout(TimeInterval)
+    case launchFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingPython:
+            return "Python 3 not found. Install it (Homebrew python3) or set the path in Settings."
+        case .missingScripts(let path):
+            return "Bundled scripts not found at \(path)."
+        case .missingScript(let name):
+            return "Missing script \(name)."
+        case .timeout(let seconds):
+            return "Timed out after \(Int(seconds))s."
+        case .launchFailed(let message):
+            return message
+        }
+    }
+}
+
+enum PythonRunner {
+    static func findInterpreter(override: String) -> String? {
+        let fm = FileManager.default
+        let trimmed = override.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty, fm.isExecutableFile(atPath: trimmed) {
+            return trimmed
+        }
+        let fallbacks = [
+            "/opt/homebrew/bin/python3",
+            "/usr/local/bin/python3",
+            "/usr/bin/python3",
+        ]
+        return fallbacks.first { fm.isExecutableFile(atPath: $0) }
+    }
+
+    static func run(
+        script: String,
+        arguments: [String],
+        extraEnv: [String: String] = [:],
+        pythonPath: String,
+        timeout: TimeInterval
+    ) async throws -> ProcessResult {
+        try await Task.detached(priority: .userInitiated) {
+            try runSync(
+                script: script,
+                arguments: arguments,
+                extraEnv: extraEnv,
+                pythonPath: pythonPath,
+                timeout: timeout
+            )
+        }.value
+    }
+
+    private static func runSync(
+        script: String,
+        arguments: [String],
+        extraEnv: [String: String],
+        pythonPath: String,
+        timeout: TimeInterval
+    ) throws -> ProcessResult {
+        guard let python = findInterpreter(override: pythonPath) else {
+            throw RunnerError.missingPython
+        }
+        let scripts = try ScriptBundle.directory()
+        let scriptURL = scripts.appendingPathComponent(script)
+        guard FileManager.default.fileExists(atPath: scriptURL.path) else {
+            throw RunnerError.missingScript(script)
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: python)
+        process.arguments = [scriptURL.path] + arguments
+        process.currentDirectoryURL = scripts
+
+        var env = ProcessInfo.processInfo.environment
+        env["PYTHONUNBUFFERED"] = "1"
+        for (key, value) in extraEnv {
+            env[key] = value
+        }
+        process.environment = env
+
+        let outPipe = Pipe()
+        let errPipe = Pipe()
+        process.standardOutput = outPipe
+        process.standardError = errPipe
+        process.standardInput = FileHandle.nullDevice
+
+        do {
+            try process.run()
+        } catch {
+            throw RunnerError.launchFailed(error.localizedDescription)
+        }
+
+        let deadline = Date().addingTimeInterval(timeout)
+        while process.isRunning, Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+        if process.isRunning {
+            process.terminate()
+            throw RunnerError.timeout(timeout)
+        }
+        process.waitUntilExit()
+
+        let stdout = String(data: outPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let stderr = String(data: errPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        return ProcessResult(exitCode: process.terminationStatus, stdout: stdout, stderr: redact(stderr, extraEnv: extraEnv))
+    }
+
+    private static func redact(_ text: String, extraEnv: [String: String]) -> String {
+        var result = text
+        if let key = extraEnv["WATERMARKS_REWRITE_API_KEY"], !key.isEmpty {
+            result = result.replacingOccurrences(of: key, with: "***")
+        }
+        return result
+    }
+}

--- a/mac/Sources/WatermarksMac/Reports.swift
+++ b/mac/Sources/WatermarksMac/Reports.swift
@@ -1,0 +1,220 @@
+import Foundation
+
+struct Hit: Sendable, Identifiable {
+    var id: String { "\(codepoint)-\(kind)-\(count)" }
+    var codepoint: String
+    var label: String
+    var count: Int
+    var kind: String
+    var confidence: String
+}
+
+struct InspectReport: Sendable {
+    var kind: String
+    var path: String?
+    var note: String?
+    var format: String?
+    var length: Int?
+    var suspiciousTotal: Int
+    var hits: [Hit]
+    var hasC2PA: Bool
+    var hasAIMetadata: Bool
+    var findings: [String]
+    var notes: [String]
+    var rawJSON: String
+
+    var isActionable: Bool {
+        suspiciousTotal > 0 || hasC2PA || hasAIMetadata || !findings.isEmpty
+    }
+
+    var summary: String {
+        if kind == "unknown" {
+            return note ?? "Unrecognized format"
+        }
+        var parts: [String] = [kind]
+        if let format, !format.isEmpty { parts.append(format) }
+        if suspiciousTotal > 0 { parts.append("\(suspiciousTotal) Unicode marks") }
+        if hasC2PA { parts.append("C2PA") }
+        if hasAIMetadata { parts.append("AI metadata") }
+        if !isActionable { parts.append("clean") }
+        return parts.joined(separator: " · ")
+    }
+
+    static func parse(json: String, fallbackKind: String = "unknown") -> InspectReport {
+        var report = InspectReport(
+            kind: fallbackKind,
+            path: nil,
+            note: nil,
+            format: nil,
+            length: nil,
+            suspiciousTotal: 0,
+            hits: [],
+            hasC2PA: false,
+            hasAIMetadata: false,
+            findings: [],
+            notes: [],
+            rawJSON: json
+        )
+        guard let data = json.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            if !json.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                report.note = json
+            }
+            return report
+        }
+        report.kind = obj["kind"] as? String ?? fallbackKind
+        report.path = obj["path"] as? String
+        report.note = obj["note"] as? String
+        report.format = obj["format"] as? String
+        report.length = obj["length"] as? Int
+        report.suspiciousTotal = obj["suspicious_total"] as? Int ?? 0
+        report.hasC2PA = obj["has_c2pa"] as? Bool ?? false
+        report.hasAIMetadata = obj["has_ai_metadata"] as? Bool ?? false
+        report.findings = obj["findings"] as? [String] ?? []
+        report.notes = obj["notes"] as? [String] ?? []
+        if let hits = (obj["hits"] as? [[String: Any]]) ?? (obj["layer_a_hits"] as? [[String: Any]]) {
+            report.hits = hits.map { hit in
+                Hit(
+                    codepoint: hit["codepoint"] as? String ?? "",
+                    label: hit["label"] as? String ?? "",
+                    count: hit["count"] as? Int ?? 0,
+                    kind: hit["kind"] as? String ?? "",
+                    confidence: hit["confidence"] as? String ?? ""
+                )
+            }
+        }
+        return report
+    }
+}
+
+struct CleanReport: Sendable {
+    var kind: String
+    var changed: Bool
+    var output: String?
+    var actions: [String]
+    var stillHasC2PA: Bool
+    var stillHasAIMetadata: Bool
+    var removedCount: Int
+    var replacedCount: Int
+    var degraded: Bool
+    var rawJSON: String
+
+    var residual: Bool { stillHasC2PA || stillHasAIMetadata }
+
+    static func parse(json: String) -> CleanReport {
+        var report = CleanReport(
+            kind: "unknown",
+            changed: false,
+            output: nil,
+            actions: [],
+            stillHasC2PA: false,
+            stillHasAIMetadata: false,
+            removedCount: 0,
+            replacedCount: 0,
+            degraded: false,
+            rawJSON: json
+        )
+        guard let data = json.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return report }
+        report.kind = obj["kind"] as? String ?? "unknown"
+        report.changed = obj["changed"] as? Bool ?? false
+        report.output = obj["output"] as? String
+        report.actions = obj["actions"] as? [String] ?? []
+        report.stillHasC2PA = obj["still_has_c2pa"] as? Bool ?? false
+        report.stillHasAIMetadata = obj["still_has_ai_metadata"] as? Bool ?? false
+        if let stats = obj["stats"] as? [String: Any] {
+            report.removedCount = stats["removed_count"] as? Int ?? 0
+            report.replacedCount = stats["replaced_count"] as? Int ?? 0
+        }
+        if let meta = obj["meta"] as? [String: Any] {
+            report.degraded = meta["degraded"] as? Bool ?? false
+        }
+        return report
+    }
+}
+
+enum WatermarkService {
+    static func siblingCleanedURL(for url: URL) -> URL {
+        let ext = url.pathExtension
+        let stem = url.deletingPathExtension().lastPathComponent
+        let name = ext.isEmpty ? "\(stem).cleaned" : "\(stem).cleaned.\(ext)"
+        return url.deletingLastPathComponent().appendingPathComponent(name)
+    }
+
+    static func inspect(file: URL, pythonPath: String) async throws -> (InspectReport, ProcessResult) {
+        let result = try await PythonRunner.run(
+            script: "inspect_file.py",
+            arguments: [file.path, "--json"],
+            pythonPath: pythonPath,
+            timeout: 60
+        )
+        if result.exitCode == 2 {
+            throw RunnerError.launchFailed(result.stderr.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty ?? "Inspect refused this file.")
+        }
+        let report = InspectReport.parse(json: result.stdout)
+        return (report, result)
+    }
+
+    static func clean(file: URL, output: URL, pythonPath: String) async throws -> (CleanReport, ProcessResult) {
+        let result = try await PythonRunner.run(
+            script: "clean_file.py",
+            arguments: [file.path, "-o", output.path, "--json"],
+            pythonPath: pythonPath,
+            timeout: 60
+        )
+        if result.exitCode == 2 {
+            throw RunnerError.launchFailed(result.stderr.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty ?? "Clean refused this file.")
+        }
+        let report = CleanReport.parse(json: result.stdout)
+        return (report, result)
+    }
+
+    static func rewrite(
+        file: URL,
+        output: URL,
+        settings: SettingsSnapshot
+    ) async throws -> ProcessResult {
+        var args = [
+            file.path,
+            "-o", output.path,
+            "--backend", settings.backendFlag,
+            "--tactic", settings.tactic,
+            "--reasoning-effort", "off",
+            "--json-stats",
+        ]
+        if !settings.model.isEmpty {
+            args += ["--model", settings.model]
+        }
+        if !settings.baseURL.isEmpty {
+            args += ["--base-url", settings.baseURL]
+        }
+        var env: [String: String] = [:]
+        if !settings.apiKey.isEmpty {
+            env["WATERMARKS_REWRITE_API_KEY"] = settings.apiKey
+        }
+        if settings.allowRemote {
+            env["WATERMARKS_REWRITE_ALLOW_REMOTE"] = "1"
+            args.append("--allow-remote")
+        }
+        let result = try await PythonRunner.run(
+            script: "rewrite_text.py",
+            arguments: args,
+            extraEnv: env,
+            pythonPath: settings.pythonPath,
+            timeout: 180
+        )
+        if result.exitCode != 0 {
+            throw RunnerError.launchFailed(
+                result.stderr.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty
+                    ?? "Rewrite failed (exit \(result.exitCode))."
+            )
+        }
+        return result
+    }
+}
+
+private extension String {
+    var nonEmpty: String? { isEmpty ? nil : self }
+}

--- a/mac/Sources/WatermarksMac/ScriptBundle.swift
+++ b/mac/Sources/WatermarksMac/ScriptBundle.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+enum ScriptBundle {
+    /// Keep in lockstep with `mac/Scripts/build_app.sh` and `tests/test_mac_app.py`.
+    /// Union of the import closures of inspect_file.py, clean_file.py, rewrite_text.py.
+    static let requiredScripts = [
+        "av_meta.py",
+        "clean_file.py",
+        "common.py",
+        "container_meta.py",
+        "detect_gumbel.py",
+        "format_dispatch.py",
+        "humanize_pass.py",
+        "image_meta.py",
+        "inspect_file.py",
+        "rewrite_text.py",
+        "text_detectors.py",
+        "text_unicode.py",
+    ]
+
+    static let inspectEntry = "inspect_file.py"
+    static let cleanEntry = "clean_file.py"
+    static let rewriteEntry = "rewrite_text.py"
+
+    static func directory() throws -> URL {
+        let fm = FileManager.default
+        if let env = ProcessInfo.processInfo.environment["WATERMARKS_SCRIPTS_DIR"], !env.isEmpty {
+            let url = URL(fileURLWithPath: env)
+            if fm.fileExists(atPath: url.appendingPathComponent(inspectEntry).path) {
+                return url
+            }
+        }
+
+        var candidates: [URL] = []
+        if let resources = Bundle.main.resourceURL {
+            candidates.append(resources.appendingPathComponent("PythonScripts"))
+            candidates.append(resources.appendingPathComponent("scripts"))
+        }
+        candidates.append(contentsOf: repoScriptCandidates())
+        if let exe = Bundle.main.executableURL {
+            let macos = exe.deletingLastPathComponent()
+            candidates.append(macos.deletingLastPathComponent().appendingPathComponent("Resources/PythonScripts"))
+        }
+
+        for candidate in candidates {
+            if fm.fileExists(atPath: candidate.appendingPathComponent(inspectEntry).path) {
+                return candidate
+            }
+        }
+        throw RunnerError.missingScripts(candidates.map(\.path).joined(separator: ", "))
+    }
+
+    /// Checkout layout: mac/Sources/WatermarksMac/*.swift → repo/service/scripts
+    private static func repoScriptCandidates() -> [URL] {
+        var urls: [URL] = []
+        let fromFile = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("service/scripts")
+        urls.append(fromFile)
+
+        var dir = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        for _ in 0..<8 {
+            urls.append(dir.appendingPathComponent("service/scripts"))
+            dir.deleteLastPathComponent()
+        }
+        return urls
+    }
+}

--- a/mac/Sources/WatermarksMac/SettingsStore.swift
+++ b/mac/Sources/WatermarksMac/SettingsStore.swift
@@ -1,0 +1,144 @@
+import Foundation
+import Security
+
+enum RewriteBackend: String, CaseIterable, Identifiable {
+    case off
+    case ollama
+    case openaiCompatible = "openai"
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .off: "Off (Layer A only)"
+        case .ollama: "Ollama (local)"
+        case .openaiCompatible: "OpenAI-compatible"
+        }
+    }
+}
+
+enum RewriteTactic: String, CaseIterable, Identifiable {
+    case paraphrase
+    case humanize
+
+    var id: String { rawValue }
+}
+
+struct SettingsSnapshot: Sendable {
+    var pythonPath: String
+    var backendFlag: String
+    var model: String
+    var baseURL: String
+    var apiKey: String
+    var tactic: String
+    var allowRemote: Bool
+    var rewriteEnabled: Bool
+}
+
+@MainActor
+@Observable
+final class SettingsStore {
+    var pythonPath: String {
+        didSet { UserDefaults.standard.set(pythonPath, forKey: "pythonPath") }
+    }
+    var backend: RewriteBackend {
+        didSet { UserDefaults.standard.set(backend.rawValue, forKey: "rewriteBackend") }
+    }
+    var ollamaModel: String {
+        didSet { UserDefaults.standard.set(ollamaModel, forKey: "ollamaModel") }
+    }
+    var ollamaBaseURL: String {
+        didSet { UserDefaults.standard.set(ollamaBaseURL, forKey: "ollamaBaseURL") }
+    }
+    var openaiModel: String {
+        didSet { UserDefaults.standard.set(openaiModel, forKey: "openaiModel") }
+    }
+    var openaiBaseURL: String {
+        didSet { UserDefaults.standard.set(openaiBaseURL, forKey: "openaiBaseURL") }
+    }
+    var tactic: RewriteTactic {
+        didSet { UserDefaults.standard.set(tactic.rawValue, forKey: "rewriteTactic") }
+    }
+    var apiKey: String
+
+    init() {
+        let defaults = UserDefaults.standard
+        pythonPath = defaults.string(forKey: "pythonPath") ?? ""
+        backend = RewriteBackend(rawValue: defaults.string(forKey: "rewriteBackend") ?? "off") ?? .off
+        ollamaModel = defaults.string(forKey: "ollamaModel") ?? "llama3.2"
+        ollamaBaseURL = defaults.string(forKey: "ollamaBaseURL") ?? "http://127.0.0.1:11434"
+        openaiModel = defaults.string(forKey: "openaiModel") ?? "gpt-4o-mini"
+        openaiBaseURL = defaults.string(forKey: "openaiBaseURL") ?? "https://api.openai.com/v1"
+        tactic = RewriteTactic(rawValue: defaults.string(forKey: "rewriteTactic") ?? "paraphrase") ?? .paraphrase
+        apiKey = KeychainStore.get() ?? ""
+    }
+
+    func saveAPIKey() {
+        KeychainStore.set(apiKey)
+    }
+
+    func snapshot() -> SettingsSnapshot {
+        let rewriteOn = backend != .off
+        let model: String
+        let baseURL: String
+        switch backend {
+        case .off:
+            model = ""
+            baseURL = ""
+        case .ollama:
+            model = ollamaModel
+            baseURL = ollamaBaseURL
+        case .openaiCompatible:
+            model = openaiModel
+            baseURL = openaiBaseURL
+        }
+        let allowRemote: Bool = {
+            guard let host = URL(string: baseURL)?.host else { return false }
+            return !["127.0.0.1", "localhost", "::1"].contains(host)
+        }()
+        return SettingsSnapshot(
+            pythonPath: pythonPath,
+            backendFlag: backend == .openaiCompatible ? "openai-compatible" : "ollama",
+            model: model,
+            baseURL: baseURL,
+            apiKey: apiKey,
+            tactic: tactic.rawValue,
+            allowRemote: allowRemote,
+            rewriteEnabled: rewriteOn
+        )
+    }
+}
+
+enum KeychainStore {
+    private static let service = "io.github.guillaumemeyer.watermarksremover"
+    private static let account = "rewrite-api-key"
+
+    static func get() -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess, let data = item as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    static func set(_ value: String) {
+        let payload = Data(value.utf8)
+        let base: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        SecItemDelete(base as CFDictionary)
+        guard !value.isEmpty else { return }
+        var add = base
+        add[kSecValueData as String] = payload
+        add[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlocked
+        SecItemAdd(add as CFDictionary, nil)
+    }
+}

--- a/mac/Sources/WatermarksMac/SettingsView.swift
+++ b/mac/Sources/WatermarksMac/SettingsView.swift
@@ -1,0 +1,88 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @Environment(AppModel.self) private var model
+    @Environment(\.dismiss) private var dismiss
+    @State private var revealKey = false
+    @State private var keyDraft = ""
+    @State private var pythonResolved: String = "…"
+
+    var body: some View {
+        @Bindable var settings = model.settings
+
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Settings")
+                .font(.title2.weight(.semibold))
+
+            GroupBox("Python") {
+                VStack(alignment: .leading, spacing: 8) {
+                    TextField("Interpreter path (blank = auto)", text: $settings.pythonPath)
+                    Text("Using \(pythonResolved)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(6)
+            }
+
+            GroupBox("Layer B rewrite") {
+                VStack(alignment: .leading, spacing: 10) {
+                    Picker("Backend", selection: $settings.backend) {
+                        ForEach(RewriteBackend.allCases) { backend in
+                            Text(backend.label).tag(backend)
+                        }
+                    }
+                    Picker("Tactic", selection: $settings.tactic) {
+                        Text("Paraphrase").tag(RewriteTactic.paraphrase)
+                        Text("Humanize").tag(RewriteTactic.humanize)
+                    }
+                    if settings.backend == .ollama {
+                        TextField("Ollama model", text: $settings.ollamaModel)
+                        TextField("Ollama URL", text: $settings.ollamaBaseURL)
+                    }
+                    if settings.backend == .openaiCompatible {
+                        TextField("Model", text: $settings.openaiModel)
+                        TextField("Base URL", text: $settings.openaiBaseURL)
+                        HStack {
+                            Group {
+                                if revealKey {
+                                    TextField("API key", text: $keyDraft)
+                                } else {
+                                    SecureField("API key", text: $keyDraft)
+                                }
+                            }
+                            Button {
+                                revealKey.toggle()
+                            } label: {
+                                Image(systemName: revealKey ? "eye.slash" : "eye")
+                            }
+                            .help(revealKey ? "Hide the key" : "Show the key")
+                            .accessibilityLabel(revealKey ? "Hide the key" : "Show the key")
+                        }
+                    }
+                    Text("Rewrite is off by default. Clean still strips Unicode and metadata without a model.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(6)
+            }
+
+            Spacer()
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                Button("Save") {
+                    model.settings.apiKey = keyDraft
+                    model.settings.saveAPIKey()
+                    dismiss()
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(20)
+        .onAppear {
+            keyDraft = model.settings.apiKey
+            pythonResolved = PythonRunner.findInterpreter(override: model.settings.pythonPath) ?? "not found"
+        }
+    }
+}

--- a/mac/Sources/WatermarksMac/WatermarksMacApp.swift
+++ b/mac/Sources/WatermarksMac/WatermarksMacApp.swift
@@ -1,0 +1,51 @@
+import AppKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+@main
+struct WatermarksMacApp: App {
+    @State private var model = AppModel()
+
+    init() {
+        NSApplication.shared.setActivationPolicy(.regular)
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environment(model)
+                .onAppear {
+                    NSApp.activate(ignoringOtherApps: true)
+                }
+        }
+        .defaultSize(width: 920, height: 640)
+        .commands {
+            CommandGroup(replacing: .newItem) {}
+            CommandMenu("File") {
+                Button("Open…") { model.openFiles() }
+                    .keyboardShortcut("o")
+                Button("Inspect") {
+                    Task {
+                        if model.tab == .text { await model.inspectText() }
+                        else { await model.inspectSelected() }
+                    }
+                }
+                .keyboardShortcut("i")
+                Button("Clean") {
+                    Task {
+                        if model.tab == .text { await model.cleanText() }
+                        else { await model.cleanSelected() }
+                    }
+                }
+                .keyboardShortcut("k")
+                Button("Reveal Cleaned") { model.revealCleaned() }
+                    .disabled(model.selectedJob?.cleanedURL == nil)
+                Divider()
+                Button("Settings…") { model.showSettings = true }
+                    .keyboardShortcut(",")
+                Button("Quit") { NSApp.terminate(nil) }
+                    .keyboardShortcut("q")
+            }
+        }
+    }
+}

--- a/tests/test_mac_app.py
+++ b/tests/test_mac_app.py
@@ -1,0 +1,116 @@
+"""The macOS app copies `service/scripts` into the bundle; keep that list honest.
+
+``mac/`` does not vendor a fork of the cleaners. ``ScriptBundle.requiredScripts``
+and ``mac/Scripts/build_app.sh`` must match the import closure of
+``inspect_file.py``, ``clean_file.py``, and ``rewrite_text.py``.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+MAC = ROOT / "mac"
+SCRIPTS = ROOT / "service" / "scripts"
+SCRIPT_BUNDLE = MAC / "Sources" / "WatermarksMac" / "ScriptBundle.swift"
+BUILD_SCRIPT = MAC / "Scripts" / "build_app.sh"
+REWRITE_CALLER = MAC / "Sources" / "WatermarksMac" / "Reports.swift"
+
+ENTRIES = ("inspect_file.py", "clean_file.py", "rewrite_text.py")
+
+pytestmark = pytest.mark.skipif(not MAC.is_dir(), reason="mac/ app is not present")
+
+
+def import_closure(entry: str) -> set[str]:
+    local = {path.stem for path in SCRIPTS.glob("*.py")}
+    seen: set[str] = set()
+
+    def walk(module: str) -> None:
+        if module in seen:
+            return
+        seen.add(module)
+        source = SCRIPTS / f"{module}.py"
+        if not source.exists():
+            return
+        tree = ast.parse(source.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.level == 0 and node.module in local:
+                walk(node.module)
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name in local:
+                        walk(alias.name)
+
+    walk(Path(entry).stem)
+    return {f"{name}.py" for name in seen}
+
+
+def needed_scripts() -> set[str]:
+    out: set[str] = set()
+    for entry in ENTRIES:
+        out |= import_closure(entry)
+    return out
+
+
+def swift_required_scripts() -> list[str]:
+    source = SCRIPT_BUNDLE.read_text(encoding="utf-8")
+    match = re.search(r"requiredScripts\s*=\s*\[(.*?)\]", source, re.DOTALL)
+    assert match, "ScriptBundle.swift no longer declares requiredScripts"
+    return re.findall(r'"([^"]+\.py)"', match.group(1))
+
+
+def build_script_scripts() -> list[str]:
+    source = BUILD_SCRIPT.read_text(encoding="utf-8")
+    match = re.search(r"for script in \\\s*(.*?)\ndo", source, re.DOTALL)
+    if match is None:
+        match = re.search(r"for script in(.*?); do", source, re.DOTALL)
+    assert match, "build_app.sh no longer copies a literal list of scripts"
+    return re.findall(r"([\w.]+\.py)", match.group(1))
+
+
+def test_swift_list_matches_the_import_closure() -> None:
+    assert set(swift_required_scripts()) == needed_scripts()
+
+
+def test_build_script_copies_the_same_files() -> None:
+    assert set(build_script_scripts()) == set(swift_required_scripts())
+
+
+def test_every_required_script_exists() -> None:
+    for name in swift_required_scripts():
+        assert (SCRIPTS / name).is_file(), f"service/scripts/{name} is missing"
+
+
+def test_entry_points_are_inspect_clean_rewrite() -> None:
+    source = SCRIPT_BUNDLE.read_text(encoding="utf-8")
+    assert 'inspectEntry = "inspect_file.py"' in source
+    assert 'cleanEntry = "clean_file.py"' in source
+    assert 'rewriteEntry = "rewrite_text.py"' in source
+
+
+def test_bundled_scripts_are_standard_library_only() -> None:
+    allowed = {name.removesuffix(".py") for name in swift_required_scripts()}
+    stdlib_modules = set(getattr(__import__("sys"), "stdlib_module_names", ()))
+    for name in swift_required_scripts():
+        tree = ast.parse((SCRIPTS / name).read_text(encoding="utf-8"))
+        for node in tree.body:
+            roots: list[str] = []
+            if isinstance(node, ast.Import):
+                roots = [alias.name.split(".")[0] for alias in node.names]
+            elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+                roots = [node.module.split(".")[0]]
+            for root in roots:
+                assert root in allowed or root in stdlib_modules, (
+                    f"{name} imports {root} at module level, which the system "
+                    "python3 the app runs does not have"
+                )
+
+
+def test_app_sets_reasoning_effort_explicitly() -> None:
+    source = REWRITE_CALLER.read_text(encoding="utf-8")
+    assert '"--reasoning-effort"' in source
+    assert '"off"' in source


### PR DESCRIPTION
## Summary
- Adds `mac/`, a SwiftUI front-end that calls in-tree `service/scripts` (`inspect_file.py` / `clean_file.py` / optional `rewrite_text.py`). Drop files or paste text; originals are never overwritten.
- This is a GUI for this repo, not a separate product. Bundle ID is `io.github.guillaumemeyer.watermarksremover`. Signing/releases stay with the maintainer.
- Complements #318 (Watermarker, Layer B text rewrite). Happy to fold the Files tab into Watermarker if that PR lands first — `mac/` will otherwise conflict.

## Test plan
- [ ] `python3 -m pytest tests/test_mac_app.py -q` (script list matches import closure)
- [ ] `make mac-app` (needs Xcode for SwiftUI)
- [ ] Drop a markdown file with a zero-width space → Inspect → Clean → `name.cleaned.md` beside the original
- [ ] Text tab: paste, Inspect, Clean with rewrite off
- [ ] Confirm no secrets in the diff


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a macOS SwiftUI app for inspecting and cleaning files and text.
  * Supports drag-and-drop and file selection, progress tracking, reports, output saving, and Finder reveal.
  * Added configurable rewrite backends, tactics, Python interpreter settings, and secure API-key storage.
  * Added build, launch, signing, and cleanup workflows for the macOS app.

* **Documentation**
  * Documented the macOS app, repository layout, requirements, usage, configuration, and build commands.

* **Tests**
  * Added validation for bundled scripts, entry points, dependencies, and app configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->