### PR TITLE
fix(audit): count only the files a scanner actually read

### DIFF
--- a/service/scripts/audit_dir.py
+++ b/service/scripts/audit_dir.py
@@ -129,7 +129,9 @@ def main() -> int:
     summary = aggregate(files)
     report = {
         "root": str(root),
-        "files_scanned": len(files),
+        # Not len(files): "files" also holds the items no pipeline claimed, and
+        # those were never opened. Their count is summary["unrecognized"].
+        "files_scanned": summary["read"],
         "files_skipped": skipped,
         "summary": summary,
         "files": files,

--- a/service/scripts/audit_lib.py
+++ b/service/scripts/audit_lib.py
@@ -164,9 +164,17 @@ def is_actionable(item: dict[str, Any]) -> bool:
 
 
 def aggregate(files: list[dict[str, Any]]) -> dict[str, Any]:
-    """Build the summary block shared by directory and website audits."""
+    """Build the summary block shared by directory and website audits.
+
+    "total" is every item the audit considered; "read" is the subset a scanner
+    actually opened, and "unrecognized" the rest. They are separate numbers
+    because a file no pipeline claimed carries no verdict: reporting it as
+    scanned turns "no findings" into "clean" for content nothing looked at.
+    """
     summary = {
         "total": len(files),
+        "read": 0,
+        "unrecognized": 0,
         "by_kind": {},
         "with_c2pa": 0,
         "with_ai_metadata": 0,
@@ -177,6 +185,10 @@ def aggregate(files: list[dict[str, Any]]) -> dict[str, Any]:
     for item in files:
         kind = str(item.get("kind") or "error")
         summary["by_kind"][kind] = summary["by_kind"].get(kind, 0) + 1
+        if kind == "unknown":
+            summary["unrecognized"] += 1
+        else:
+            summary["read"] += 1
         if item.get("has_c2pa"):
             summary["with_c2pa"] += 1
         if item.get("has_ai_metadata"):
@@ -197,7 +209,10 @@ def print_human_report(
     """Shared plain-text rendering for audit scripts."""
     for key, value in (extra_header or {}).items():
         print(f"{key}: {value}")
-    print(f"Files scanned: {summary['total']}")
+    print(f"Files scanned: {summary['read']}")
+    # Counted, not listed, the same way "Files skipped" is: the paths are in
+    # --json, where each unrecognized item carries its "not scanned" note.
+    print(f"Files unrecognized: {summary['unrecognized']}")
     print(f"By kind: {summary['by_kind']}")
     print(f"With C2PA: {summary['with_c2pa']}")
     print(f"With AI metadata: {summary['with_ai_metadata']}")

--- a/service/scripts/check_staged.py
+++ b/service/scripts/check_staged.py
@@ -35,6 +35,7 @@ def main() -> int:
     args = p.parse_args()
 
     actionable: list[dict] = []
+    unrecognized: list[Path] = []
     for path in args.paths:
         if not path.is_file():
             eprint(f"not a file: {path}")
@@ -44,10 +45,23 @@ def main() -> int:
             continue
         item = scan_file(path, check_stylometry=args.check_stylometry)
         if item.get("kind") == "unknown":
+            # No pipeline claims this suffix, so nothing read the file. Say so:
+            # a silent pass reads as "checked and clean" to whoever staged it.
+            unrecognized.append(path)
             continue
         if is_actionable(item):
             actionable.append(item)
 
+    if unrecognized:
+        eprint(
+            f"watermarks-remover: {len(unrecognized)} file(s) not scanned "
+            "(no pipeline claims the format); this hook has no verdict on them:"
+        )
+        for path in unrecognized:
+            eprint(f"  {path}")
+
+    # An unscanned file is a gap in coverage, not a finding: the exit code is
+    # decided by actionable findings alone, so no existing gate turns red.
     if not actionable:
         return 0
 

--- a/tests/test_unscanned_file_accounting.py
+++ b/tests/test_unscanned_file_accounting.py
@@ -1,0 +1,114 @@
+"""A file nothing read must not be counted as a file that was scanned.
+
+``classify()`` answers ``unknown`` for every suffix outside the four routing
+tables, and both consumers read that as nothing to say: ``aggregate()`` counted
+the item under ``Files scanned`` while ``Files skipped`` only ever tracked read
+failures, and ``check_staged.py`` dropped it with a bare ``continue``. The
+result is a summary that reports ten files read when it read three, and a gate
+that returns 0 on a set of files it never opened.
+
+Widening an extension table moves individual suffixes across that line; it does
+not change what the numbers mean. These tests pin the accounting itself: what
+was read is counted as read, what was not read is counted and named.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "service" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import check_staged
+from audit_lib import aggregate, print_human_report, scan_file
+
+ZWSP = chr(0x200B)
+CARRIER = f"Intro{ZWSP} paragraph with a hidden carrier.\n"
+
+# Suffixes no table claims, so ``classify()`` answers "unknown" and the byte
+# sniffer finds no image/container/av signature either.
+UNREAD_NAMES = ("settings.env", "matrix.m", "deps.lock", "notes.xyz")
+
+
+def _mixed_tree(tmp_path: Path) -> tuple[list[Path], list[Path]]:
+    """Two files the scanners read, four they walk past."""
+    read = []
+    for name in ("a.txt", "b.md"):
+        path = tmp_path / name
+        path.write_text(CARRIER, encoding="utf-8")
+        read.append(path)
+    unread = []
+    for name in UNREAD_NAMES:
+        path = tmp_path / name
+        path.write_text(CARRIER, encoding="utf-8")
+        unread.append(path)
+    return read, unread
+
+
+def test_aggregate_separates_read_from_unrecognized(tmp_path):
+    read, unread = _mixed_tree(tmp_path)
+    summary = aggregate([scan_file(p) for p in read + unread])
+
+    assert summary["read"] == len(read)
+    assert summary["unrecognized"] == len(unread)
+    assert summary["total"] == len(read) + len(unread)
+
+
+def test_aggregate_on_read_files_only_reports_nothing_unrecognized(tmp_path):
+    read, _ = _mixed_tree(tmp_path)
+    summary = aggregate([scan_file(p) for p in read])
+
+    assert summary["unrecognized"] == 0
+    assert summary["read"] == summary["total"] == len(read)
+
+
+def test_scanned_line_counts_only_the_files_that_were_read(tmp_path, capsys):
+    read, unread = _mixed_tree(tmp_path)
+    files = [scan_file(p) for p in read + unread]
+    print_human_report(files, aggregate(files))
+    out = capsys.readouterr().out
+
+    assert f"Files scanned: {len(read)}" in out
+    assert f"Files unrecognized: {len(unread)}" in out
+
+
+def test_precommit_gate_names_the_files_it_did_not_read(tmp_path, monkeypatch, capsys):
+    """Silence is the defect: an unread file is not a file that passed."""
+    _, unread = _mixed_tree(tmp_path)
+    paths = [str(p) for p in unread]
+
+    monkeypatch.setattr(sys, "argv", ["check_staged.py", *paths])
+    # The exit code stays 0 on purpose: nobody's gate turns red overnight
+    # because this hook learned to speak.
+    assert check_staged.main() == 0
+
+    err = capsys.readouterr().err
+    for path in paths:
+        assert path in err
+    assert "not scanned" in err
+
+
+def test_precommit_gate_reports_unread_files_alongside_findings(tmp_path, monkeypatch, capsys):
+    """A carrier in one file must not hide the fact that another went unread."""
+    read, unread = _mixed_tree(tmp_path)
+    paths = [str(p) for p in read + unread]
+
+    monkeypatch.setattr(sys, "argv", ["check_staged.py", *paths])
+    assert check_staged.main() == 1
+
+    err = capsys.readouterr().err
+    assert "layer-a" in err
+    for path in unread:
+        assert str(path) in err
+
+
+def test_precommit_gate_stays_quiet_when_every_file_was_read(tmp_path, monkeypatch, capsys):
+    """No new noise on a repository the scanners fully understand."""
+    path = tmp_path / "clean.txt"
+    path.write_text("Ordinary prose, nothing hidden.\n", encoding="utf-8")
+
+    monkeypatch.setattr(sys, "argv", ["check_staged.py", str(path)])
+    assert check_staged.main() == 0
+    assert capsys.readouterr().err == ""


### PR DESCRIPTION
## What

`aggregate()` splits `total` into `read` and `unrecognized`, `print_human_report()`
reports `Files scanned` as the read count and adds a `Files unrecognized` line,
`audit_dir.py`'s JSON `files_scanned` follows the same definition, and
`check_staged.py` names the files it did not read instead of dropping them
with a bare `continue`.

Exit codes are unchanged on every path.

## Why

This is the accounting half of #282; #284 closed the extension-table half.

A file whose suffix no table claims is never opened, but `aggregate()` counted
it in `total`, which `print_human_report()` renders as `Files scanned`, while
`Files skipped` only tracks read failures. Nine files, one U+200B carrier each,
four of them with suffixes the tables know:

```
Files skipped: 0
Files scanned: 9
By kind: {'text': 3, 'markdown': 1, 'unknown': 5}
```

Five files were never read, and the summary says otherwise. `check_staged.py`
had the same hole from the gate side: `if item.get("kind") == "unknown": continue`,
so the hook returned 0 without a word about files it never opened.

Widening the extension table moves individual suffixes across that line, but
whatever stays outside it keeps getting reported as scanned. This changes what
the numbers mean instead, so the guarantee holds for suffixes nobody has
thought of yet.

The repository audits itself as an example. Before:

```
Files scanned: 279
```

After:

```
Files scanned: 267
Files unrecognized: 12
```

The twelve are `.gitignore`, `.dockerignore`, `.env.example`, `LICENSE`,
`Makefile`, five `Dockerfile*` and `integrations/cursor/clean-user-facing-text.mdc`.

## Checklist

- [x] Behaviour matches `SKILL.md` / `references/removal-matrix.md` when relevant
- [x] Unit tests updated or added under `tests/`
- [x] `python3 -m pytest -q` passes: 1340 passed, 35 skipped
- [x] Docs updated (README and/or skill references) if user-facing behaviour changes: no document quotes the summary lines (grepped `*.md` for `Files scanned` / `files_scanned` / `Files skipped`: no hits), so there was nothing to update
- [x] No drive-by refactors unrelated to the fix or feature

## Notes for the reviewer

**Layer involved:** A (Unicode), audit and pre-commit surfaces only. No fixtures
added; the tests write into `tmp_path`.

**Exit codes.** Deliberately untouched. An unscanned file is a gap in coverage,
not a finding, so no existing gate turns red because the hook learned to speak.
`audit_dir.py` still returns `EXIT_PARTIAL` only for read failures.

**Counted, not listed.** `Files unrecognized` prints a number, matching the
existing `Files skipped` line. The paths and their `"unrecognized format; not
scanned"` notes stay in `--json`, so a repository full of binaries does not turn
the human report into a file listing. Happy to add a `--list-unrecognized` flag
if you would rather have them inline.

**`summary["total"]` is unchanged** (`read + unrecognized`), so anything reading
it keeps working; `tests/test_audit.py::test_aggregate_summary` still asserts
`total == 2` and passes untouched.

**`files_scanned` in `audit_dir.py --json`** now counts read files rather than
`len(files)`, because the CI surface carried the same claim as the human one.
`tests/test_audit_sarif_and_concurrency.py` asserts `files_scanned == 12` on a
tree of ten `.txt`, one `.png` and one `.md`, all of which are read, so the
number is the same and the test passes untouched.

**Negative control.** With the three production files reverted and the new test
kept, five of the six tests fail. The sixth
(`test_precommit_gate_stays_quiet_when_every_file_was_read`) passes both before
and after on purpose: it pins that the new stderr note stays silent on a tree
that was fully read.

**What this does not do.** It does not decide whether an unrecognized file
should be read (sniffing, option (b) in #282), and it does not widen any table.
It only stops the tools from claiming they read what they did not.
