### PR TITLE
feat(rewrite): encode humanize benchmark finding with warning and regression guards

### DIFF
--- a/service/scripts/rewrite_text.py
+++ b/service/scripts/rewrite_text.py
@@ -38,6 +38,10 @@ the fact/voice rules. The humanize tactic additionally runs a deterministic
 humanizer pass (humanize_pass.py) over each generated candidate — straight
 quotes, no em/en dashes or double hyphens, filler-phrase collapses, and the
 utilize->use swap — before evaluation, so the scored text is the text returned.
+Note: In benchmark testing (02-04 Sep 2026), humanize@0.2 collapsed Pangram
+human_like from 0.44 to 0.02 on an 8-doc watermarked corpus because prompting an
+LLM to "write like a human" generates formulaic transitions that detectors flag;
+prefer paraphrase + mlm for statistical watermark removal.
 
 Security notes:
   - Only http(s) endpoints are accepted; redirects are refused outright so an
@@ -57,6 +61,7 @@ import re
 import sys
 import urllib.error
 import urllib.request
+import warnings
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -1079,6 +1084,13 @@ def parse_strategy(spec: str) -> list[tuple[str, float]]:
         tactic = tactic.strip()
         if tactic not in KNOWN_TACTICS:
             raise ValueError(f"unknown strategy tactic {tactic!r}")
+        if tactic == "humanize":
+            warnings.warn(
+                "humanize tactic in strategy collapsed Pangram human_like from 0.44 to 0.02 "
+                "in benchmark runs (02-04 Sep 2026); consider paraphrase + mlm instead",
+                UserWarning,
+                stacklevel=2,
+            )
         try:
             level = float(raw_level)
         except ValueError:
@@ -1204,6 +1216,9 @@ def build_parser() -> argparse.ArgumentParser:
         "--tactic",
         choices=("paraphrase", "backtranslate", "structural", "humanize", "code", "chunk", "mlm"),
         default="paraphrase",
+        help="Rewrite tactic to use (default: paraphrase). Note: 'humanize' is available "
+        "for manual-polish styling, but collapsed Pangram human_like from 0.44 to 0.02 "
+        "in benchmark runs (02-04 Sep 2026); prefer paraphrase + mlm for detector robustness.",
     )
     p.add_argument(
         "--strategy",

--- a/skills/remove-ai-marks/references/removal-matrix.md
+++ b/skills/remove-ai-marks/references/removal-matrix.md
@@ -46,7 +46,8 @@
 | Tactic | When |
 | --- | --- |
 | `paraphrase` | Default; explicit word-choice + syntax churn |
-| `humanize` | Zero-shot "write like a human" token reshuffle |
+| `mlm` | Local masked-LM infill; perturbs token distribution without conversational cadence |
+| `humanize` | Zero-shot "write like a human" token reshuffle (caution: collapsed detector human_like score to 0.02 in benchmarks; prefer paraphrase + mlm) |
 | `backtranslate` | Stronger token reshuffle via pivot language |
 | `structural` | Strongest; most drift (outline → human prose) |
 | `code` | Comments/docstrings/string-literal wording + local identifier renames |

--- a/tests/test_clean_strategy.py
+++ b/tests/test_clean_strategy.py
@@ -47,6 +47,23 @@ def test_parse_strategy_empty():
         parse_strategy("")
 
 
+def test_parse_strategy_humanize_warning():
+    with pytest.warns(UserWarning, match=r"humanize.*0\.44.*0\.02"):
+        steps = parse_strategy("humanize@0.2")
+    assert steps == [("humanize", 0.2)]
+
+
+def test_default_strategy_has_no_humanize():
+    config_path = ROOT / "config" / "clean_strategy.json"
+    default_strategy = _load_default_strategy(config_path)
+    assert default_strategy is not None
+    steps = parse_strategy(default_strategy)
+    assert not any(tactic == "humanize" for tactic, _ in steps), (
+        "default strategy must not include humanize: humanize@0.2 collapses human_like "
+        "score from 0.44 to 0.02 (Pangram AI detector benchmark 02-04 Sep 2026)"
+    )
+
+
 # --- apply_strategy ---------------------------------------------------------
 
 


### PR DESCRIPTION
### Summary

Encodes the empirical benchmark finding regarding prompt-based humanization into `rewrite_text.py` and `test_clean_strategy.py`. Emits a runtime warning when `humanize` is used in a strategy, guards the default configuration against regressing to `humanize`, and documents the detector mechanics.

### Context

On the 8-doc watermarked benchmark corpus (02–04 Sep 2026), `paraphrase@0.4` alone scored a Pangram `human_like` of **0.44**. Appending `humanize@0.2` collapsed it to **~0.02**. 

Prompting an LLM to "write like a human" forces it into formulaic transitions, uniform pacing, and clichéd conversational registers that modern AI detectors (e.g. Pangram) easily identify. Meanwhile, masked-LM infill (`mlm@0.2` via `roberta-large`) perturbs token distributions bidirectionally without adopting an LLM conversational cadence, holding `human_like` at ~0.42 while improving the removal margin.

While `config/clean_strategy.json` was updated to `paraphrase@0.8,mlm@0.2`, this critical institutional memory was not encoded in code or test assertions.

### Changes

1. **Runtime Warning**: `rewrite_text.py:parse_strategy()` emits a `UserWarning` when the `humanize` tactic is present in a parsed strategy, warning about the 0.44 → 0.02 collapse and suggesting `paraphrase + mlm`.
2. **CLI Help & Docstring**: Documented the benchmark finding under `--tactic humanize` and the module docstring.
3. **Regression Guards**:
   - `test_parse_strategy_humanize_warning`: asserts that parsing `humanize@0.2` warns with the empirical score citation.
   - `test_default_strategy_has_no_humanize`: asserts that `config/clean_strategy.json` never includes a `humanize` step.
4. **Docs**: Updated `skills/remove-ai-marks/references/removal-matrix.md` with the empirical caution on `humanize` and documented `mlm`.

### Verification

- `python -m pytest tests/test_clean_strategy.py -v` (23 passed in 0.39s)
- `python -m ruff check service/scripts/rewrite_text.py tests/test_clean_strategy.py` (All checks passed)
- `python -m ruff format --check service/scripts/rewrite_text.py tests/test_clean_strategy.py` (2 files already formatted)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `mlm` rewording tactic as an available Layer B option.

- **Documentation**
  - Updated rewrite tactic guidance with benchmark results.
  - Recommended `paraphrase + mlm` as an alternative to `humanize`.
  - Added guidance to command-line help discouraging use of `humanize`.

- **Warnings**
  - Using the `humanize` tactic now displays a runtime warning with performance guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->