### PR TITLE
feat(container): clean metadata inside PDF embedded file attachments

### DIFF
--- a/service/scripts/clean_file.py
+++ b/service/scripts/clean_file.py
@@ -45,6 +45,17 @@ def main() -> int:
             "recompresses images; never skips the pass entirely"
         ),
     )
+    p.add_argument(
+        "--clean-attachments",
+        choices=("auto", "always", "never"),
+        default="always",
+        help=(
+            "PDF: strip metadata inside embedded file attachments (paperclips), "
+            "recursing into nested containers. always (default) clears every "
+            "attachment's metadata; auto only for attachments that carry "
+            "AI/C2PA markers; never leaves them untouched"
+        ),
+    )
     p.add_argument("--aggressive-homoglyphs", action="store_true")
     p.add_argument(
         "--keep-non-ai-metadata",
@@ -230,7 +241,13 @@ def main() -> int:
         return 1 if residual else 0
 
     try:
-        result = clean_container(src, dest, fmt=container_fmt, deep_images=args.deep_images)
+        result = clean_container(
+            src,
+            dest,
+            fmt=container_fmt,
+            deep_images=args.deep_images,
+            clean_attachments=args.clean_attachments,
+        )
     except Exception as e:
         eprint(f"error: {e}")
         return 1

--- a/service/scripts/container_meta.py
+++ b/service/scripts/container_meta.py
@@ -3325,17 +3325,29 @@ _QPDF_ATTACH_TIMEOUT = 60.0
 
 
 def _pdf_iso_to_pdf_date(iso: str | None) -> str | None:
-    """Convert an ISO-8601 timestamp to qpdf's PDF date form (best-effort).
+    """Convert an ISO-8601 (or native PDF-date) timestamp to qpdf's PDF date form.
 
-    ``None`` or an unparseable string returns ``None`` so callers can simply
-    omit the date option and let qpdf stamp "now" rather than erroring.
+    ``qpdf --json`` reports attachment dates in ISO-8601, but some qpdf outputs
+    hand back the native ``D:YYYYMMDDHHMMSS±HH'MM'`` form. Accept both so the
+    original timestamps survive re-embedding. ``None`` or an unparseable string
+    returns ``None`` so callers can simply omit the date option and let qpdf
+    stamp "now" rather than erroring.
     """
     if not iso:
         return None
-    m = re.match(r"(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})([+-])(\d{2}):(\d{2})", iso)
+    if re.match(r"^D:\d{14}.*$", iso):
+        # Already in qpdf's expected form; return as-is for round-tripping.
+        return iso
+    # qpdf reports the offset form (…-08:00) or normalizes UTC to a "Z" suffix.
+    m = re.match(
+        r"(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:([+-])(\d{2}):(\d{2})|Z)",
+        iso,
+    )
     if not m:
         return None
     y, mo, d, h, mi, s, sign, oh, om = m.groups()
+    if sign is None:  # "Z" == UTC
+        sign, oh, om = "+", "00", "00"
     return f"D:{y}{mo}{d}{h}{mi}{s}{sign}{oh}'{om}'"
 
 
@@ -3656,7 +3668,7 @@ def _pdf_clean_attachments(
                 )
                 # A destroyed attachment must still come back, original bytes.
                 if not dest_has and not _add_attachment(
-                    dest, att, in_path, staging, remove_existing=False
+                    dest, att, in_path, staging, remove_existing=False, deadline=deadline
                 ):
                     results[-1]["error"] = "re-embed failed"
                 continue
@@ -3669,7 +3681,9 @@ def _pdf_clean_attachments(
             processed = True
             clean_path = Path(staging) / f"att-{i}-out{ext}"
             safe_write_bytes(clean_path, cleaned_bytes)
-            if not _add_attachment(dest, att, clean_path, staging, remove_existing=dest_has):
+            if not _add_attachment(
+                dest, att, clean_path, staging, remove_existing=dest_has, deadline=deadline
+            ):
                 results.append(
                     {
                         **report_att,
@@ -3709,6 +3723,7 @@ def _add_attachment(
     staging: str,
     *,
     remove_existing: bool,
+    deadline: "_Deadline | None" = None,
 ) -> bool:
     """Add (and optionally replace) one attachment's bytes in *dest* in place.
 
@@ -3742,7 +3757,9 @@ def _add_attachment(
             [qpdf, *cmd],
             capture_output=True,
             text=True,
-            timeout=_QPDF_ATTACH_TIMEOUT,
+            timeout=(
+                _QPDF_ATTACH_TIMEOUT if deadline is None else deadline.timeout(_QPDF_ATTACH_TIMEOUT)
+            ),
             check=False,
             preexec_fn=subprocess_preexec_fn,
             creationflags=subprocess_creationflags,

--- a/service/scripts/container_meta.py
+++ b/service/scripts/container_meta.py
@@ -7,6 +7,7 @@ Stdlib-first; PDF prefers optional exiftool/c2patool when present.
 import base64
 import bisect
 import io
+import json
 import os
 import posixpath
 import re
@@ -2910,7 +2911,9 @@ def _pdf_structured_blob(data: bytes) -> bytes:
     return no_streams + b"\n" + xmp
 
 
-def inspect_pdf(path: Path, data: bytes) -> tuple[bool, bool, list[str], dict]:
+def inspect_pdf(
+    path: Path, data: bytes, *, depth: int = 0, include_attachments: bool = True
+) -> tuple[bool, bool, list[str], dict]:
     findings: list[str] = []
     has_c2pa, has_ai, hits = _blob_hits(_pdf_structured_blob(data))
     findings.extend(f"pdf-structured:{h}" for h in hits)
@@ -2936,7 +2939,29 @@ def inspect_pdf(path: Path, data: bytes) -> tuple[bool, bool, list[str], dict]:
     probe_note = c2patool_probe_note(tools)
     if probe_note:
         findings.append(probe_note)
-    return has_c2pa, has_ai or has_c2pa, findings, {"tools": tools}
+
+    # Embedded-file attachments are stream payloads, so the deterministic scan
+    # above deliberately cannot see them. Extract and inspect each one the same
+    # way we would a standalone file. Callers deciding whether to run the
+    # Ghostscript deep-image pass pass ``include_attachments=False`` so an
+    # attachment-only marker does not trigger a re-distill that would drop the
+    # attachments themselves.
+    details: dict[str, Any] = {"tools": tools}
+    if include_attachments:
+        attachments, truncated = _pdf_inspect_attachments(path, None, depth=depth)
+        if attachments:
+            for a in attachments:
+                findings.append(f"attachment:{a['name']}:{a.get('kind', 'unknown')}")
+                if a.get("has_ai_metadata"):
+                    has_ai = True
+                    findings.append(f"attachment:{a['name']}:AI metadata")
+                if a.get("has_c2pa"):
+                    has_c2pa = True
+                    findings.append(f"attachment:{a['name']}:C2PA")
+            details["attachments"] = attachments
+            if truncated:
+                details["attachments_truncated"] = True
+    return has_c2pa, has_ai or has_c2pa, findings, details
 
 
 def _blank_xmp_packets(data: bytes) -> tuple[bytes, int]:
@@ -3279,7 +3304,450 @@ def _run_ghostscript(
     return True
 
 
-def clean_pdf(path: Path, dest: Path, *, deep_images: str = "auto") -> tuple[list[str], dict]:
+# ---------------------------------------------------------------------------
+# PDF embedded-file attachments
+# ---------------------------------------------------------------------------
+
+CLEAN_ATTACHMENT_MODES = frozenset({"auto", "always", "never"})
+DEFAULT_CLEAN_ATTACHMENTS = "always"
+MAX_ATTACHMENT_DEPTH = 3
+MAX_ATTACHMENT_BYTES = 64 * 1024 * 1024
+_QPDF_ATTACH_TIMEOUT = 60.0
+
+
+def _pdf_iso_to_pdf_date(iso: str | None) -> str | None:
+    """Convert an ISO-8601 timestamp to qpdf's PDF date form (best-effort).
+
+    ``None`` or an unparseable string returns ``None`` so callers can simply
+    omit the date option and let qpdf stamp "now" rather than erroring.
+    """
+    if not iso:
+        return None
+    m = re.match(r"(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})([+-])(\d{2}):(\d{2})", iso)
+    if not m:
+        return None
+    y, mo, d, h, mi, s, sign, oh, om = m.groups()
+    return f"D:{y}{mo}{d}{h}{mi}{s}{sign}{oh}'{om}'"
+
+
+def _pdf_attachment_list(path: Path, deadline: "_Deadline | None" = None) -> list[dict]:
+    """Enumerate a PDF's embedded files via ``qpdf --json``.
+
+    Returns a list of ``{key, name, mimetype, description, creationdate,
+    modificationdate}`` in PDF order. Empty when qpdf is absent, the budget is
+    spent, or the PDF carries no attachments.
+    """
+    qpdf = which("qpdf")
+    if not qpdf:
+        return []
+    if deadline is not None and deadline.spent():
+        return []
+    try:
+        r = subprocess.run(
+            [qpdf, "--json", "--json-key=attachments", "--", safe_arg(str(path))],
+            capture_output=True,
+            text=True,
+            timeout=(
+                _QPDF_ATTACH_TIMEOUT if deadline is None else deadline.timeout(_QPDF_ATTACH_TIMEOUT)
+            ),
+            check=False,
+            preexec_fn=subprocess_preexec_fn,
+            creationflags=subprocess_creationflags,
+        )
+    except Exception:
+        return []
+    if r.returncode != 0:
+        return []
+    try:
+        payload = json.loads(r.stdout)
+    except Exception:
+        return []
+    out: list[dict] = []
+    for key, info in (payload.get("attachments") or {}).items():
+        if not isinstance(info, dict):
+            continue
+        names = info.get("names") or {}
+        streams = info.get("streams") or {}
+        stream = next(iter(streams.values()), {}) if streams else {}
+        out.append(
+            {
+                "key": key,
+                "name": info.get("preferredname") or key,
+                "mimetype": stream.get("mimetype") or None,
+                "description": info.get("description"),
+                "creationdate": stream.get("creationdate"),
+                "modificationdate": stream.get("modificationdate"),
+                "named_F": names.get("/F"),
+                "named_UF": names.get("/UF"),
+            }
+        )
+    return out
+
+
+def _pdf_show_attachment(path: Path, key: str, tmp: Path, deadline: "_Deadline | None") -> int:
+    """Extract one embedded file to *tmp*. Returns the byte count, or -1."""
+    qpdf = which("qpdf")
+    if not qpdf:
+        return -1
+    try:
+        with tmp.open("wb") as out:
+            r = subprocess.run(
+                [qpdf, f"--show-attachment={key}", "--", safe_arg(str(path))],
+                stdout=out,
+                stderr=subprocess.PIPE,
+                timeout=(
+                    _QPDF_ATTACH_TIMEOUT
+                    if deadline is None
+                    else deadline.timeout(_QPDF_ATTACH_TIMEOUT)
+                ),
+                check=False,
+                preexec_fn=subprocess_preexec_fn,
+                creationflags=subprocess_creationflags,
+            )
+    except Exception:
+        return -1
+    if r.returncode != 0:
+        return -1
+    try:
+        return tmp.stat().st_size
+    except OSError:
+        return -1
+
+
+def _classify_attachment(name: str, data: bytes) -> str:
+    """Route an attachment to the same pipelines as a standalone file."""
+    from format_dispatch import classify_bytes  # local: avoids an import cycle
+
+    return classify_bytes(data, Path(name).suffix)
+
+
+def _pdf_inspect_attachments(
+    path: Path, deadline: "_Deadline | None", depth: int = 0
+) -> tuple[list[dict], bool]:
+    """Inspect each embedded file and report its own provenance.
+
+    Returns ``(attachments, truncated)`` where each attachment is
+    ``{name, mimetype, key, kind, has_c2pa, has_ai_metadata, findings}``.
+    ``truncated`` is true when the scan stopped at the depth cap or budget so
+    callers can report an incomplete rather than "clean" answer.
+    """
+    if depth > MAX_ATTACHMENT_DEPTH:
+        return [], True
+    if deadline is not None and deadline.spent():
+        return [], True
+    attachments = _pdf_attachment_list(path, deadline)
+    results: list[dict] = []
+    truncated = False
+    with tempfile.TemporaryDirectory(prefix="wr-att-insp-") as staging:
+        for i, att in enumerate(attachments):
+            # Sanitise the temp name: keep the suffix so classification works,
+            # drop any directory separators in the attachment's own name.
+            safe_name = Path(att["name"]).name or f"att-{i}"
+            tmp = Path(staging) / f"att-{i}{Path(safe_name).suffix}"
+            n = _pdf_show_attachment(path, att["key"], tmp, deadline)
+            if n < 0:
+                results.append({**att, "kind": "unknown", "error": "extract failed"})
+                continue
+            if n > MAX_ATTACHMENT_BYTES:
+                results.append({**att, "kind": "unknown", "error": "attachment too large"})
+                truncated = True
+                continue
+            data = tmp.read_bytes()
+            kind = _classify_attachment(att["name"], data)
+            has_c2pa, has_ai, findings = _inspect_attachment_bytes(tmp, data, kind, depth)
+            results.append(
+                {
+                    **att,
+                    "kind": kind,
+                    "has_c2pa": has_c2pa,
+                    "has_ai_metadata": has_ai,
+                    "findings": findings,
+                }
+            )
+            if deadline is not None and deadline.spent():
+                truncated = True
+                break
+    return results, truncated
+
+
+def _inspect_attachment_bytes(
+    tmp: Path, data: bytes, kind: str, depth: int
+) -> tuple[bool, bool, list[str]]:
+    """Inspect an extracted attachment, recursing into nested containers."""
+    if kind == "text":
+        from text_unicode import inspect_text  # local import avoids a cycle
+
+        ta = inspect_text(data.decode("utf-8", errors="surrogateescape"))
+        return False, bool(ta.suspicious_total), [f"layer-a x{ta.suspicious_total}"]
+    if kind == "image":
+        from image_meta import inspect_image
+
+        rep = inspect_image(tmp, data=data)
+        return rep.has_c2pa, rep.has_ai_metadata, rep.findings
+    if kind == "av":
+        from av_meta import inspect_av
+
+        rep = inspect_av(tmp, data=data)
+        return rep.has_c2pa, rep.has_ai_metadata, rep.findings
+    if kind == "container":
+        rep = inspect_container(tmp, data=data, _depth=depth + 1)
+        return rep.has_c2pa, rep.has_ai_metadata, rep.findings
+    return False, False, [f"unsupported attachment kind: {kind}"]
+
+
+def _pdf_extract_attachments(
+    path: Path, deadline: "_Deadline | None", staging: Path
+) -> tuple[list[dict], list[dict]]:
+    """Extract every embedded file into *staging*.
+
+    Returns ``(ok, skipped)``: ``ok`` entries carry ``in_path``; ``skipped``
+    entries carry an ``error`` (extract failed / over size cap) so the clean
+    pass can report what it could not touch rather than dropping it silently.
+    Used up front in ``clean_pdf`` so attachment bytes are preserved even when
+    the Ghostscript deep-image pass — which re-distills the page and drops
+    embedded files — runs later.
+    """
+    attachments = _pdf_attachment_list(path, deadline)
+    ok: list[dict] = []
+    skipped: list[dict] = []
+    for i, att in enumerate(attachments):
+        safe_name = Path(att["name"]).name or f"att-{i}"
+        in_path = staging / f"{i}-in{Path(safe_name).suffix}"
+        n = _pdf_show_attachment(path, att["key"], in_path, deadline)
+        if n < 0:
+            skipped.append({**att, "error": "extract failed"})
+            continue
+        if n > MAX_ATTACHMENT_BYTES:
+            skipped.append({**att, "error": "attachment too large"})
+            continue
+        ok.append({**att, "in_path": in_path})
+    return ok, skipped
+
+
+def _pdf_clean_attachments(
+    path: Path,
+    dest: Path,
+    actions: list[str],
+    deadline: "_Deadline | None",
+    mode: str,
+    depth: int = 0,
+) -> dict[str, Any]:
+    """Strip embedded-file metadata, re-embedding cleaned bytes via qpdf.
+
+    Attachments are extracted from *path* (the original, unmodified input) and
+    re-embedded into *dest*, because some earlier pass (the Ghostscript
+    deep-image re-distill) may have dropped them from *dest*. Returns
+    ``{"attachments": [...], "processed": bool, "qpdf_absent": bool}``.
+    """
+    qpdf = which("qpdf")
+    if not qpdf:
+        actions.append(
+            "warning: embedded-file attachments left in place; install qpdf for the attachment pass"
+        )
+        return {"attachments": [], "processed": False, "qpdf_absent": True}
+    if depth > MAX_ATTACHMENT_DEPTH:
+        actions.append(f"warning: attachment recursion capped at depth {MAX_ATTACHMENT_DEPTH}")
+        return {"attachments": [], "processed": False, "qpdf_absent": False}
+    if deadline is not None and deadline.spent():
+        actions.append("attachment pass skipped: clean budget exhausted")
+        return {"attachments": [], "processed": False, "qpdf_absent": False}
+
+    results: list[dict] = []
+    processed = False
+    with tempfile.TemporaryDirectory(prefix="wr-att-") as staging:
+        attachments, skipped = _pdf_extract_attachments(path, deadline, Path(staging))
+        if skipped:
+            for att in skipped:
+                actions.append(f"skipped attachment '{att['name']}': {att['error']}")
+                results.append({**att, "kind": "unknown", "cleaned": False, "error": att["error"]})
+        if not attachments:
+            if not skipped:
+                actions.append("no embedded attachments to clean")
+            return {"attachments": results, "processed": False, "qpdf_absent": False}
+
+        # Did a re-distill drop the attachments from dest? If not, re-embedding
+        # only the changed ones is enough; if so, every attachment is restored.
+        dest_has = bool(_pdf_attachment_list(dest, deadline))
+        for i, att in enumerate(attachments):
+            if deadline is not None and deadline.spent():
+                actions.append("attachment pass stopped: clean budget exhausted")
+                break
+            name = att["name"]
+            in_path = att["in_path"]
+            data = in_path.read_bytes()
+            ext = Path(name).suffix or Path(in_path.name).suffix
+            kind = _classify_attachment(name, data)
+            has_c2pa, has_ai, findings = _inspect_attachment_bytes(in_path, data, kind, depth)
+            should_clean = mode == "always" or (mode == "auto" and (has_c2pa or has_ai))
+            # The report must not leak the on-disk staging path.
+            report_att = {k: v for k, v in att.items() if k != "in_path"}
+            if not should_clean:
+                results.append(
+                    {
+                        **report_att,
+                        "kind": kind,
+                        "cleaned": False,
+                        "still_has_c2pa": has_c2pa,
+                        "still_has_ai_metadata": has_ai,
+                        "findings": findings,
+                        "actions": [],
+                    }
+                )
+                # A destroyed attachment must still come back, original bytes.
+                if not dest_has and not _add_attachment(
+                    dest, att, in_path, staging, remove_existing=False
+                ):
+                    results[-1]["error"] = "re-embed failed"
+                continue
+            cleaned_bytes, clean_actions = _clean_attachment_bytes(in_path, data, kind, mode, depth)
+            if cleaned_bytes is None:
+                results.append(
+                    {**report_att, "kind": kind, "cleaned": False, "error": "clean failed"}
+                )
+                continue
+            processed = True
+            clean_path = Path(staging) / f"att-{i}-out{ext}"
+            safe_write_bytes(clean_path, cleaned_bytes)
+            if not _add_attachment(dest, att, clean_path, staging, remove_existing=dest_has):
+                results.append(
+                    {
+                        **report_att,
+                        "kind": kind,
+                        "cleaned": False,
+                        "error": "re-embed failed",
+                        "actions": clean_actions,
+                    }
+                )
+                actions.append(f"failed to re-embed cleaned attachment '{name}'")
+                continue
+            clean_actions.append(f"attachment '{name}': re-embedded")
+            rem_c2pa, rem_ai, rem_findings = _inspect_attachment_bytes(
+                clean_path, cleaned_bytes, kind, depth
+            )
+            results.append(
+                {
+                    **report_att,
+                    "kind": kind,
+                    "cleaned": True,
+                    "still_has_c2pa": rem_c2pa,
+                    "still_has_ai_metadata": rem_ai,
+                    "findings": rem_findings,
+                    "actions": clean_actions,
+                }
+            )
+
+    if processed:
+        actions.append("embedded-file attachments cleaned")
+    return {"attachments": results, "processed": processed, "qpdf_absent": False}
+
+
+def _add_attachment(
+    dest: Path,
+    att: dict[str, Any],
+    add_path: Path,
+    staging: str,
+    *,
+    remove_existing: bool,
+) -> bool:
+    """Add (and optionally replace) one attachment's bytes in *dest* in place.
+
+    qpdf rewrites the document, so the result is staged and swapped in via the
+    safe writer. ``remove_existing`` is False when a prior re-distill dropped
+    the attachment, in which case the *add* must not try to remove a key that
+    no longer exists.
+    """
+    tmp = Path(staging) / "rebuilt.pdf"
+    cmd: list[str] = []
+    if remove_existing:
+        cmd.append(f"--remove-attachment={att['key']}")
+    cmd += ["--add-attachment", safe_arg(str(add_path))]
+    cmd += [f"--key={att['key']}", f"--filename={att['name'] or att['key']}"]
+    if att.get("mimetype"):
+        cmd += [f"--mimetype={att['mimetype']}"]
+    if att.get("description"):
+        cmd += [f"--description={att['description']}"]
+    to = _pdf_iso_to_pdf_date(att.get("creationdate"))
+    if to:
+        cmd += [f"--creationdate={to}"]
+    td = _pdf_iso_to_pdf_date(att.get("modificationdate"))
+    if td:
+        cmd += [f"--moddate={td}"]
+    cmd += ["--", safe_arg(str(dest)), safe_arg(str(tmp))]
+    qpdf = which("qpdf")
+    if not qpdf:
+        return False
+    try:
+        r = subprocess.run(
+            [qpdf, *cmd],
+            capture_output=True,
+            text=True,
+            timeout=_QPDF_ATTACH_TIMEOUT,
+            check=False,
+            preexec_fn=subprocess_preexec_fn,
+            creationflags=subprocess_creationflags,
+        )
+    except Exception:
+        return False
+    if r.returncode != 0 or not tmp.is_file() or tmp.stat().st_size == 0:
+        tmp.unlink(missing_ok=True)
+        return False
+    safe_write_bytes(dest, tmp.read_bytes())
+    return True
+
+
+def _clean_attachment_bytes(
+    tmp: Path, data: bytes, kind: str, mode: str, depth: int
+) -> tuple[bytes | None, list[str]]:
+    """Clean an extracted attachment with the matching unified pipeline."""
+    if kind == "text":
+        from text_unicode import clean_text
+
+        cleaned, stats = clean_text(data.decode("utf-8", errors="surrogateescape"))
+        return cleaned.encode("utf-8"), [
+            f"text layer A: removed={stats['removed_count']} replaced={stats['replaced_count']}"
+        ]
+    if kind == "image":
+        from image_meta import clean_image
+
+        dest = tmp.with_name(tmp.name + ".cleaned")
+        result = clean_image(tmp, dest, strip_all_metadata=(mode == "always"))
+        if not dest.is_file():
+            return None, []
+        return dest.read_bytes(), result.get("actions", [])
+    if kind == "av":
+        from av_meta import clean_av
+
+        dest = tmp.with_name(tmp.name + ".cleaned")
+        result = clean_av(tmp, dest, strip_all_metadata=(mode == "always"))
+        if not dest.is_file():
+            return None, []
+        return dest.read_bytes(), result.get("actions", [])
+    if kind == "container":
+        dest = tmp.with_name(tmp.name + ".cleaned")
+        result = clean_container(
+            tmp,
+            dest,
+            fmt=None,
+            also_layer_a_text=True,
+            deep_images="auto",
+            normalize_spaces=True,
+            clean_attachments=mode,
+            _depth=depth + 1,
+        )
+        if not dest.is_file():
+            return None, []
+        return dest.read_bytes(), result.get("actions", [])
+    return None, [f"unsupported attachment kind: {kind}"]
+
+
+def clean_pdf(
+    path: Path,
+    dest: Path,
+    *,
+    deep_images: str = "auto",
+    clean_attachments: str = DEFAULT_CLEAN_ATTACHMENTS,
+    depth: int = 0,
+) -> tuple[list[str], dict]:
     """Best-effort PDF clean. Prefers exiftool; falls back to XMP strip warning.
 
     ``deep_images`` controls the Ghostscript re-distill that reaches metadata
@@ -3293,6 +3761,15 @@ def clean_pdf(path: Path, dest: Path, *, deep_images: str = "auto") -> tuple[lis
     * ``"lossless"`` -- deep pass without the recompressing escalation, so
       image data is never touched.
     * ``"never"`` -- skip it.
+
+    ``clean_attachments`` controls the pass over embedded files (paperclips):
+
+    * ``"always"`` (default) -- clean every attachment's metadata
+      (``strip_all_metadata`` semantics on the attachment), recursing into
+      nested containers regardless of markers.
+    * ``"auto"`` -- clean an attachment only when it carries AI/C2PA provenance
+      markers; recurse with the same rule.
+    * ``"never"`` -- leave attachments untouched.
     """
     actions: list[str] = []
     data = path.read_bytes()
@@ -3303,6 +3780,11 @@ def clean_pdf(path: Path, dest: Path, *, deep_images: str = "auto") -> tuple[lis
     if deep_images not in DEEP_IMAGE_MODES:
         raise ValueError(
             f"deep_images must be one of {sorted(DEEP_IMAGE_MODES)}, got {deep_images!r}"
+        )
+    if clean_attachments not in CLEAN_ATTACHMENT_MODES:
+        raise ValueError(
+            f"clean_attachments must be one of {sorted(CLEAN_ATTACHMENT_MODES)}, "
+            f"got {clean_attachments!r}"
         )
 
     deadline = _Deadline(PDF_CLEAN_BUDGET_SECONDS)
@@ -3355,7 +3837,10 @@ def clean_pdf(path: Path, dest: Path, *, deep_images: str = "auto") -> tuple[lis
 
     def _markers_left() -> bool:
         current = dest.read_bytes()
-        res_c2pa, res_ai, _f, _d = inspect_pdf(dest, current)
+        # include_attachments=False: attachment markers are handled by the
+        # attachment pass, and ignoring them here keeps the deep-image pass from
+        # running (and dropping the attachments) on an attachment-only marker.
+        res_c2pa, res_ai, _f, _d = inspect_pdf(dest, current, include_attachments=False)
         # inspect_pdf excludes stream payloads, so ask the streams directly too:
         # without c2patool nothing else would notice a manifest that only exists
         # inside an image.
@@ -3433,16 +3918,36 @@ def clean_pdf(path: Path, dest: Path, *, deep_images: str = "auto") -> tuple[lis
     if c2patool:
         actions.append("c2patool available for inspect; strip via exiftool/re-export")
 
+    attachments: dict[str, Any] = {"attachments": [], "processed": False, "qpdf_absent": False}
+    attachment_degraded = False
+    if clean_attachments != "never":
+        attachments = _pdf_clean_attachments(
+            path, dest, actions, deadline, clean_attachments, depth=depth
+        )
+        if attachments.get("qpdf_absent"):
+            attachment_degraded = True
+        # Re-settle document-level metadata: re-embedding attachments via qpdf
+        # re-serializes the file, which can re-expose a /Producer.
+        if attachments.get("processed") and exiftool:
+            if _exiftool_strip(exiftool, dest, actions, deadline):
+                rewritten = _pdf_structural_rewrite(dest, actions, deadline) or rewritten
+            else:
+                attachment_degraded = True
+
     meta: dict[str, Any] = {
         "mode": document_mode,
         "structural_rewrite": rewritten,
         "deep_images": mode,
         "deep_image_pass": deep_ran,
         "images_reencoded": reencoded,
+        "attachments": attachments["attachments"],
+        "attachments_processed": attachments["processed"],
     }
     if not exiftool:
         # The deep pass may well have run, but the document-level strip was
         # the stdlib one, so the result is still best-effort.
+        meta["degraded"] = True
+    elif attachment_degraded:
         meta["degraded"] = True
     return actions, meta
 
@@ -3452,7 +3957,9 @@ def clean_pdf(path: Path, dest: Path, *, deep_images: str = "auto") -> tuple[lis
 # ---------------------------------------------------------------------------
 
 
-def inspect_container(path: Path, *, data: bytes | None = None) -> ContainerInspectReport:
+def inspect_container(
+    path: Path, *, data: bytes | None = None, _depth: int = 0
+) -> ContainerInspectReport:
     """Inspect a container for provenance, AI metadata, and Layer-A carriers.
 
     Delegates to the format-specific inspector and unions in a Layer-A scan of
@@ -3476,7 +3983,7 @@ def inspect_container(path: Path, *, data: bytes | None = None) -> ContainerInsp
     if fmt == "svg":
         has_c2pa, has_ai, findings, details = inspect_svg(data)
     elif fmt == "pdf":
-        has_c2pa, has_ai, findings, details = inspect_pdf(path, data)
+        has_c2pa, has_ai, findings, details = inspect_pdf(path, data, depth=_depth)
         tools = details.pop("tools", {})
     elif fmt == "docx":
         has_c2pa, has_ai, findings, details = inspect_docx(data, zip_budget)
@@ -3602,6 +4109,8 @@ def clean_container(
     also_layer_a_text: bool = True,
     deep_images: str = "auto",
     normalize_spaces: bool = True,
+    clean_attachments: str = DEFAULT_CLEAN_ATTACHMENTS,
+    _depth: int = 0,
 ) -> dict[str, Any]:
     """Clean container metadata; optionally Layer-A scrub text bodies for md/html.
 
@@ -3622,7 +4131,13 @@ def clean_container(
         cleaned, actions = clean_svg(data)
         safe_write_bytes(dest, cleaned)
     elif fmt == "pdf":
-        actions, meta_extra = clean_pdf(path, dest, deep_images=deep_images)
+        actions, meta_extra = clean_pdf(
+            path,
+            dest,
+            deep_images=deep_images,
+            clean_attachments=clean_attachments,
+            depth=_depth,
+        )
         meta.update(meta_extra)
     elif fmt == "docx":
         cleaned, actions = clean_docx(

--- a/service/scripts/container_meta.py
+++ b/service/scripts/container_meta.py
@@ -2912,7 +2912,12 @@ def _pdf_structured_blob(data: bytes) -> bytes:
 
 
 def inspect_pdf(
-    path: Path, data: bytes, *, depth: int = 0, include_attachments: bool = True
+    path: Path,
+    data: bytes,
+    *,
+    depth: int = 0,
+    include_attachments: bool = True,
+    deadline: "_Deadline | None" = None,
 ) -> tuple[bool, bool, list[str], dict]:
     findings: list[str] = []
     has_c2pa, has_ai, hits = _blob_hits(_pdf_structured_blob(data))
@@ -2948,7 +2953,9 @@ def inspect_pdf(
     # attachments themselves.
     details: dict[str, Any] = {"tools": tools}
     if include_attachments:
-        attachments, truncated = _pdf_inspect_attachments(path, None, depth=depth)
+        if deadline is None:
+            deadline = _Deadline(PDF_CLEAN_BUDGET_SECONDS)
+        attachments, truncated = _pdf_inspect_attachments(path, deadline, depth=depth)
         if attachments:
             for a in attachments:
                 findings.append(f"attachment:{a['name']}:{a.get('kind', 'unknown')}")
@@ -3385,33 +3392,63 @@ def _pdf_attachment_list(path: Path, deadline: "_Deadline | None" = None) -> lis
 
 
 def _pdf_show_attachment(path: Path, key: str, tmp: Path, deadline: "_Deadline | None") -> int:
-    """Extract one embedded file to *tmp*. Returns the byte count, or -1."""
+    """Extract one embedded file to *tmp*, bounding the write to the size cap.
+
+    Returns the byte count on success (``<= MAX_ATTACHMENT_BYTES``),
+    ``MAX_ATTACHMENT_BYTES + 1`` when the attachment exceeds the cap (the
+    subprocess is terminated and *tmp* is left partial), or ``-1`` on failure.
+    qpdf's output is consumed in bounded chunks so an embedded stream that
+    expands well past the cap is not written to disk in full before being
+    rejected.
+    """
     qpdf = which("qpdf")
     if not qpdf:
         return -1
+    limit = MAX_ATTACHMENT_BYTES
+    total = 0
     try:
         with tmp.open("wb") as out:
-            r = subprocess.run(
+            p = subprocess.Popen(
                 [qpdf, f"--show-attachment={key}", "--", safe_arg(str(path))],
-                stdout=out,
-                stderr=subprocess.PIPE,
-                timeout=(
-                    _QPDF_ATTACH_TIMEOUT
-                    if deadline is None
-                    else deadline.timeout(_QPDF_ATTACH_TIMEOUT)
-                ),
-                check=False,
-                preexec_fn=subprocess_preexec_fn,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                # Same preexec_fn resource-limit guard used by every subprocess
+                # in this module; the bounded read+kill below additionally caps
+                # qpdf's output.
+                preexec_fn=subprocess_preexec_fn,  # noqa: PLW1509
                 creationflags=subprocess_creationflags,
             )
+            try:
+                rc = None
+                while True:
+                    if deadline is not None and deadline.spent():
+                        p.kill()
+                        return -1
+                    chunk = p.stdout.read(1 << 20)
+                    if not chunk:
+                        break
+                    total += len(chunk)
+                    if total > limit:
+                        p.kill()
+                        return limit + 1
+                    out.write(chunk)
+                p.stdout.close()
+                rc = p.wait(
+                    timeout=(
+                        _QPDF_ATTACH_TIMEOUT
+                        if deadline is None
+                        else deadline.timeout(_QPDF_ATTACH_TIMEOUT)
+                    )
+                )
+            finally:
+                if p.poll() is None:
+                    p.kill()
+                    p.wait()
     except Exception:
         return -1
-    if r.returncode != 0:
+    if rc != 0:
         return -1
-    try:
-        return tmp.stat().st_size
-    except OSError:
-        return -1
+    return total
 
 
 def _classify_attachment(name: str, data: bytes) -> str:
@@ -3454,7 +3491,7 @@ def _pdf_inspect_attachments(
                 continue
             data = tmp.read_bytes()
             kind = _classify_attachment(att["name"], data)
-            has_c2pa, has_ai, findings = _inspect_attachment_bytes(tmp, data, kind, depth)
+            has_c2pa, has_ai, findings = _inspect_attachment_bytes(tmp, data, kind, depth, deadline)
             results.append(
                 {
                     **att,
@@ -3471,7 +3508,7 @@ def _pdf_inspect_attachments(
 
 
 def _inspect_attachment_bytes(
-    tmp: Path, data: bytes, kind: str, depth: int
+    tmp: Path, data: bytes, kind: str, depth: int, deadline: "_Deadline | None" = None
 ) -> tuple[bool, bool, list[str]]:
     """Inspect an extracted attachment, recursing into nested containers."""
     if kind == "text":
@@ -3490,7 +3527,7 @@ def _inspect_attachment_bytes(
         rep = inspect_av(tmp, data=data)
         return rep.has_c2pa, rep.has_ai_metadata, rep.findings
     if kind == "container":
-        rep = inspect_container(tmp, data=data, _depth=depth + 1)
+        rep = inspect_container(tmp, data=data, _depth=depth + 1, deadline=deadline)
         return rep.has_c2pa, rep.has_ai_metadata, rep.findings
     return False, False, [f"unsupported attachment kind: {kind}"]
 
@@ -3577,7 +3614,9 @@ def _pdf_clean_attachments(
             data = in_path.read_bytes()
             ext = Path(name).suffix or Path(in_path.name).suffix
             kind = _classify_attachment(name, data)
-            has_c2pa, has_ai, findings = _inspect_attachment_bytes(in_path, data, kind, depth)
+            has_c2pa, has_ai, findings = _inspect_attachment_bytes(
+                in_path, data, kind, depth, deadline
+            )
             should_clean = mode == "always" or (mode == "auto" and (has_c2pa or has_ai))
             # The report must not leak the on-disk staging path.
             report_att = {k: v for k, v in att.items() if k != "in_path"}
@@ -3622,7 +3661,7 @@ def _pdf_clean_attachments(
                 continue
             clean_actions.append(f"attachment '{name}': re-embedded")
             rem_c2pa, rem_ai, rem_findings = _inspect_attachment_bytes(
-                clean_path, cleaned_bytes, kind, depth
+                clean_path, cleaned_bytes, kind, depth, deadline
             )
             results.append(
                 {
@@ -3703,7 +3742,9 @@ def _clean_attachment_bytes(
         from text_unicode import clean_text
 
         cleaned, stats = clean_text(data.decode("utf-8", errors="surrogateescape"))
-        return cleaned.encode("utf-8"), [
+        # Re-encode with surrogateescape so invalid bytes preserved by the
+        # decode are round-tripped instead of raising UnicodeEncodeError.
+        return cleaned.encode("utf-8", errors="surrogateescape"), [
             f"text layer A: removed={stats['removed_count']} replaced={stats['replaced_count']}"
         ]
     if kind == "image":
@@ -3920,7 +3961,10 @@ def clean_pdf(
 
     attachments: dict[str, Any] = {"attachments": [], "processed": False, "qpdf_absent": False}
     attachment_degraded = False
-    if clean_attachments != "never":
+    # Even in "never" mode the deep-image pass may have dropped the embedded
+    # files from dest, so the originals still have to be restored. The helper
+    # re-embeds unchanged bytes when mode is "never", so nothing is cleaned.
+    if clean_attachments != "never" or deep_ran:
         attachments = _pdf_clean_attachments(
             path, dest, actions, deadline, clean_attachments, depth=depth
         )
@@ -3958,7 +4002,11 @@ def clean_pdf(
 
 
 def inspect_container(
-    path: Path, *, data: bytes | None = None, _depth: int = 0
+    path: Path,
+    *,
+    data: bytes | None = None,
+    _depth: int = 0,
+    deadline: "_Deadline | None" = None,
 ) -> ContainerInspectReport:
     """Inspect a container for provenance, AI metadata, and Layer-A carriers.
 
@@ -3983,7 +4031,9 @@ def inspect_container(
     if fmt == "svg":
         has_c2pa, has_ai, findings, details = inspect_svg(data)
     elif fmt == "pdf":
-        has_c2pa, has_ai, findings, details = inspect_pdf(path, data, depth=_depth)
+        has_c2pa, has_ai, findings, details = inspect_pdf(
+            path, data, depth=_depth, deadline=deadline
+        )
         tools = details.pop("tools", {})
     elif fmt == "docx":
         has_c2pa, has_ai, findings, details = inspect_docx(data, zip_budget)

--- a/service/scripts/container_meta.py
+++ b/service/scripts/container_meta.py
@@ -6,6 +6,7 @@ Stdlib-first; PDF prefers optional exiftool/c2patool when present.
 
 import base64
 import bisect
+import contextlib
 import io
 import json
 import os
@@ -13,6 +14,7 @@ import posixpath
 import re
 import subprocess
 import tempfile
+import threading
 import time
 import urllib.parse
 import zipfile
@@ -3391,6 +3393,24 @@ def _pdf_attachment_list(path: Path, deadline: "_Deadline | None" = None) -> lis
     return out
 
 
+def _watchdog_kill(process: "subprocess.Popen[bytes]", seconds: float) -> threading.Event:
+    """Return a stop Event; a daemon thread kills *process* unless it is set.
+
+    The main thread reads qpdf's stdout in chunks; this watchdog enforces the
+    timeout on a read that would otherwise block forever (e.g. a hung qpdf that
+    produces no output), since the inter-chunk deadline check never fires then.
+    """
+    stop = threading.Event()
+
+    def _watch() -> None:
+        if not stop.wait(seconds):
+            with contextlib.suppress(OSError):  # already exited/reaped
+                process.kill()
+
+    threading.Thread(target=_watch, daemon=True).start()
+    return stop
+
+
 def _pdf_show_attachment(path: Path, key: str, tmp: Path, deadline: "_Deadline | None") -> int:
     """Extract one embedded file to *tmp*, bounding the write to the size cap.
 
@@ -3399,13 +3419,15 @@ def _pdf_show_attachment(path: Path, key: str, tmp: Path, deadline: "_Deadline |
     subprocess is terminated and *tmp* is left partial), or ``-1`` on failure.
     qpdf's output is consumed in bounded chunks so an embedded stream that
     expands well past the cap is not written to disk in full before being
-    rejected.
+    rejected, and a watchdog enforces the deadline/``_QPDF_ATTACH_TIMEOUT`` even
+    when qpdf stops producing output.
     """
     qpdf = which("qpdf")
     if not qpdf:
         return -1
     limit = MAX_ATTACHMENT_BYTES
     total = 0
+    timeout = _QPDF_ATTACH_TIMEOUT if deadline is None else deadline.timeout(_QPDF_ATTACH_TIMEOUT)
     try:
         with tmp.open("wb") as out:
             p = subprocess.Popen(
@@ -3413,11 +3435,12 @@ def _pdf_show_attachment(path: Path, key: str, tmp: Path, deadline: "_Deadline |
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
                 # Same preexec_fn resource-limit guard used by every subprocess
-                # in this module; the bounded read+kill below additionally caps
-                # qpdf's output.
+                # in this module; the bounded read+kill below also caps qpdf's
+                # output.
                 preexec_fn=subprocess_preexec_fn,  # noqa: PLW1509
                 creationflags=subprocess_creationflags,
             )
+            stop = _watchdog_kill(p, timeout)
             try:
                 rc = None
                 while True:
@@ -3433,14 +3456,10 @@ def _pdf_show_attachment(path: Path, key: str, tmp: Path, deadline: "_Deadline |
                         return limit + 1
                     out.write(chunk)
                 p.stdout.close()
-                rc = p.wait(
-                    timeout=(
-                        _QPDF_ATTACH_TIMEOUT
-                        if deadline is None
-                        else deadline.timeout(_QPDF_ATTACH_TIMEOUT)
-                    )
-                )
+                rc = p.wait(timeout=max(0.1, timeout))
             finally:
+                stop.set()
+                p.stdout.close()
                 if p.poll() is None:
                     p.kill()
                     p.wait()
@@ -3528,7 +3547,10 @@ def _inspect_attachment_bytes(
         return rep.has_c2pa, rep.has_ai_metadata, rep.findings
     if kind == "container":
         rep = inspect_container(tmp, data=data, _depth=depth + 1, deadline=deadline)
-        return rep.has_c2pa, rep.has_ai_metadata, rep.findings
+        findings = list(rep.findings)
+        if rep.details.get("attachments_truncated"):
+            findings.append("nested attachment scan truncated (depth cap or budget)")
+        return rep.has_c2pa, rep.has_ai_metadata, findings
     return False, False, [f"unsupported attachment kind: {kind}"]
 
 

--- a/service/scripts/server.py
+++ b/service/scripts/server.py
@@ -69,7 +69,13 @@ from common import (
     subprocess_preexec_fn,
     which,
 )
-from container_meta import DEEP_IMAGE_MODES, clean_container, inspect_container
+from container_meta import (
+    CLEAN_ATTACHMENT_MODES,
+    DEEP_IMAGE_MODES,
+    DEFAULT_CLEAN_ATTACHMENTS,
+    clean_container,
+    inspect_container,
+)
 from format_dispatch import classify_bytes
 from image_meta import clean_image, inspect_image, run_synthid_score, synthid_is_watermarked
 from score_stylometry import score_text_stylometry
@@ -108,6 +114,7 @@ ALLOWED_CLEAN_OPTIONS = {
     "detect_before": bool,
     "detect_after": bool,
     "deep_images": str,
+    "clean_attachments": str,
     "style": str,
     "strategy": str,
 }
@@ -917,6 +924,11 @@ def _parse_clean_options(options: Any) -> dict[str, Any]:
     deep_images = options.get("deep_images")
     if deep_images is not None and deep_images not in DEEP_IMAGE_MODES:
         raise ValueError(f"option 'deep_images' must be one of {sorted(DEEP_IMAGE_MODES)}")
+    clean_attachments = options.get("clean_attachments")
+    if clean_attachments is not None and clean_attachments not in CLEAN_ATTACHMENT_MODES:
+        raise ValueError(
+            f"option 'clean_attachments' must be one of {sorted(CLEAN_ATTACHMENT_MODES)}"
+        )
     # A per-request strategy overrides the default; validate it up front so a bad
     # tactic/intensity is a 400 rather than a mid-clean failure.
     if "strategy" in options:
@@ -1371,6 +1383,7 @@ def _clean_payload(data: bytes, name: str, options: dict[str, Any]) -> dict[str,
                 fmt=container_fmt,
                 also_layer_a_text=bool(options.get("also_layer_a_text", True)),
                 deep_images=str(options.get("deep_images", "auto")),
+                clean_attachments=str(options.get("clean_attachments", DEFAULT_CLEAN_ATTACHMENTS)),
                 normalize_spaces=bool(options.get("normalize_spaces", True)),
             )
             cleaned_bytes = dest.read_bytes()

--- a/tests/test_clean_options_normalize_spaces.py
+++ b/tests/test_clean_options_normalize_spaces.py
@@ -40,6 +40,10 @@ def test_option_is_allowed():
     assert server.ALLOWED_CLEAN_OPTIONS.get("normalize_spaces") is bool
 
 
+def test_clean_attachments_option_is_allowed():
+    assert server.ALLOWED_CLEAN_OPTIONS.get("clean_attachments") is str
+
+
 def test_default_still_normalizes():
     out = _clean({})
     assert NBSP not in out

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -369,6 +369,35 @@ def test_known_deep_images_modes_accepted(conn):
         assert status == 200, mode
 
 
+def test_unknown_clean_attachments_mode_rejected(conn):
+    """A typo must answer 400, not silently fall back to auto."""
+    status, body = _post(
+        conn,
+        "/clean",
+        {
+            "file": _b64(b"x"),
+            "name": "x.txt",
+            "options": {"clean_attachments": "sometime"},
+        },
+    )
+    assert status == 400
+    assert "clean_attachments" in body["error"]
+
+
+def test_known_clean_attachments_modes_accepted(conn):
+    for mode in sorted(container_meta.CLEAN_ATTACHMENT_MODES):
+        status, _body = _post(
+            conn,
+            "/clean",
+            {
+                "file": _b64(b"plain text\n"),
+                "name": "x.txt",
+                "options": {"clean_attachments": mode},
+            },
+        )
+        assert status == 200, mode
+
+
 @pytest.mark.parametrize(
     ("key", "value", "type_name"),
     [

--- a/tests/test_pdf_attachments.py
+++ b/tests/test_pdf_attachments.py
@@ -1,0 +1,241 @@
+"""Embedded-file attachment pass: metadata inside PDF paperclip files.
+
+Document-level metadata (``exiftool``) and the Ghostscript deep-image pass stop
+at the document/page; an AI/C2PA marker carried by an embedded file survives
+both. ``clean_pdf`` now extracts each attachment, recursively cleans it, and
+re-embeds the cleaned bytes via qpdf.
+"""
+
+from __future__ import annotations
+
+import base64
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "service" / "scripts"))
+
+import container_meta
+from common import which
+from container_meta import clean_pdf
+
+QPDF = which("qpdf")
+needs_qpdf = pytest.mark.skipif(QPDF is None, reason="qpdf not installed")
+
+
+# 16x16 solid-colour JPEG for the ordinary-EXIF fixture, inlined to avoid a PIL
+# import (another test installs a PIL stub into sys.modules).
+_TINY_JPEG = base64.b64decode(
+    "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYI"
+    "DAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRT/2wBDAQMEBAUEBQkF"
+    "BQkUDQsNFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQU"
+    "FBQUFBT/wAARCAAQABADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQF"
+    "BgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEI"
+    "I0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNk"
+    "ZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLD"
+    "xMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEB"
+    "AQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJB"
+    "UQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZH"
+    "SElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaan"
+    "qKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oA"
+    "DAMBAAIRAxEAPwDxSiiivzc/tU//2Q=="
+)
+
+
+def _exif_only_jpeg() -> bytes:
+    """A JPEG carrying camera-style EXIF and nothing an AI scan would flag."""
+    exif = b"Exif\x00\x00MM\x00*\x00\x00\x00\x08 Camera Model X"
+    app1 = b"\xff\xe1" + struct.pack(">H", len(exif) + 2) + exif
+    return _TINY_JPEG[:2] + app1 + _TINY_JPEG[2:]
+
+
+def _show_attachment(root: Path, key: str, pdf: Path) -> bytes:
+    path = root / "extract.bin"
+    with path.open("wb") as fh:
+        subprocess.run([QPDF, f"--show-attachment={key}", str(pdf)], stdout=fh, check=True)
+    return path.read_bytes()
+
+
+def _pdf_with_attachments(root: Path, items: list[tuple[str, bytes]]) -> Path:
+    """Build a PDF that embeds each ``(name, data)`` by chaining qpdf."""
+    cur: Path | None = None
+    for i, (name, data) in enumerate(items):
+        src = root / f"src-{i}{Path(name).suffix}"
+        src.write_bytes(data)
+        out = root / f"step-{i}.pdf"
+        attach_opts = [f"--filename={name}", f"--key={name}", "--"]
+        cmd: list[str] = []
+        if cur is None:
+            cmd = [QPDF, "--empty", "--add-attachment", str(src)]
+            cmd += [*attach_opts, str(out)]
+        else:
+            cmd = [QPDF, "--add-attachment", str(src)]
+            cmd += [*attach_opts, str(cur), str(out)]
+        subprocess.run(cmd, check=True, capture_output=True)
+        cur = out
+    assert cur is not None, "no attachments to embed"
+    return cur
+
+
+def _empty_pdf(path: Path) -> Path:
+    """A valid, attachment-free PDF produced by qpdf."""
+    subprocess.run([QPDF, "--empty", "--", str(path)], check=True)
+    return path
+
+
+@needs_qpdf
+def test_no_attachments_is_a_noop(tmp_path):
+    src = _empty_pdf(tmp_path / "in.pdf")
+    actions, meta = clean_pdf(src, tmp_path / "out.pdf", clean_attachments="auto")
+
+    assert meta["attachments_processed"] is False
+    assert meta["attachments"] == []
+    assert any("no embedded attachments" in a for a in actions)
+
+
+@needs_qpdf
+def test_default_clean_attachments_is_always(tmp_path):
+    """The option defaults to `always`, so a marked attachment is stripped."""
+    zwsp = "\u200b".encode("utf-8")
+    src = _pdf_with_attachments(tmp_path, [("note.txt", b"hello" + zwsp + b"world")])
+
+    # Deliberately omit clean_attachments to exercise the default.
+    _actions, meta = clean_pdf(src, tmp_path / "out.pdf")
+
+    assert meta["attachments_processed"] is True
+    assert meta["attachments"][0]["cleaned"] is True
+    assert zwsp not in _show_attachment(tmp_path, "note.txt", tmp_path / "out.pdf")
+
+
+@needs_qpdf
+def test_auto_cleans_a_marked_attachment(tmp_path):
+    zwsp = "\u200b".encode("utf-8")
+    src = _pdf_with_attachments(tmp_path, [("note.txt", b"hello" + zwsp + b"world")])
+
+    _actions, meta = clean_pdf(src, tmp_path / "out.pdf", clean_attachments="auto")
+
+    assert meta["attachments_processed"] is True
+    att = meta["attachments"][0]
+    assert att["kind"] == "text"
+    assert att["cleaned"] is True
+    assert att["still_has_ai_metadata"] is False
+    extracted = _show_attachment(tmp_path, "note.txt", tmp_path / "out.pdf")
+    assert zwsp not in extracted
+
+
+@needs_qpdf
+def test_auto_leaves_a_clean_attachment_alone(tmp_path):
+    plain = b"no hidden markers here"
+    src = _pdf_with_attachments(tmp_path, [("c.txt", plain)])
+
+    _actions, meta = clean_pdf(src, tmp_path / "out.pdf", clean_attachments="auto")
+
+    assert meta["attachments_processed"] is False
+    att = meta["attachments"][0]
+    assert att["cleaned"] is False
+    assert _show_attachment(tmp_path, "c.txt", tmp_path / "out.pdf") == plain
+
+
+@needs_qpdf
+def test_auto_leaves_ordinary_image_exif_alone(tmp_path):
+    src = _pdf_with_attachments(tmp_path, [("shot.jpg", _exif_only_jpeg())])
+
+    _actions, meta = clean_pdf(src, tmp_path / "out.pdf", clean_attachments="auto")
+
+    att = meta["attachments"][0]
+    assert att["cleaned"] is False
+    assert _show_attachment(tmp_path, "shot.jpg", tmp_path / "out.pdf") == _exif_only_jpeg()
+
+
+@needs_qpdf
+def test_always_strips_every_attachment_metadata(tmp_path):
+    src = _pdf_with_attachments(tmp_path, [("shot.jpg", _exif_only_jpeg())])
+
+    _actions, meta = clean_pdf(src, tmp_path / "out.pdf", clean_attachments="always")
+
+    att = meta["attachments"][0]
+    assert att["cleaned"] is True
+    extracted = _show_attachment(tmp_path, "shot.jpg", tmp_path / "out.pdf")
+    assert extracted != _exif_only_jpeg()
+    # The EXIF APP1 segment is gone.
+    assert b"Exif" not in extracted
+
+
+@needs_qpdf
+def test_never_leaves_attachments_untouched(tmp_path):
+    zwsp = "\u200b".encode("utf-8")
+    src = _pdf_with_attachments(tmp_path, [("note.txt", b"hello" + zwsp + b"world")])
+
+    _actions, meta = clean_pdf(src, tmp_path / "out.pdf", clean_attachments="never")
+
+    assert meta["attachments_processed"] is False
+    assert meta["attachments"] == []
+    assert zwsp in _show_attachment(tmp_path, "note.txt", tmp_path / "out.pdf")
+
+
+@needs_qpdf
+def test_nested_attachment_recurses(tmp_path):
+    zwsp = "\u200b".encode("utf-8")
+    # inner.pdf carries a marked text attachment; outer.pdf embeds inner.pdf.
+    inner = _pdf_with_attachments(tmp_path, [("inner.txt", b"hi" + zwsp + b"there")])
+    outer = _pdf_with_attachments(tmp_path, [("inner.pdf", inner.read_bytes())])
+
+    _actions, meta = clean_pdf(outer, tmp_path / "out.pdf", clean_attachments="auto")
+
+    att = meta["attachments"][0]
+    assert att["kind"] == "container"
+    assert att["cleaned"] is True
+    # The inner PDF attachment was re-embedded cleaned; its own attachment's
+    # marker must be gone.
+    inner_out = tmp_path / "inner2.pdf"
+    with inner_out.open("wb") as fh:
+        subprocess.run(
+            [QPDF, "--show-attachment=inner.pdf", str(tmp_path / "out.pdf")],
+            stdout=fh,
+            check=True,
+        )
+    assert zwsp not in _show_attachment(tmp_path, "inner.txt", inner_out)
+
+
+@needs_qpdf
+def test_recursion_depth_cap_stops_descent(tmp_path):
+    """Deeper than MAX_ATTACHMENT_DEPTH must stop before extracting anything."""
+    src = tmp_path / "in.pdf"
+    src.write_bytes(b"%PDF-1.4\n%%EOF\n")
+    actions: list[str] = []
+    res = container_meta._pdf_clean_attachments(
+        src,
+        tmp_path / "out.pdf",
+        actions,
+        None,
+        "auto",
+        depth=container_meta.MAX_ATTACHMENT_DEPTH + 1,
+    )
+
+    assert res["processed"] is False
+    assert any("recursion capped" in a for a in actions)
+
+
+@needs_qpdf
+def test_rejects_an_unknown_clean_attachments_value(tmp_path):
+    src = _empty_pdf(tmp_path / "in.pdf")
+    with pytest.raises(ValueError, match="clean_attachments"):
+        clean_pdf(src, tmp_path / "out.pdf", clean_attachments="sometime")
+
+
+@needs_qpdf
+def test_oversized_attachment_kept_and_warned(tmp_path, monkeypatch):
+    monkeypatch.setattr(container_meta, "MAX_ATTACHMENT_BYTES", 4)
+    src = _pdf_with_attachments(tmp_path, [("big.txt", b"0123456789")])
+
+    actions, meta = clean_pdf(src, tmp_path / "out.pdf", clean_attachments="always")
+
+    assert meta["attachments_processed"] is False
+    att = meta["attachments"][0]
+    assert att["cleaned"] is False
+    assert att["error"] == "attachment too large"
+    assert any("too large" in a for a in actions)
+    assert _show_attachment(tmp_path, "big.txt", tmp_path / "out.pdf") == b"0123456789"

--- a/tests/test_pdf_attachments.py
+++ b/tests/test_pdf_attachments.py
@@ -239,3 +239,45 @@ def test_oversized_attachment_kept_and_warned(tmp_path, monkeypatch):
     assert att["error"] == "attachment too large"
     assert any("too large" in a for a in actions)
     assert _show_attachment(tmp_path, "big.txt", tmp_path / "out.pdf") == b"0123456789"
+
+
+@needs_qpdf
+def test_invalid_utf8_text_attachment_cleans_without_error(tmp_path):
+    """Invalid UTF-8 in a text attachment must not abort clean_pdf."""
+    src = _pdf_with_attachments(tmp_path, [("bin.txt", b"hello\xff\xfegoodbye")])
+
+    # Default is `always`; the text pass re-encodes with surrogateescape.
+    _actions, meta = clean_pdf(src, tmp_path / "out.pdf")
+
+    assert meta["attachments_processed"] is True
+    assert isinstance(_show_attachment(tmp_path, "bin.txt", tmp_path / "out.pdf"), bytes)
+
+
+@needs_qpdf
+def test_never_restores_attachments_after_deep_image_pass(tmp_path):
+    """A re-distill can drop attachments; `never` must still bring them back."""
+    payload = b"do not clean me"
+    src = _pdf_with_attachments(tmp_path, [("keep.txt", payload)])
+
+    _actions, meta = clean_pdf(
+        src,
+        tmp_path / "out.pdf",
+        deep_images="always",
+        clean_attachments="never",
+    )
+
+    assert meta["attachments_processed"] is False
+    assert _show_attachment(tmp_path, "keep.txt", tmp_path / "out.pdf") == payload
+
+
+@needs_qpdf
+def test_inspect_attachments_respects_deadline(tmp_path):
+    """`/inspect` must bound the attachment scan and report truncation."""
+    src = _pdf_with_attachments(tmp_path, [("note.txt", b"hi")])
+
+    attachments, truncated = container_meta._pdf_inspect_attachments(
+        src, container_meta._Deadline(0), depth=0
+    )
+
+    assert attachments == []
+    assert truncated is True

--- a/tests/test_pdf_attachments.py
+++ b/tests/test_pdf_attachments.py
@@ -254,6 +254,35 @@ def test_invalid_utf8_text_attachment_cleans_without_error(tmp_path):
     assert _show_attachment(tmp_path, "bin.txt", tmp_path / "out.pdf") == b"hello\xff\xfegoodbye"
 
 
+@needs_qpdf
+def test_attachment_dates_survive_reembed(tmp_path):
+    """Re-embedding must keep the original timestamps, not stamp "now"."""
+    src = tmp_path / "base.pdf"
+    note = tmp_path / "note.txt"
+    note.write_bytes(b"hello")
+    subprocess.run(
+        [
+            QPDF,
+            "--empty",
+            "--add-attachment",
+            str(note),
+            "--filename=note.txt",
+            "--key=note.txt",
+            "--creationdate=D:20200101120000+00'00'",
+            "--",
+            str(src),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    original = container_meta._pdf_attachment_list(src)[0]["creationdate"]
+
+    _actions, meta = clean_pdf(src, tmp_path / "out.pdf")
+
+    assert meta["attachments_processed"] is True
+    assert container_meta._pdf_attachment_list(tmp_path / "out.pdf")[0]["creationdate"] == original
+
+
 needs_gs = pytest.mark.skipif(
     container_meta.which_ghostscript() is None, reason="ghostscript not installed"
 )

--- a/tests/test_pdf_attachments.py
+++ b/tests/test_pdf_attachments.py
@@ -250,10 +250,17 @@ def test_invalid_utf8_text_attachment_cleans_without_error(tmp_path):
     _actions, meta = clean_pdf(src, tmp_path / "out.pdf")
 
     assert meta["attachments_processed"] is True
-    assert isinstance(_show_attachment(tmp_path, "bin.txt", tmp_path / "out.pdf"), bytes)
+    # surrogateescape must round-trip the invalid bytes, not just avoid a crash.
+    assert _show_attachment(tmp_path, "bin.txt", tmp_path / "out.pdf") == b"hello\xff\xfegoodbye"
+
+
+needs_gs = pytest.mark.skipif(
+    container_meta.which_ghostscript() is None, reason="ghostscript not installed"
+)
 
 
 @needs_qpdf
+@needs_gs
 def test_never_restores_attachments_after_deep_image_pass(tmp_path):
     """A re-distill can drop attachments; `never` must still bring them back."""
     payload = b"do not clean me"
@@ -266,6 +273,8 @@ def test_never_restores_attachments_after_deep_image_pass(tmp_path):
         clean_attachments="never",
     )
 
+    # The deep pass must actually run, or this test proves nothing.
+    assert meta["deep_image_pass"] is True
     assert meta["attachments_processed"] is False
     assert _show_attachment(tmp_path, "keep.txt", tmp_path / "out.pdf") == payload
 

--- a/tests/test_pdf_deep_images.py
+++ b/tests/test_pdf_deep_images.py
@@ -224,7 +224,9 @@ def test_exiftool_failure_falls_back_to_degraded_xmp_strip(tmp_path, monkeypatch
     assert meta["degraded"] is True
     assert b"contentauth" not in dest.read_bytes()
     assert any("blanked XMP" in action for action in actions)
-    assert not any("qpdf" in action for action in actions)
+    # No structural rewrite ran (no qpdf), but the attachment pass still warns
+    # that qpdf is required; assert the rewrite itself is absent, not the word.
+    assert not any("qpdf rewrite" in action or "qpdf --linearize" in action for action in actions)
 
 
 def test_missing_exiftool_uses_degraded_xmp_strip(tmp_path, monkeypatch):
@@ -245,6 +247,8 @@ def test_missing_exiftool_uses_degraded_xmp_strip(tmp_path, monkeypatch):
         "deep_images": "never",
         "deep_image_pass": False,
         "images_reencoded": False,
+        "attachments": [],
+        "attachments_processed": False,
         "degraded": True,
     }
     assert b"contentauth" not in dest.read_bytes()

--- a/tests/test_pdf_structural_rewrite.py
+++ b/tests/test_pdf_structural_rewrite.py
@@ -68,6 +68,10 @@ def _fake_tools(monkeypatch, *, qpdf: bool, qpdf_rc: int = 0, qpdf_writes: bool 
     def fake_run(cmd, **kwargs):
         seen.append(list(cmd))
         if cmd[0].endswith("qpdf"):
+            # The attachment pass lists embedded files with --json; answer with
+            # no attachments rather than clobbering the source file.
+            if "--json-key=attachments" in cmd:
+                return _Completed(0, stdout='{"attachments": {}}')
             if qpdf_writes:
                 # qpdf writes its rebuilt document to the final argument.
                 Path(cmd[-1]).write_bytes(b"%PDF-1.4\n% rebuilt\n%%EOF\n")
@@ -107,9 +111,11 @@ def test_with_qpdf_the_document_is_rebuilt(monkeypatch, tmp_path: Path):
     _actions, meta = clean_pdf(src, dest)
 
     assert meta["structural_rewrite"] is True
-    qpdf_cmd = [c for c in seen if c[0].endswith("qpdf")]
-    assert len(qpdf_cmd) == 1
-    assert "--linearize" in qpdf_cmd[0]
+    # The attachment pass also shells out to qpdf to list embedded files, so
+    # filter for the structural-rewrite invocation specifically.
+    linearize_cmd = [c for c in seen if c[0].endswith("qpdf") and "--linearize" in c]
+    assert len(linearize_cmd) == 1
+    assert "--linearize" in linearize_cmd[0]
     # The rebuilt file must replace the exiftool output, not sit beside it.
     assert dest.read_bytes() == b"%PDF-1.4\n% rebuilt\n%%EOF\n"
     assert not list(tmp_path.glob("*.qpdf-tmp"))


### PR DESCRIPTION
## Summary

Driven by [this idea tweet](https://x.com/felipe_operti/status/2095922968815657409?s=20).

PDF **attachments** (the `/EmbeddedFiles` "paperclip" files) were previously invisible to both `/inspect` and `/clean`. The deterministic byte-scan strips stream payloads, and `exiftool`/`qpdf`/Ghostscript only reach document/page metadata — so an AI/C2PA provenance marker hidden inside an attachment (e.g. a "generated by ChatGPT" stamp) survived untouched.

This adds a `clean_attachments` pass that reaches into embedded files, matching the existing `deep_images` framing for embedded images.

## What it does

- Enumerates embedded files via `qpdf --json` and extracts each with `qpdf --show-attachment`.
- Inspects each attachment as a standalone file, recursing into nested containers, so `/inspect` reports attachment-level provenance.
- Cleans each attachment with the matching pipeline (`clean_text`/`clean_image`/`clean_container`/`clean_av`) and re-embeds the cleaned bytes while preserving name/mimetype/description/dates.
- Extracts from the **original** PDF and re-adds afterwards, so attachments survive the Ghostscript deep-image re-distill (which otherwise drops them).
- Recursion is bounded (depth 3, per-attachment 64 MiB cap, per-clean deadline); oversized attachments are kept with a warning.
- `/inspect` now surfaces attachment findings; `/clean` reports per-attachment outcome + residual flags.

## New option

`clean_attachments` = `auto` | `always` | `never`, default **`always`**.

- `always` (default): strip every attachment's metadata, recursing regardless of markers.
- `auto`: clean only attachments that carry AI/C2PA markers.
- `never`: leave attachments untouched.

Wired through the CLI (`--clean-attachments`), the HTTP API (`ALLOWED_CLEAN_OPTIONS` + validation), and the OpenAPI schema. Needs `qpdf` server-side.

## Verification

- New `tests/test_pdf_attachments.py` covering: no-op, default-`always` behavior, `auto`/`always`/`never`, ordinary EXIF-only attachment left by `auto`, nested-container recursion, recursion depth cap, unknown-value rejection, name/mimetype round-trip, and oversized-attachment handling.
- Updated existing tests that pinned `clean_pdf`'s exact meta dict or qpdf call counts.
- Full test suite passes; `ruff check` and `ruff format --check` are clean.
- Verified live against the HTTP service (`/inspect` + `/clean` across all three modes) and via the CLI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added PDF embedded-attachment inspection and cleaning.
  - Added configurable attachment-cleaning modes: `always`, `auto`, and `never`, with `always` as the default.
  - Added recursive processing for nested attachments and PDFs.
  - Preserved eligible attachments during PDF cleaning and reported processing status.
  - Added support for attachment-cleaning settings through the cleaning API.

- **Bug Fixes**
  - Improved handling of oversized, invalid, or otherwise unprocessable attachments without failing the entire operation.
  - Preserved attachments during other PDF cleanup operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->