### PR TITLE
docs: list DropMarks in the Ecosystem chapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1140,6 +1140,10 @@ Third-party projects that wrap or complement this repository, listed for discove
 
 [unmark-web](https://github.com/ivanusto/unmark-web) is an independent, MIT-licensed static web client. It removes invisible Unicode marks from text and strips provenance metadata from images entirely in the browser, and can optionally call this repository's HTTP service for the formats it does not handle locally. It is a separate codebase and is not affiliated with this project; see its README for scope and limits.
 
+### DropMarks — macOS GUI
+
+[DropMarks](https://github.com/Nicktili72/dropmarks) is an independent MIT-licensed macOS SwiftUI application. It calls this repository's `inspect_file.py` / `clean_file.py` (and optionally `rewrite_text.py`) via a vendored snapshot of those stdlib scripts. It is a separate codebase and is not affiliated with this project; see its README for scope and limits.
+
 ### Adding a project
 
 To register a project here, open a PR adding a short entry — project name, what it wraps or adds, and a link to its own repository. Keep entries brief and factual; do not claim compatibility with, or endorsement by, this project. A listed project should build on or integrate this repository — for example, by calling its service or reusing its detection engine — rather than merely address the same problem independently. Please avoid names that start with or closely resemble `watermarks-remover` — look-alike names make it hard to tell which project is which.


### PR DESCRIPTION
## Summary
- Registers [DropMarks](https://github.com/Nicktili72/dropmarks), an independent MIT macOS SwiftUI GUI that calls this repository's `inspect_file.py` / `clean_file.py` (vendored stdlib snapshot).
- Follows the request on closed #322: UI lives in its own repo; this PR is README Ecosystem only.
- Not affiliated or endorsed; no detector-beating claims. Name does not resemble `watermarks-remover`.

## Test plan
- [ ] Confirm the DropMarks repo is public and the link works
- [ ] Confirm the entry sits with MetaClean / unmark-web and matches Ecosystem policy tone

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added DropMarks, an independent MIT-licensed macOS GUI application, to the Ecosystem section.
  - Documented its integration with the repository’s file inspection and cleaning capabilities.
  - Clarified that DropMarks is a separate, unaffiliated project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->