### PR TITLE
fix(rewrite): place input text strictly after intensity and style clauses (#337)

### DIFF
--- a/service/scripts/rewrite_text.py
+++ b/service/scripts/rewrite_text.py
@@ -544,19 +544,27 @@ def build_prompt(
     """Construct the LLM rewrite prompt for a given tactic and intensity."""
     if tactic is None:
         if rewrite_level is not None:
-            base = PROMPTS["level"].format(TEXT=text, LEVEL=rewrite_level)
+            header = PROMPTS["level"].format(TEXT="", LEVEL=rewrite_level)
         else:
             raise ValueError("unknown tactic: None")
     else:
-        base = _tactic_prompt(tactic, text, lang, original_lang)
+        header = _tactic_prompt(tactic, "", lang, original_lang)
         # A (tactic, intensity) pair: modulate the named tactic prompt with the
         # level instead of replacing it with the generic level-only prompt. Code is
         # exempt — identifier/comment rewrites are not naturally intensity-modulated.
         if rewrite_level is not None and tactic != "code":
-            base = base + "\n\n" + _intensity_clause(rewrite_level)
+            suffix = "\n\n---\n"
+            if header.endswith(suffix):
+                header = header[: -len(suffix)]
+            header = header + "\n\n" + _intensity_clause(rewrite_level) + suffix
     if style:
-        base = base + "\n\n" + _style_clause(style)
-    return base
+        suffix = "\n\n---\n"
+        if header.endswith(suffix):
+            header = header[: -len(suffix)]
+        header = header + "\n\n" + _style_clause(style) + suffix
+    if not header.endswith("\n\n---\n"):
+        header = header.rstrip() + "\n\n---\n"
+    return header + text
 
 
 def _split_units(text: str) -> list[tuple[str, str]]:

--- a/tests/test_rewrite_text.py
+++ b/tests/test_rewrite_text.py
@@ -118,6 +118,22 @@ def test_build_prompt_no_style_when_unset():
     assert "Apply this writing style" not in p
 
 
+def test_build_prompt_text_always_placed_at_end_after_clauses():
+    """Text must appear strictly after all instruction, intensity, and style clauses (#337)."""
+    text = "Unique content text 98765."
+    for tactic in ("paraphrase", "humanize", "code", "backtranslate", "structural", "chunk"):
+        p = build_prompt(
+            tactic,
+            text,
+            rewrite_level=0.75,
+            style="poetic and succinct",
+        )
+        assert p.endswith(f"\n\n---\n{text}")
+        if tactic != "code":
+            assert p.find("0.75") < p.find(f"\n\n---\n{text}")
+        assert p.find("poetic and succinct") < p.find(f"\n\n---\n{text}")
+
+
 def test_rewrite_level_modulates_tactic():
     out, info = rewrite(
         "Sample prose about water marks 42.",


### PR DESCRIPTION
Fixes #337.

## What
In uild_prompt() (service/scripts/rewrite_text.py), ensure that the input {text} is always positioned strictly after all instruction, intensity, and style clauses at the end of the prompt (after \n\n---\n).

## Why
When combining a tactic with an intensity level (e.g. paraphrase@0.8) or --style, _intensity_clause and _style_clause were previously appended *after* {TEXT}. As reported in #337, models would frequently treat the trailing instructions as part of the source content to rewrite or echo meta-commentary back.

## Tests
- Added 	est_build_prompt_text_always_placed_at_end_after_clauses in 	ests/test_rewrite_text.py covering all tactics with intensity and style.
- All existing tests in 	ests/test_rewrite_text.py pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text rewriting prompts so instruction, intensity, and style settings are consistently applied before the input text.
  * Preserved tactic-specific behavior, including special handling for code rewriting.

* **Tests**
  * Added coverage to verify that input text consistently appears at the end of generated prompts across supported rewriting tactics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->