### PR TITLE
fix(plugin): align plugin manifests with v0.7.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "source": "./",
       "displayName": "Watermarks Remover",
       "description": "Remove multi-vendor AI provenance marks from text, images, documents, and media. Bundles the remove-ai-marks and clean-user-facing-text skills.",
-      "version": "0.5.0",
+      "version": "0.7.0",
       "author": {
         "name": "watermarks-remover contributors",
         "url": "https://github.com/guillaumemeyer/watermarks-remover"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "watermarks-remover",
   "displayName": "Watermarks Remover",
-  "version": "0.5.0",
+  "version": "0.7.0",
   "description": "Remove multi-vendor AI provenance marks: invisible Unicode (Layer A), statistical text watermarks via rewrite (Layer B), and C2PA/EXIF/XMP/container metadata on images, documents, and media. Ships the remove-ai-marks skill (thin client over the repo's HTTP service) and the self-contained clean-user-facing-text skill.",
   "author": {
     "name": "watermarks-remover contributors",


### PR DESCRIPTION
## What

Update the version in `.claude-plugin/plugin.json` and the matching entry in `.claude-plugin/marketplace.json` from `0.5.0` to `0.7.0`.

## Why

The v0.7.0 release still advertises plugin version 0.5.0, as reported in #319 and #326. Both manifests agree with each other, so the existing manifest consistency test passes despite the stale release version.

## Local reproduction

Reproduced the actual local-marketplace installation path on macOS 26.5.1 (arm64), Claude Code 2.1.236. Three independent configuration/cache directories were used:

| Installed source | `claude plugin list --json` version |
| --- | --- |
| Locally fetched `v0.7.0` release tag | `0.5.0` (bug reproduced) |
| Unmodified main at `d9e9590d94e19b39eb2794266292324bfec8249a` | `0.5.0` (bug reproduced) |
| Same main plus these two version-field changes | `0.7.0` (fixed) |

Sanitized excerpt from the actual `claude plugin list --json` output (only plugin ID and version retained; local paths and timestamps omitted):

```json
{
  "release_v0.7.0": {"id": "watermarks-remover@watermarks-remover", "version": "0.5.0"},
  "unmodified_main": {"id": "watermarks-remover@watermarks-remover", "version": "0.5.0"},
  "fixed_main": {"id": "watermarks-remover@watermarks-remover", "version": "0.7.0"}
}
```

All marketplace-add, install, and list commands exited 0. The fix changes only the two metadata fields in the same-base comparison. No Claude login or model/provider credentials were used; `claude auth status` confirmed `loggedIn: false` and `authMethod: none`. No inference request was made.

To repeat from the fixed working tree, with `v0.7.0` fetched locally:

```sh
repro_dir=$(mktemp -d)
mkdir -p "$repro_dir/release" "$repro_dir/before" "$repro_dir/after" "$repro_dir/run"
git archive v0.7.0 | tar -x -C "$repro_dir/release"
git archive d9e9590d94e19b39eb2794266292324bfec8249a | tar -x -C "$repro_dir/before"
git archive d9e9590d94e19b39eb2794266292324bfec8249a | tar -x -C "$repro_dir/after"
cp .claude-plugin/plugin.json "$repro_dir/after/.claude-plugin/plugin.json"
cp .claude-plugin/marketplace.json "$repro_dir/after/.claude-plugin/marketplace.json"
(
  cd "$repro_dir/run"
  for sample in release before after; do
    export CLAUDE_CONFIG_DIR="$repro_dir/config-$sample"
    claude plugin marketplace add "$repro_dir/$sample"
    claude plugin install watermarks-remover@watermarks-remover
    claude plugin list --json
  done
)
```

The install command also reports an unset `hook_mode` userConfig option in all three cases; it does not prevent installation or version listing. Configuring or running hooks is outside this metadata fix.

A direct local assertion also fails before and passes after. From the repository root:

```sh
python3 - <<'PY'
import json
from pathlib import Path

expected = '0.7.0'
plugin = json.loads(Path('.claude-plugin/plugin.json').read_text())
marketplace = json.loads(Path('.claude-plugin/marketplace.json').read_text())
entry = next(p for p in marketplace['plugins'] if p['name'] == plugin['name'])
actual = [plugin['version'], entry['version']]
print(f'expected={expected}, actual={actual}', flush=True)
assert actual == [expected, expected]
PY
```

Before the fix: `expected=0.7.0, actual=['0.5.0', '0.5.0']`, followed by `AssertionError` (exit 1).

After the fix: `expected=0.7.0, actual=['0.7.0', '0.7.0']` (exit 0).

Also confirmed locally with `git show v0.7.0:.claude-plugin/plugin.json` and `git show v0.7.0:.claude-plugin/marketplace.json` that the published tag contains 0.5.0 in both files.

## Validation

- Local version assertion: FAIL before, PASS after.
- Real Claude Code marketplace installation/listing: old release and unmodified main report 0.5.0; fixed snapshot reports 0.7.0 in a fresh cache.
- `python -m pytest tests/test_plugin_manifest.py -o addopts='' -q`: 11 passed after the fix; the original manifest suite also passed before the fix.
- `git diff --check`: passed.
- `python -m pytest -o addopts='' -q`: 1239 passed, 2 skipped in 38.36s (CPython 3.13.11, pytest 9.1.1, macOS). Run with localhost listener access; the initial sandboxed run was blocked by `PermissionError` while binding test HTTP servers.

## Notes for the reviewer

Only two version fields change. No installer, runtime, or release workflow changes. This does not rewrite the already-published v0.7.0 tag/archive; the corrected metadata needs to be delivered through a subsequent release. Future release-version synchronization remains a separate follow-up.

Refs #319, #326.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the plugin version to 0.7.0 across marketplace and plugin listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->