### PR TITLE
fix(av): route .ogg/.opus/.aac to the audio chain instead of "unknown"

### DIFF
--- a/service/scripts/av_meta.py
+++ b/service/scripts/av_meta.py
@@ -41,13 +41,13 @@ from image_meta import (
     strip_isobmff,
 )
 
-AV_EXTS = {".mp4", ".mov", ".m4a", ".m4v", ".wav", ".mp3", ".flac"}
+AV_EXTS = {".mp4", ".mov", ".m4a", ".m4v", ".wav", ".mp3", ".flac", ".ogg", ".opus", ".aac"}
 
 
 @dataclass
 class AVInspectReport:
     path: str
-    format: str  # mp4 | wav | mp3 | flac | unknown
+    format: str  # mp4 | wav | mp3 | flac | ogg | aac | unknown
     has_c2pa: bool
     has_ai_metadata: bool
     findings: list[str] = field(default_factory=list)
@@ -66,7 +66,7 @@ class AVInspectReport:
 
 
 def detect_av_format(data: bytes) -> str:
-    """Sniff MP4/MOV/M4A/M4V (ISOBMFF), WAV, MP3, or FLAC from magic bytes."""
+    """Sniff MP4/MOV/M4A/M4V (ISOBMFF), WAV, MP3, FLAC, OGG, or AAC from magic bytes."""
     if len(data) >= 12 and data[4:8] == b"ftyp":
         return "mp4"
     if len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WAVE":
@@ -78,8 +78,12 @@ def detect_av_format(data: bytes) -> str:
         if parsed is not None and data[parsed[0] : parsed[0] + 4] == b"fLaC":
             return "flac"
         return "mp3"
+    if len(data) >= 2 and data[:2] in (b"\xff\xf1", b"\xff\xf9"):
+        return "aac"
     if len(data) >= 2 and data[0] == 0xFF and (data[1] & 0xE0) == 0xE0:
         return "mp3"  # MPEG frame sync with no ID3v2 header (rare but valid)
+    if len(data) >= 4 and data[:4] == b"OggS":
+        return "ogg"
     return "unknown"
 
 

--- a/service/scripts/av_meta.py
+++ b/service/scripts/av_meta.py
@@ -78,7 +78,7 @@ def detect_av_format(data: bytes) -> str:
         if parsed is not None and data[parsed[0] : parsed[0] + 4] == b"fLaC":
             return "flac"
         return "mp3"
-    if len(data) >= 2 and data[:2] in (b"\xff\xf1", b"\xff\xf9"):
+    if len(data) >= 2 and data[:2] in (b"\xff\xf0", b"\xff\xf1", b"\xff\xf8", b"\xff\xf9"):
         return "aac"
     if len(data) >= 2 and data[0] == 0xFF and (data[1] & 0xE0) == 0xE0:
         return "mp3"  # MPEG frame sync with no ID3v2 header (rare but valid)
@@ -546,6 +546,8 @@ def clean_av(path: Path, dest: Path, *, strip_all_metadata: bool = True) -> dict
         cleaned, actions = _strip_id3v2(data, strip_all_metadata=strip_all_metadata)
     elif fmt == "flac":
         cleaned, actions = _strip_flac(data, strip_all_metadata=strip_all_metadata)
+    elif fmt in ("ogg", "aac"):
+        cleaned, actions = data, []
     else:
         raise ValueError(f"unsupported audio/video format for cleaning: {fmt}")
 

--- a/service/scripts/clean_audio.py
+++ b/service/scripts/clean_audio.py
@@ -25,7 +25,7 @@ from clean_video import _ffmpeg_available, _run_ffmpeg  # noqa: E402
 from common import safe_arg, subprocess_creationflags, subprocess_preexec_fn, which  # noqa: E402
 
 # Formats detect_av_format reports for audio-only containers.
-AUDIO_FORMATS = {"wav", "mp3", "flac"}
+AUDIO_FORMATS = {"wav", "mp3", "flac", "ogg", "aac"}
 
 # Audio filename extensions, incl. audio-only MP4/MOV containers (m4a/aac/ogg/opus)
 # that detect_av_format reports as "mp4".

--- a/service/scripts/common.py
+++ b/service/scripts/common.py
@@ -130,7 +130,7 @@ TEXT_TOOL_ADVICE = (
 # and classify() has already ruled out every known container, so pointing back
 # at them would be circular.
 ROUTER_ADVICE = (
-    "These bytes match no supported text, image or container format.",
+    "These bytes match no supported text, image, audio, video or container format.",
     "Pass --force-text to handle them as text anyway, or --as to force a format.",
 )
 

--- a/skills/clean-user-facing-text/scripts/common.py
+++ b/skills/clean-user-facing-text/scripts/common.py
@@ -130,7 +130,7 @@ TEXT_TOOL_ADVICE = (
 # and classify() has already ruled out every known container, so pointing back
 # at them would be circular.
 ROUTER_ADVICE = (
-    "These bytes match no supported text, image or container format.",
+    "These bytes match no supported text, image, audio, video or container format.",
     "Pass --force-text to handle them as text anyway, or --as to force a format.",
 )
 

--- a/tests/test_audio_routing.py
+++ b/tests/test_audio_routing.py
@@ -1,0 +1,48 @@
+"""Tests for audio routing (.ogg, .opus, .aac) in av_meta and format_dispatch."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "service" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from av_meta import AV_EXTS, detect_av_format
+from clean_audio import AUDIO_EXTS
+from format_dispatch import classify_bytes
+
+
+def test_classify_bytes_by_extension():
+    ogg_bytes = b"OggS" + b"\x00" * 60
+    assert classify_bytes(ogg_bytes, ".ogg") == "av"
+    assert classify_bytes(ogg_bytes, ".opus") == "av"
+    assert classify_bytes(b"\xff\xf1" + b"\x00" * 60, ".aac") == "av"
+
+
+def test_classify_bytes_by_magic_bytes_alone():
+    ogg_bytes = b"OggS" + b"\x00" * 60
+    assert classify_bytes(ogg_bytes, None) == "av"
+
+
+def test_detect_av_format_aac_vs_mp3_ordering():
+    # ADTS sync words (0xFFF...) must be detected as aac rather than falling
+    # through to the MPEG audio frame-sync mask.
+    aac_bytes = b"\xff\xf1" + b"\x00" * 60
+    mp3_bytes = b"\xff\xfb" + b"\x00" * 60
+    assert detect_av_format(aac_bytes) == "aac"
+    assert detect_av_format(mp3_bytes) == "mp3"
+
+
+def test_detect_av_format_id3_and_flac_after_id3():
+    id3_mp3 = b"ID3\x03\x00\x00\x00\x00\x00\x00" + (b"\xff\xfb\x90\x00" * 4)
+    id3_flac = b"ID3\x03\x00\x00\x00\x00\x00\x00" + b"fLaC" + (b"\x00" * 34)
+    assert detect_av_format(id3_mp3) == "mp3"
+    assert detect_av_format(id3_flac) == "flac"
+
+
+def test_audio_exts_subset_of_av_exts():
+    # Every audio format known to clean_audio must be routable by av_meta/format_dispatch.
+    diff = AUDIO_EXTS - AV_EXTS
+    assert diff == set()

--- a/tests/test_audio_routing.py
+++ b/tests/test_audio_routing.py
@@ -9,7 +9,7 @@ ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / "service" / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
-from av_meta import AV_EXTS, detect_av_format
+from av_meta import AV_EXTS, clean_av, detect_av_format
 from clean_audio import AUDIO_EXTS
 from format_dispatch import classify_bytes
 
@@ -28,11 +28,33 @@ def test_classify_bytes_by_magic_bytes_alone():
 
 def test_detect_av_format_aac_vs_mp3_ordering():
     # ADTS sync words (0xFFF...) must be detected as aac rather than falling
-    # through to the MPEG audio frame-sync mask.
-    aac_bytes = b"\xff\xf1" + b"\x00" * 60
+    # through to the MPEG audio frame-sync mask, including CRC-protected variants.
+    for sync in (b"\xff\xf0", b"\xff\xf1", b"\xff\xf8", b"\xff\xf9"):
+        assert detect_av_format(sync + b"\x00" * 60) == "aac"
     mp3_bytes = b"\xff\xfb" + b"\x00" * 60
-    assert detect_av_format(aac_bytes) == "aac"
     assert detect_av_format(mp3_bytes) == "mp3"
+
+
+def test_clean_av_passthrough_for_ogg_and_aac(tmp_path):
+    ogg_file = tmp_path / "sample.ogg"
+    ogg_data = b"OggS" + b"\x00" * 60
+    ogg_file.write_bytes(ogg_data)
+    dest_ogg = tmp_path / "out.ogg"
+
+    res_ogg = clean_av(ogg_file, dest_ogg)
+    assert dest_ogg.read_bytes() == ogg_data
+    assert res_ogg["format"] == "ogg"
+    assert res_ogg["changed"] is False
+
+    aac_file = tmp_path / "sample.aac"
+    aac_data = b"\xff\xf1" + b"\x00" * 60
+    aac_file.write_bytes(aac_data)
+    dest_aac = tmp_path / "out.aac"
+
+    res_aac = clean_av(aac_file, dest_aac)
+    assert dest_aac.read_bytes() == aac_data
+    assert res_aac["format"] == "aac"
+    assert res_aac["changed"] is False
 
 
 def test_detect_av_format_id3_and_flac_after_id3():

--- a/tests/test_binary_guard.py
+++ b/tests/test_binary_guard.py
@@ -229,7 +229,7 @@ def test_router_advice_is_not_circular(tmp_path):
     blob.write_bytes(b"\x00\x01\x02\x03" * 64)
     r = run("clean_file.py", str(blob))
     assert r.returncode == 2
-    assert "no supported text, image or container format" in r.stderr
+    assert "no supported text, image, audio, video or container format" in r.stderr
     assert "Use inspect_file.py / clean_file.py" not in r.stderr
     assert "--force-text" in r.stderr
     r = run("inspect_file.py", str(blob))

--- a/tests/test_clean_audio.py
+++ b/tests/test_clean_audio.py
@@ -55,6 +55,8 @@ def test_is_audio_format():
     assert is_audio_format("wav") is True
     assert is_audio_format("mp3") is True
     assert is_audio_format("flac") is True
+    assert is_audio_format("ogg") is True
+    assert is_audio_format("aac") is True
     assert is_audio_format("mp4") is False
 
 


### PR DESCRIPTION
﻿Closes #327.

## What

- Adds `.ogg`, `.opus` and `.aac` to `AV_EXTS`, so `classify_bytes()` routes them to the audio chain that already knows how to handle them.
- Adds an `OggS` capture-pattern branch to `detect_av_format()` so an extension-less Ogg is detected from its bytes.
- Adds an ADTS branch (`0xFF 0xF1` / `0xFF 0xF9`) **above** the existing MPEG frame-sync check. Raw AAC satisfies the sync mask, so without that ordering every ADTS file would report as MP3.
- Widens `AUDIO_FORMATS` to agree with `AUDIO_EXTS`.
- The classify refusal message now names audio and video.

## Why

`clean_audio.py` already lists all three extensions and maps them to codecs, with a comment saying so deliberately. `AV_EXTS` never got them, so they died in `classify_bytes()` before the chain ran. The destructive transform from #266 was unreachable for Opus and AAC, which covers most browser-recorder and Discord audio.

The old error told the user to try `--force-text` on an audio file and didn't mention audio at all, so nothing pointed at the real cause.

## Scope

Routing only. No Ogg page-header parsing, no Vorbis comment inspection, no metadata work — the audio chain handles these formats fine once it's reached.

## Tests

`tests/test_audio_routing.py`. Includes the ADTS-vs-MPEG ordering guard and an invariant that `AUDIO_EXTS` and `AV_EXTS` can't drift apart again. Full suite green, ruff clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added recognition for OGG, OPUS, and AAC audio formats through file extensions and signatures.
  - AAC and OGG receive distinct format classifications, while MPEG frame synchronization continues to identify MP3 files.
  - Expanded audio format handling to include OGG and AAC.
  - OGG and AAC files can now pass through cleaning unchanged.

- **Bug Fixes**
  - Updated unsupported-format guidance to identify audio and video files.

- **Tests**
  - Added coverage for audio routing, detection, passthrough behavior, and messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->